### PR TITLE
feat(ui): set default page size to 1000 across all list views

### DIFF
--- a/api/sync_data.lua
+++ b/api/sync_data.lua
@@ -248,7 +248,7 @@ function SyncRulesAPI(args)
     local apiPageSize = settings.env_vars.API_PAGE_SIZE or os.getenv("API_PAGE_SIZE")
     local apiTotalPages = 1
     local profileName = args.envprofile
-    apiPageSize = (apiPageSize == nil or apiPageSize == "") and 100 or apiPageSize
+    apiPageSize = (apiPageSize == nil or apiPageSize == "") and 1000 or apiPageSize
 
     local totalPages = 1
     local totalRules = saveRecordsToDisk(
@@ -288,7 +288,7 @@ function SyncServersAPI(args)
     local apiPageSize = settings.env_vars.API_PAGE_SIZE or os.getenv("API_PAGE_SIZE")
     local apiTotalPages = 1
     local profileName = args.envprofile
-    apiPageSize = (apiPageSize == nil or apiPageSize == "") and 100 or apiPageSize
+    apiPageSize = (apiPageSize == nil or apiPageSize == "") and 1000 or apiPageSize
     local settings = getSettings()
     -- if settings.sync_nginx_conf_files ~= nil and settings.sync_nginx_conf_files == true then
     --     deleteFilesInDirectory(configPath .. "data/servers/" .. profileName .. "/conf")

--- a/data/sample-settings.json
+++ b/data/sample-settings.json
@@ -31,7 +31,7 @@
     "JWT_SECURITY_PASSPHRASE": "docker-standlone-dev-jwt",
     "REDIS_PORT": 6379,
     "APP_NAME": "Openresty",
-    "API_PAGE_SIZE": 100,
+    "API_PAGE_SIZE": 1000,
     "STACK": "Lua 5.1",
     "VITE_DEPLOYMENT_TIME": "20240821210059",
     "NGINX_CONFIG_DIR": "/opt/nginx",

--- a/openresty-admin/src/Instances/List.jsx
+++ b/openresty-admin/src/Instances/List.jsx
@@ -45,6 +45,7 @@ const List = () => {
   return (
     <RaList
       title={"Instances"}
+      perPage={1000}
       sort={{ field: 'created_at', order: 'DESC' }}
       empty={<Empty resource={"instances"} />}
       filters={secretFilters}

--- a/openresty-admin/src/Profiles/List.jsx
+++ b/openresty-admin/src/Profiles/List.jsx
@@ -3,7 +3,7 @@ import { List as RaList, Datagrid, TextField } from 'react-admin';
 
 const List = () => {
   return (
-    <RaList>
+    <RaList perPage={1000}>
       <Datagrid
         rowClick="edit"
       >

--- a/openresty-admin/src/Rules/List.jsx
+++ b/openresty-admin/src/Rules/List.jsx
@@ -33,6 +33,7 @@ const List = () => {
   return (
     <RaList
       title={"Rules"}
+      perPage={1000}
       exporter={ExportJsonButton}
       empty={<Empty resource={"rules"} />}
       filters={rulesFilters}

--- a/openresty-admin/src/Secrets/List.jsx
+++ b/openresty-admin/src/Secrets/List.jsx
@@ -27,6 +27,7 @@ const List = () => {
   return (
     <RaList
       title={"Secrets"}
+      perPage={1000}
       sort={{ field: 'created_at', order: 'DESC' }}
       empty={<Empty resource={"secrets"} />}
       filters={secretFilters}

--- a/openresty-admin/src/Servers/List.jsx
+++ b/openresty-admin/src/Servers/List.jsx
@@ -183,6 +183,7 @@ const List = () => {
 
       <RaList
         title={" "}
+        perPage={1000}
         sort={{ field: 'created_at', order: 'DESC' }}
         exporter={ExportJsonButton}
         empty={<Empty resource={"servers"} />}

--- a/openresty-admin/src/Sessions/List.jsx
+++ b/openresty-admin/src/Sessions/List.jsx
@@ -3,7 +3,7 @@ import { Datagrid, DateField, EmailField, List as RaList, TextField } from 'reac
 
 const List = () => {
   return (
-    <RaList title={"Sessions"}>
+    <RaList title={"Sessions"} perPage={1000}>
       <Datagrid>
         <TextField source='id' />
         <TextField source='session_id' />

--- a/openresty-admin/src/Upstreams/List.jsx
+++ b/openresty-admin/src/Upstreams/List.jsx
@@ -24,6 +24,7 @@ const List = () => {
   return (
     <RaList
       title={"Upstreams"}
+      perPage={1000}
       sort={{ field: 'created_at', order: 'DESC' }}
       empty={<Empty resource={"upstreams"} />}
       filters={upstreamFilters}

--- a/openresty-admin/src/Users/List.jsx
+++ b/openresty-admin/src/Users/List.jsx
@@ -3,7 +3,7 @@ import { Datagrid, EmailField, List as RaList, TextField } from "react-admin";
 
 const List = () => {
   return (
-    <RaList title={"Users"} sort={{ field: 'created_at', order: 'DESC' }}>
+    <RaList title={"Users"} perPage={1000} sort={{ field: 'created_at', order: 'DESC' }}>
       <Datagrid rowClick="edit">
         <TextField source="name" />
         <EmailField source="email" />


### PR DESCRIPTION
Updated all React Admin list components to use perPage={1000} instead of the framework default of 50. Also updated API_PAGE_SIZE in sample-settings.json and sync_data.lua fallback defaults.