### PR TITLE
feat: track server and rule configs in git for Ansible deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ error.html
 .vscode
 sealed-secret*
 data/settings.json
-data/servers
-data/rules
 data/ssl
 node_modules
 .DS_Store

--- a/data/rules/prod/prod-our-wslproxy-rule.json
+++ b/data/rules/prod/prod-our-wslproxy-rule.json
@@ -1,0 +1,27 @@
+{
+  "id": "prod-our-wslproxy-rule",
+  "created_at": 1769388395,
+  "name": "prod-our-wslproxy-local",
+  "profile_id": "prod",
+  "priority": 1,
+  "match": {
+    "rules": {
+      "path": "/",
+      "path_key": "starts_with",
+      "client_ip_key": "equals",
+      "country_key": "equals",
+      "jwt_token_validation": "equals"
+    },
+    "response": {
+      "code": 305,
+      "redirect_uri": "127.0.0.1:8080",
+      "allow": false,
+      "message": "undefined",
+      "is_consul": false
+    }
+  },
+  "version": 1,
+  "servers": [
+    "host:prod-our.wslproxy.com"
+  ]
+}

--- a/data/rules/prod/wslproxy-com-rule.json
+++ b/data/rules/prod/wslproxy-com-rule.json
@@ -1,0 +1,27 @@
+{
+  "id": "wslproxy-com-rule",
+  "created_at": 1769388395,
+  "name": "wslproxy-com-local",
+  "profile_id": "prod",
+  "priority": 1,
+  "match": {
+    "rules": {
+      "path": "/",
+      "path_key": "starts_with",
+      "client_ip_key": "equals",
+      "country_key": "equals",
+      "jwt_token_validation": "equals"
+    },
+    "response": {
+      "code": 305,
+      "redirect_uri": "127.0.0.1",
+      "allow": false,
+      "message": "undefined",
+      "is_consul": false
+    }
+  },
+  "version": 1,
+  "servers": [
+    "host:wslproxy.com"
+  ]
+}

--- a/data/rules/prod/wslproxy-org-rule.json
+++ b/data/rules/prod/wslproxy-org-rule.json
@@ -1,0 +1,27 @@
+{
+  "id": "wslproxy-org-rule",
+  "created_at": 1769388395,
+  "name": "wslproxy-org-local",
+  "profile_id": "prod",
+  "priority": 1,
+  "match": {
+    "rules": {
+      "path": "/",
+      "path_key": "starts_with",
+      "client_ip_key": "equals",
+      "country_key": "equals",
+      "jwt_token_validation": "equals"
+    },
+    "response": {
+      "code": 305,
+      "redirect_uri": "127.0.0.1",
+      "allow": false,
+      "message": "undefined",
+      "is_consul": false
+    }
+  },
+  "version": 1,
+  "servers": [
+    "host:wslproxy.org"
+  ]
+}

--- a/data/rules/prod/www-wslproxy-com-rule.json
+++ b/data/rules/prod/www-wslproxy-com-rule.json
@@ -1,0 +1,27 @@
+{
+  "id": "www-wslproxy-com-rule",
+  "created_at": 1769388395,
+  "name": "www-wslproxy-com-local",
+  "profile_id": "prod",
+  "priority": 1,
+  "match": {
+    "rules": {
+      "path": "/",
+      "path_key": "starts_with",
+      "client_ip_key": "equals",
+      "country_key": "equals",
+      "jwt_token_validation": "equals"
+    },
+    "response": {
+      "code": 305,
+      "redirect_uri": "127.0.0.1",
+      "allow": false,
+      "message": "undefined",
+      "is_consul": false
+    }
+  },
+  "version": 1,
+  "servers": [
+    "host:www.wslproxy.com"
+  ]
+}

--- a/data/rules/prod/www-wslproxy-org-rule.json
+++ b/data/rules/prod/www-wslproxy-org-rule.json
@@ -1,0 +1,27 @@
+{
+  "id": "www-wslproxy-org-rule",
+  "created_at": 1769388395,
+  "name": "www-wslproxy-org-local",
+  "profile_id": "prod",
+  "priority": 1,
+  "match": {
+    "rules": {
+      "path": "/",
+      "path_key": "starts_with",
+      "client_ip_key": "equals",
+      "country_key": "equals",
+      "jwt_token_validation": "equals"
+    },
+    "response": {
+      "code": 305,
+      "redirect_uri": "127.0.0.1",
+      "allow": false,
+      "message": "undefined",
+      "is_consul": false
+    }
+  },
+  "version": 1,
+  "servers": [
+    "host:www.wslproxy.org"
+  ]
+}

--- a/data/servers/prod/host:prod-our.wslproxy.com.json
+++ b/data/servers/prod/host:prod-our.wslproxy.com.json
@@ -1,0 +1,28 @@
+{
+  "id": "host:prod-our.wslproxy.com",
+  "server_name": "prod-our.wslproxy.com",
+  "proxy_server_name": "prod-our.wslproxy.com",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/access.log",
+  "error_log": "logs/error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "proxy_pass": "http://localhost:8080",
+  "rules": "prod-our-wslproxy-rule",
+  "created_at": 1769388403,
+  "listens": [
+    {
+      "listen": "80"
+    }
+  ],
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "balinder.walia@gmail.com",
+  "cache_enabled": false,
+  "cache_bypass_auth": false,
+  "match_cases": {},
+  "custom_headers": []
+}

--- a/data/servers/prod/host:wslproxy.com.json
+++ b/data/servers/prod/host:wslproxy.com.json
@@ -1,0 +1,28 @@
+{
+  "id": "host:wslproxy.com",
+  "server_name": "wslproxy.com",
+  "proxy_server_name": "wslproxy.com",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/access.log",
+  "error_log": "logs/error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "proxy_pass": "http://127.0.0.1",
+  "rules": "wslproxy-com-rule",
+  "created_at": 1769388403,
+  "listens": [
+    {
+      "listen": "80"
+    }
+  ],
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "balinder.walia@gmail.com",
+  "cache_enabled": false,
+  "cache_bypass_auth": false,
+  "match_cases": {},
+  "custom_headers": []
+}

--- a/data/servers/prod/host:wslproxy.org.json
+++ b/data/servers/prod/host:wslproxy.org.json
@@ -1,0 +1,28 @@
+{
+  "id": "host:wslproxy.org",
+  "server_name": "wslproxy.org",
+  "proxy_server_name": "wslproxy.org",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/access.log",
+  "error_log": "logs/error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "proxy_pass": "http://127.0.0.1",
+  "rules": "wslproxy-org-rule",
+  "created_at": 1769388403,
+  "listens": [
+    {
+      "listen": "80"
+    }
+  ],
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "balinder.walia@gmail.com",
+  "cache_enabled": false,
+  "cache_bypass_auth": false,
+  "match_cases": {},
+  "custom_headers": []
+}

--- a/data/servers/prod/host:www.wslproxy.com.json
+++ b/data/servers/prod/host:www.wslproxy.com.json
@@ -1,0 +1,28 @@
+{
+  "id": "host:www.wslproxy.com",
+  "server_name": "www.wslproxy.com",
+  "proxy_server_name": "www.wslproxy.com",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/access.log",
+  "error_log": "logs/error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "proxy_pass": "http://127.0.0.1",
+  "rules": "www-wslproxy-com-rule",
+  "created_at": 1769388403,
+  "listens": [
+    {
+      "listen": "80"
+    }
+  ],
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "balinder.walia@gmail.com",
+  "cache_enabled": false,
+  "cache_bypass_auth": false,
+  "match_cases": {},
+  "custom_headers": []
+}

--- a/data/servers/prod/host:www.wslproxy.org.json
+++ b/data/servers/prod/host:www.wslproxy.org.json
@@ -1,0 +1,28 @@
+{
+  "id": "host:www.wslproxy.org",
+  "server_name": "www.wslproxy.org",
+  "proxy_server_name": "www.wslproxy.org",
+  "root": "/var/www/html",
+  "index": "index.html",
+  "access_log": "logs/access.log",
+  "error_log": "logs/error.log",
+  "config_status": false,
+  "profile_id": "prod",
+  "proxy_pass": "http://127.0.0.1",
+  "rules": "www-wslproxy-org-rule",
+  "created_at": 1769388403,
+  "listens": [
+    {
+      "listen": "80"
+    }
+  ],
+  "ssl_enabled": true,
+  "ssl_force_https": true,
+  "ssl_staging": false,
+  "ssl_auto_renew": true,
+  "ssl_email": "balinder.walia@gmail.com",
+  "cache_enabled": false,
+  "cache_bypass_auth": false,
+  "match_cases": {},
+  "custom_headers": []
+}


### PR DESCRIPTION
Remove data/servers and data/rules from .gitignore so these configs are committed and deployable via the Ansible/GitHub workflow. These files contain no secrets - sensitive data lives in data/settings.json which remains gitignored.

Includes configs for all domains:
- wslproxy.com / www.wslproxy.com (commercial)
- wslproxy.org / www.wslproxy.org (free)
- prod-our.wslproxy.com (admin UI)