### PR TITLE
fix: align deploy-configs workflow defaults to prod environment

### DIFF
--- a/.github/workflows/deploy-configs.yml
+++ b/.github/workflows/deploy-configs.yml
@@ -13,7 +13,7 @@ on:
       TARGET_ENV:
         type: choice
         description: "Target environment to deploy configs"
-        default: "int"
+        default: "prod"
         required: true
         options:
           - dev
@@ -28,7 +28,7 @@ on:
         default: false
 
 env:
-  TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || 'int' }}
+  TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || 'prod' }}
   DRY_RUN: ${{ github.event.inputs.DRY_RUN || 'false' }}
 
 jobs:


### PR DESCRIPTION
## Summary
- Changed default `TARGET_ENV` from `int` to `prod` in the deploy-configs workflow
- The workflow targets host `185.237.99.238` which is in `[openresty_prod]` group

## Problem
The workflow was failing with:
```
Error: Host 185.237.99.238 not found in group [openresty_int]
```

## Test plan
- [ ] Re-run the deploy-configs workflow with defaults
- [ ] Verify the host validation passes