### PR TITLE
fix(mcp): use fallback require for cjson/lfs to prevent module loadin…

### DIFF
--- a/api/mcp/auth.lua
+++ b/api/mcp/auth.lua
@@ -83,7 +83,8 @@ function _M.enforce()
     if not ok then
         ngx.status = status_code
         ngx.header.content_type = "application/json"
-        ngx.say(Cjson.encode({
+        local cjson = Cjson or require("cjson")
+        ngx.say(cjson.encode({
             error = {
                 code = status_code,
                 message = err_msg,

--- a/api/mcp/handler.lua
+++ b/api/mcp/handler.lua
@@ -5,7 +5,7 @@
 
 local _M = {}
 
-local cjson = Cjson
+local cjson = Cjson or require("cjson")
 local McpConfig = require("mcp.config")
 local McpAuth = require("mcp.auth")
 local McpResources = require("mcp.resources")

--- a/api/mcp/resources.lua
+++ b/api/mcp/resources.lua
@@ -4,8 +4,8 @@
 
 local _M = {}
 
-local cjson = Cjson
-local lfs = LFS
+local cjson = Cjson or require("cjson")
+local lfs = LFS or require("lfs")
 local configPath = os.getenv("NGINX_CONFIG_DIR") or "/opt/nginx/"
 local McpConfig = require("mcp.config")
 

--- a/api/mcp/tools.lua
+++ b/api/mcp/tools.lua
@@ -4,7 +4,7 @@
 
 local _M = {}
 
-local cjson = Cjson
+local cjson = Cjson or require("cjson")
 local McpConfig = require("mcp.config")
 
 -- Tool definitions (schemas for AI agents)


### PR DESCRIPTION
…g failure

MCP Lua modules relied on global Cjson/LFS variables set by api/init.lua. If init.lua hasn't executed before the MCP handler loads, the globals are nil, causing "loop or previous error loading module 'mcp.handler'" on production. Each module now falls back to require() if the global is unavailable, making MCP self-contained.