### PR TITLE
fix: change env fallback from 'int' to 'prod' for push triggers

### DIFF
--- a/.github/workflows/build-run-openresty-via-ansible.yml
+++ b/.github/workflows/build-run-openresty-via-ansible.yml
@@ -36,8 +36,8 @@ on:
 env:
   TARGET_HOST: ${{ github.event.inputs.TARGET_HOST || '185.237.99.238' }}
   # Map host to env (add more as needed)
-  TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '185.237.99.238' && 'prod' || github.event.inputs.TARGET_HOST == 'whisky03' && 'int' || 'int') }}
-  API_DOMAINNAME_ENDPOINT: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '185.237.99.238' && 'prod' || github.event.inputs.TARGET_HOST == 'whisky03' && 'int' || 'int') }}.wslproxy.com
+  TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '185.237.99.238' && 'prod' || github.event.inputs.TARGET_HOST == 'whisky03' && 'int' || 'prod') }}
+  API_DOMAINNAME_ENDPOINT: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '185.237.99.238' && 'prod' || github.event.inputs.TARGET_HOST == 'whisky03' && 'int' || 'prod') }}.wslproxy.com
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Changed the final fallback in TARGET_ENV from `'int'` to `'prod'`
- This affects workflow runs triggered by **push** (not manual workflow_dispatch)

## Problem
When triggered by push, `github.event.inputs.TARGET_HOST` is empty, so:
- `'' == '185.237.99.238'` → false
- `'' == 'whisky03'` → false  
- Falls through to final default → **'int'** (wrong!)

Since the default host is `185.237.99.238` (prod), the fallback should be `'prod'`.

## Test plan
- [ ] Push to main and verify workflow runs with `env: prod`