### PR TITLE
fix(nginx): add server_name to 443 SSL server block

### DIFF
--- a/devops/ansible/roles/wslproxy/templates/nginx.conf.j2
+++ b/devops/ansible/roles/wslproxy/templates/nginx.conf.j2
@@ -424,6 +424,7 @@ http {
 server {
     listen *:443 ssl;
     listen [::]:443 ssl;
+    server_name {{ nginx_default_server_hostname }};
 
     http2 on;
         ssl_session_timeout  5m;


### PR DESCRIPTION
## Summary

- PR #910 added `server_name {{ nginx_default_server_hostname }}` to the **port 80** block but missed the **port 443 SSL** block
- Without `server_name`, all HTTPS requests hit the Lua gateway as a catch-all, fail to match any routing rules, and return the "No Rules" error page
- The self-signed fallback cert is served because `auto_ssl` can't determine which domain to issue a cert for

### Changes

- **`nginx.conf.j2`**: Add `server_name {{ nginx_default_server_hostname }};` to the 443 SSL server block (line 427), matching what #910 did for port 80

### Result

Production will render as:

```nginx
server {
    listen *:443 ssl;
    listen [::]:443 ssl;
    server_name wslproxy.com www.wslproxy.com;
    
    http2 on;
    # ... SSL config, Lua gateway routing ...
}
```

### Test plan

- [ ] Deploy via Ansible to production (185.237.99.238)
- [ ] Verify `https://www.wslproxy.com/` returns the correct site (not "No Rules")
- [ ] Verify SSL cert is issued by Let's Encrypt (not self-signed)
- [ ] Verify `https://prod-our.wslproxy.com/` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)