### PR TITLE
chore: bump OpenResty version from 1.27.1.1 to 1.27.1.2

### DIFF
--- a/devops/ansible/roles/luarocks/templates/openresty.sh.j2
+++ b/devops/ansible/roles/luarocks/templates/openresty.sh.j2
@@ -53,7 +53,7 @@ build_openresty() {
  git clone https://github.com/ffutop/ngx_http_env_module.git
 
 # OPENRESTY_VERSION="1.25.3.2"
-OPENRESTY_VERSION="1.27.1.1"
+OPENRESTY_VERSION="1.27.1.2"
 wget  https://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz
 tar -xzf openresty-${OPENRESTY_VERSION}.tar.gz
 cd openresty-${OPENRESTY_VERSION}


### PR DESCRIPTION
## Summary
- Updates OpenResty version from 1.27.1.1 to 1.27.1.2 in the Ansible build template
- Latest patch release includes bug fixes and improvements

## Test plan
- [x] Deploy to integration environment and verify OpenResty builds successfully
- [x] Confirm `openresty -v` shows version 1.27.1.2 after deployment