### PR TITLE
Add Web Application Firewall (WAF) for WSLProxy

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: WSL Proxy Dashboard E2E Tests
 
 on:
   push:

--- a/api/api.lua
+++ b/api/api.lua
@@ -302,6 +302,81 @@ local function handleValidationErrors(errors, resourceType)
     end
 end
 
+-- =====================================================
+-- WAF Rule Validation
+-- =====================================================
+local function validateWafRulePayload(payloads)
+    local errors = {}
+
+    if not payloads.name or payloads.name == "" then
+        table.insert(errors, { field = "name", message = "WAF rule name is required" })
+    elseif type(payloads.name) ~= "string" then
+        table.insert(errors, { field = "name", message = "WAF rule name must be a string" })
+    end
+
+    if not payloads.category or payloads.category == "" then
+        table.insert(errors, { field = "category", message = "WAF rule category is required" })
+    else
+        local valid_categories = { sqli = true, xss = true, cmdi = true, lfi = true, rfi = true, protocol = true, custom = true }
+        if not valid_categories[payloads.category] then
+            table.insert(errors, { field = "category", message = "Invalid category. Must be one of: sqli, xss, cmdi, lfi, rfi, protocol, custom" })
+        end
+    end
+
+    if not payloads.pattern or payloads.pattern == "" then
+        table.insert(errors, { field = "pattern", message = "WAF rule pattern is required" })
+    elseif payloads.pattern_type ~= "string" then
+        local ok, compile_err = pcall(ngx.re.compile, payloads.pattern, "ijo")
+        if not ok then
+            table.insert(errors, { field = "pattern", message = "Invalid regex pattern: " .. tostring(compile_err) })
+        end
+    end
+
+    if not payloads.target or payloads.target == "" then
+        table.insert(errors, { field = "target", message = "WAF rule target is required" })
+    else
+        local valid_targets = { url = true, headers = true, body = true, args = true, cookies = true, user_agent = true, all = true }
+        if not valid_targets[payloads.target] then
+            table.insert(errors, { field = "target", message = "Invalid target. Must be one of: url, headers, body, args, cookies, user_agent, all" })
+        end
+    end
+
+    if not payloads.action or payloads.action == "" then
+        table.insert(errors, { field = "action", message = "WAF rule action is required" })
+    else
+        local valid_actions = { block = true, monitor = true, allow = true }
+        if not valid_actions[payloads.action] then
+            table.insert(errors, { field = "action", message = "Invalid action. Must be one of: block, monitor, allow" })
+        end
+    end
+
+    return errors
+end
+
+-- =====================================================
+-- WAF Policy Validation
+-- =====================================================
+local function validateWafPolicyPayload(payloads)
+    local errors = {}
+
+    if not payloads.name or payloads.name == "" then
+        table.insert(errors, { field = "name", message = "WAF policy name is required" })
+    elseif type(payloads.name) ~= "string" then
+        table.insert(errors, { field = "name", message = "WAF policy name must be a string" })
+    end
+
+    if not payloads.mode or payloads.mode == "" then
+        table.insert(errors, { field = "mode", message = "WAF policy mode is required" })
+    else
+        local valid_modes = { block = true, monitor = true }
+        if not valid_modes[payloads.mode] then
+            table.insert(errors, { field = "mode", message = "Invalid mode. Must be one of: block, monitor" })
+        end
+    end
+
+    return errors
+end
+
 local red = {}
 
 if settings.storage_type == "redis" then
@@ -1895,6 +1970,355 @@ local function createUpdateInstances(body, uuid)
 end
 
 -- =====================================================
+-- WAF Rules API Functions
+-- =====================================================
+local function listWafRules(args)
+    local allRules, totalRecords = {}, 0
+    local params = args
+    local qParams, environment = {}, "prod"
+    params = params.params
+    if params == nil and type(params) == "nil" then
+        qParams = {
+            pagination = {
+                page = args['pagination[page]'],
+                perPage = args['pagination[perPage]']
+            },
+            sort = {
+                field = args['sort[field]'],
+                order = args['sort[order]']
+            },
+            filter = {
+                profile_id = args['filter[profile_id]']
+            }
+        }
+    else
+        qParams = cjson.decode(params)
+    end
+    qParams["type"] = {
+        table = "waf_rules",
+        key_name = "name"
+    }
+    local pageSize = qParams.pagination.perPage
+    local pageNumber = qParams.pagination.page
+    if qParams.filter ~= nil and qParams.filter.profile_id ~= nil then
+        environment = qParams.filter.profile_id
+    end
+    allRules, totalRecords = listFromDisk("waf_rules/" .. environment, pageSize, pageNumber, qParams)
+    if qParams.sort ~= nil and qParams.sort.order == "DESC" then
+        table.sort(allRules, Helper.sortDesc(qParams.sort.field))
+    elseif qParams.sort ~= nil and qParams.sort.order == "ASC" then
+        table.sort(allRules, Helper.sortAsc(qParams.sort.field))
+    end
+    ngx.say(cjson.encode({
+        data = allRules,
+        total = totalRecords
+    }))
+end
+
+local function listWafRule(args, uuid)
+    local envProfile = args.envprofile ~= nil and args.envprofile or "prod"
+    local jsonData, dataErr = Helper.getDataFromFile(configPath ..
+        "data/waf_rules/" .. envProfile .. "/" .. uuid .. ".json")
+    if dataErr == nil then
+        local resultData = cjson.decode(jsonData)
+        ngx.say(cjson.encode({
+            data = resultData
+        }))
+    else
+        Errors.throwError("WAF rule not found: " .. tostring(dataErr), ngx.HTTP_NOT_FOUND)
+    end
+end
+
+local function createUpdateWafRules(body, uuid)
+    local payloads, response = Helper.GetPayloads(body), {}
+
+    local validationErrors = validateWafRulePayload(payloads)
+    handleValidationErrors(validationErrors, "waf_rule")
+
+    if not uuid then
+        ---@diagnostic disable-next-line: param-type-mismatch
+        payloads.created_at = os.time(os.date("!*t"))
+    end
+    ---@diagnostic disable-next-line: param-type-mismatch
+    payloads.updated_at = os.time(os.date("!*t"))
+
+    if uuid then
+        response = CreateUpdateRecord(payloads, uuid, "waf_rules", "waf_rules", "update")
+    else
+        local envProfile = payloads.profile_id or "prod"
+        local folderPath = string.format("%sdata/waf_rules/%s", configPath, envProfile)
+        local isUnique, err = Helper.isUniqueField(folderPath, "name", payloads.name)
+        if not isUnique then
+            Errors.conflict(err, { name = payloads.name })
+        end
+        payloads.id = Helper.generate_uuid()
+        response = CreateUpdateRecord(payloads, payloads.id, "waf_rules", "waf_rules", "create")
+    end
+    ngx.say(cjson.encode({
+        data = response
+    }))
+end
+
+local function createDeleteWafRules(body, uuid)
+    local payloads = Helper.GetPayloads(body)
+    if payloads == ngx.null or not body or type(payloads) == "nil" then
+        payloads = ngx.req.get_uri_args()
+    end
+    local envProfile = "prod"
+    if payloads.ids ~= nil then
+        envProfile = payloads.ids.envProfile or "prod"
+    elseif payloads.envProfile then
+        envProfile = payloads.envProfile
+    end
+    if uuid ~= "" and uuid ~= nil then
+        os.remove(configPath .. "data/waf_rules/" .. envProfile .. "/" .. uuid .. ".json")
+    elseif payloads and payloads.ids and payloads.ids.ids and #payloads.ids.ids > 0 then
+        for value = 1, #payloads.ids.ids do
+            os.remove(configPath .. "data/waf_rules/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json")
+        end
+    end
+    ngx.say(cjson.encode({
+        data = payloads
+    }))
+end
+
+-- =====================================================
+-- WAF Policies API Functions
+-- =====================================================
+local function listWafPolicies(args)
+    local allPolicies, totalRecords = {}, 0
+    local params = args
+    local qParams, environment = {}, "prod"
+    params = params.params
+    if params == nil and type(params) == "nil" then
+        qParams = {
+            pagination = {
+                page = args['pagination[page]'],
+                perPage = args['pagination[perPage]']
+            },
+            sort = {
+                field = args['sort[field]'],
+                order = args['sort[order]']
+            },
+            filter = {
+                profile_id = args['filter[profile_id]']
+            }
+        }
+    else
+        qParams = cjson.decode(params)
+    end
+    qParams["type"] = {
+        table = "waf_policies",
+        key_name = "name"
+    }
+    local pageSize = qParams.pagination.perPage
+    local pageNumber = qParams.pagination.page
+    if qParams.filter ~= nil and qParams.filter.profile_id ~= nil then
+        environment = qParams.filter.profile_id
+    end
+    allPolicies, totalRecords = listFromDisk("waf_policies/" .. environment, pageSize, pageNumber, qParams)
+    if qParams.sort ~= nil and qParams.sort.order == "DESC" then
+        table.sort(allPolicies, Helper.sortDesc(qParams.sort.field))
+    elseif qParams.sort ~= nil and qParams.sort.order == "ASC" then
+        table.sort(allPolicies, Helper.sortAsc(qParams.sort.field))
+    end
+    ngx.say(cjson.encode({
+        data = allPolicies,
+        total = totalRecords
+    }))
+end
+
+local function listWafPolicy(args, uuid)
+    local envProfile = args.envprofile ~= nil and args.envprofile or "prod"
+    local jsonData, dataErr = Helper.getDataFromFile(configPath ..
+        "data/waf_policies/" .. envProfile .. "/" .. uuid .. ".json")
+    if dataErr == nil then
+        local resultData = cjson.decode(jsonData)
+        ngx.say(cjson.encode({
+            data = resultData
+        }))
+    else
+        Errors.throwError("WAF policy not found: " .. tostring(dataErr), ngx.HTTP_NOT_FOUND)
+    end
+end
+
+local function createUpdateWafPolicies(body, uuid)
+    local payloads, response = Helper.GetPayloads(body), {}
+
+    local validationErrors = validateWafPolicyPayload(payloads)
+    handleValidationErrors(validationErrors, "waf_policy")
+
+    if not uuid then
+        ---@diagnostic disable-next-line: param-type-mismatch
+        payloads.created_at = os.time(os.date("!*t"))
+    end
+    ---@diagnostic disable-next-line: param-type-mismatch
+    payloads.updated_at = os.time(os.date("!*t"))
+
+    if uuid then
+        response = CreateUpdateRecord(payloads, uuid, "waf_policies", "waf_policies", "update")
+    else
+        local envProfile = payloads.profile_id or "prod"
+        local folderPath = string.format("%sdata/waf_policies/%s", configPath, envProfile)
+        local isUnique, err = Helper.isUniqueField(folderPath, "name", payloads.name)
+        if not isUnique then
+            Errors.conflict(err, { name = payloads.name })
+        end
+        payloads.id = Helper.generate_uuid()
+        response = CreateUpdateRecord(payloads, payloads.id, "waf_policies", "waf_policies", "create")
+    end
+    ngx.say(cjson.encode({
+        data = response
+    }))
+end
+
+local function createDeleteWafPolicies(body, uuid)
+    local payloads = Helper.GetPayloads(body)
+    if payloads == ngx.null or not body or type(payloads) == "nil" then
+        payloads = ngx.req.get_uri_args()
+    end
+    local envProfile = "prod"
+    if payloads.ids ~= nil then
+        envProfile = payloads.ids.envProfile or "prod"
+    elseif payloads.envProfile then
+        envProfile = payloads.envProfile
+    end
+    if uuid ~= "" and uuid ~= nil then
+        os.remove(configPath .. "data/waf_policies/" .. envProfile .. "/" .. uuid .. ".json")
+    elseif payloads and payloads.ids and payloads.ids.ids and #payloads.ids.ids > 0 then
+        for value = 1, #payloads.ids.ids do
+            os.remove(configPath .. "data/waf_policies/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json")
+        end
+    end
+    ngx.say(cjson.encode({
+        data = payloads
+    }))
+end
+
+-- =====================================================
+-- WAF Events API Functions (read-only)
+-- =====================================================
+local function listWafEvents(args)
+    local events = {}
+    local waf_dict = ngx.shared.waf_events
+    if not waf_dict then
+        ngx.say(cjson.encode({
+            data = events,
+            total = 0,
+            message = "WAF events shared dict not available"
+        }))
+        return
+    end
+
+    local keys = waf_dict:get_keys(1000)
+    for _, key in ipairs(keys) do
+        local val = waf_dict:get(key)
+        if val then
+            local ok, event = pcall(cjson.decode, val)
+            if ok and event then
+                table.insert(events, event)
+            end
+        end
+    end
+
+    -- Sort by timestamp descending (newest first)
+    table.sort(events, function(a, b)
+        return (a.timestamp or 0) > (b.timestamp or 0)
+    end)
+
+    -- Apply pagination from args
+    local params = args
+    local qParams = {}
+    params = params.params
+    if params == nil and type(params) == "nil" then
+        qParams = {
+            pagination = {
+                page = tonumber(args['pagination[page]']) or 1,
+                perPage = tonumber(args['pagination[perPage]']) or 50
+            }
+        }
+    else
+        qParams = cjson.decode(params)
+    end
+
+    local pageSize = tonumber(qParams.pagination.perPage) or 50
+    local pageNumber = tonumber(qParams.pagination.page) or 1
+    local totalRecords = #events
+    local startIdx = (pageNumber - 1) * pageSize + 1
+    local endIdx = math.min(startIdx + pageSize - 1, totalRecords)
+    local paginatedEvents = {}
+    for i = startIdx, endIdx do
+        if events[i] then
+            table.insert(paginatedEvents, events[i])
+        end
+    end
+
+    ngx.say(cjson.encode({
+        data = paginatedEvents,
+        total = totalRecords
+    }))
+end
+
+-- =====================================================
+-- WAF Seed Function
+-- =====================================================
+local function seedWafRules(args)
+    local ok, WafDefaults = pcall(require, "waf_default_rules")
+    if not ok then
+        Errors.throwError("Failed to load WAF default rules module: " .. tostring(WafDefaults),
+            ngx.HTTP_INTERNAL_SERVER_ERROR)
+        return
+    end
+
+    local payloads = Helper.GetPayloads(args)
+    local envProfile = "prod"
+    if payloads and payloads.profile_id then
+        envProfile = payloads.profile_id
+    end
+
+    local seed_data = WafDefaults.get_seed_data(envProfile)
+    local rulesDir = configPath .. "data/waf_rules/" .. envProfile
+    local policiesDir = configPath .. "data/waf_policies/" .. envProfile
+
+    -- Create directories if needed
+    if not Helper.isDirectoryExists(rulesDir) then
+        Helper.createDirectoryRecursive(rulesDir)
+    end
+    if not Helper.isDirectoryExists(policiesDir) then
+        Helper.createDirectoryRecursive(policiesDir)
+    end
+
+    -- Write seed rules
+    local rulesWritten = 0
+    for _, rule in ipairs(seed_data.rules) do
+        local filePath = rulesDir .. "/" .. rule.id .. ".json"
+        -- Only write if file doesn't exist (don't overwrite customizations)
+        if not Helper.isFileExists(filePath) then
+            Helper.setDataToFile(filePath, rule, rulesDir)
+            rulesWritten = rulesWritten + 1
+        end
+    end
+
+    -- Write default policy
+    local policiesWritten = 0
+    local policyPath = policiesDir .. "/" .. seed_data.policy.id .. ".json"
+    if not Helper.isFileExists(policyPath) then
+        Helper.setDataToFile(policyPath, seed_data.policy, policiesDir)
+        policiesWritten = 1
+    end
+
+    ngx.say(cjson.encode({
+        data = {
+            message = "WAF seed data deployed",
+            profile_id = envProfile,
+            rules_written = rulesWritten,
+            rules_skipped = #seed_data.rules - rulesWritten,
+            policies_written = policiesWritten
+        }
+    }))
+end
+
+-- =====================================================
 -- Upstreams API Functions
 -- =====================================================
 
@@ -3333,6 +3757,21 @@ local function handle_get_request(args, path)
     elseif uuid and subPath[1] == "profiles" then
         listProfile(args, uuid)
     end
+
+    -- WAF endpoints
+    if path == "waf_rules" then
+        listWafRules(args)
+    elseif uuid and #uuid > 0 and subPath[1] == "waf_rules" then
+        listWafRule(args, uuid)
+    end
+    if path == "waf_policies" then
+        listWafPolicies(args)
+    elseif uuid and #uuid > 0 and subPath[1] == "waf_policies" then
+        listWafPolicy(args, uuid)
+    end
+    if path == "waf_events" then
+        listWafEvents(args)
+    end
 end
 
 local function handle_post_request(args, path)
@@ -3377,6 +3816,15 @@ local function handle_post_request(args, path)
         end
         if path == "profiles" then
             createUpdateProfiles(args, nil)
+        end
+        if path == "waf_rules" then
+            createUpdateWafRules(args)
+        end
+        if path == "waf_policies" then
+            createUpdateWafPolicies(args)
+        end
+        if path == "waf_rules/seed" then
+            seedWafRules(args)
         end
         if path == "password/reset" then
             resetPassword(args)
@@ -3500,7 +3948,11 @@ local function handle_put_request(args, path)
             createUpdateUser(args, uuid)
         end
 
-        if string.find(path, "rules") then
+        if string.find(path, "waf_rules") then
+            createUpdateWafRules(args, uuid)
+        elseif string.find(path, "waf_policies") then
+            createUpdateWafPolicies(args, uuid)
+        elseif string.find(path, "rules") then
             createUpdateRules(args, uuid)
         end
 
@@ -3535,7 +3987,11 @@ local function handle_delete_request(args, path)
     local pattern = ".*/(.*)"
     local uuid = string.match(path, pattern)
     if settings.instance_locked == "false" or platform == "react-admin" then
-        if string.find(path, "rules") then
+        if string.find(path, "waf_rules") then
+            createDeleteWafRules(args, uuid)
+        elseif string.find(path, "waf_policies") then
+            createDeleteWafPolicies(args, uuid)
+        elseif string.find(path, "rules") then
             createDeleteRules(args, uuid)
         end
         if string.find(path, "secrets") then

--- a/api/gateway_ack.lua
+++ b/api/gateway_ack.lua
@@ -718,6 +718,18 @@ if exist_values and exist_values ~= 0 and exist_values ~= nil and exist_values ~
         -- do return ngx.say(highestPriorityKey) end
         if rulePasses == true then
             local selectedRule = parse_rules[highestPriorityParentKey][highestPriorityKey]
+
+            -- WAF Inspection (fail-open: if WAF module errors, request continues)
+            local waf_ok, WafEngine = pcall(require, "waf_engine")
+            if waf_ok and WafEngine then
+                local waf_result = WafEngine.inspect(jsonval, envProfile)
+                if waf_result and waf_result.action == "block" then
+                    local policy = WafEngine.load_policy(jsonval, envProfile)
+                    WafEngine.block_request(policy, waf_result)
+                    return
+                end
+            end
+
             local globalVars = ngx.var.frontdoor_global_vars
             globalVars = cjson.decode(globalVars)
             globalVars.executableRule = selectedRule

--- a/api/mcp/mappers/init.lua
+++ b/api/mcp/mappers/init.lua
@@ -14,6 +14,9 @@ local cache_mapper = require("mcp.mappers.cache")
 local health_mapper = require("mcp.mappers.health")
 local metrics_mapper = require("mcp.mappers.metrics")
 local settings_mapper = require("mcp.mappers.settings")
+local waf_rule_mapper = require("mcp.mappers.waf_rule")
+local waf_policy_mapper = require("mcp.mappers.waf_policy")
+local waf_event_mapper = require("mcp.mappers.waf_event")
 
 -- Registry mapping resource IDs to their mappers
 _M.registry = {
@@ -25,7 +28,10 @@ _M.registry = {
     cache = cache_mapper,
     health = health_mapper,
     metrics = metrics_mapper,
-    settings = settings_mapper
+    settings = settings_mapper,
+    waf_rules = waf_rule_mapper,
+    waf_policies = waf_policy_mapper,
+    waf_events = waf_event_mapper
 }
 
 -- Map a raw data table to a typed MCP resource

--- a/api/mcp/mappers/waf_event.lua
+++ b/api/mcp/mappers/waf_event.lua
@@ -1,0 +1,64 @@
+-- WAF Event Resource Mapper
+-- Maps WAF events from shared dict → MCP wslproxy.waf_event resources
+
+local _M = {}
+
+local resource_schema = require("mcp.schemas.resource")
+
+_M.resource_type = "wslproxy.waf_event"
+_M.schema = resource_schema.waf_event
+_M.swagger_source = {
+    list = "GET /api/waf_events"
+}
+
+function _M.map_one(event)
+    if not event then return nil end
+
+    return {
+        type = _M.resource_type,
+        id = event.id or (event.timestamp .. "-" .. (event.rule_id or "unknown")),
+        attributes = {
+            timestamp = event.timestamp,
+            type = event.type,
+            host = event.host,
+            rule_id = event.rule_id,
+            rule_name = event.rule_name,
+            category = event.category,
+            severity = event.severity,
+            client_ip = event.client_ip,
+            uri = event.uri,
+            method = event.method,
+            score = event.score,
+            matched_data = event.matched_data
+        },
+        relationships = {
+            waf_rule = event.rule_id and {
+                type = "wslproxy.waf_rule",
+                id = event.rule_id
+            } or nil
+        }
+    }
+end
+
+function _M.to_mcp(data)
+    if type(data) ~= "table" then
+        return data
+    end
+
+    if data.timestamp and data.rule_id then
+        return _M.map_one(data)
+    end
+
+    local resources = {}
+    for _, event in ipairs(data) do
+        table.insert(resources, _M.map_one(event))
+    end
+
+    return {
+        type = _M.resource_type .. ".list",
+        count = #resources,
+        items = resources
+    }
+end
+
+return _M

--- a/api/mcp/mappers/waf_policy.lua
+++ b/api/mcp/mappers/waf_policy.lua
@@ -1,0 +1,71 @@
+-- WAF Policy Resource Mapper
+-- Maps /api/waf_policies domain objects → MCP wslproxy.waf_policy resources
+
+local _M = {}
+
+local resource_schema = require("mcp.schemas.resource")
+
+_M.resource_type = "wslproxy.waf_policy"
+_M.schema = resource_schema.waf_policy
+_M.swagger_source = {
+    list = "GET /api/waf_policies",
+    detail = "GET /api/waf_policies/{id}"
+}
+
+function _M.map_one(policy)
+    if not policy then return nil end
+
+    return {
+        type = _M.resource_type,
+        id = policy.id,
+        attributes = {
+            name = policy.name,
+            description = policy.description,
+            mode = policy.mode,
+            enabled = policy.enabled,
+            waf_rules = policy.waf_rules,
+            anomaly_threshold = policy.anomaly_threshold,
+            paranoia_level = policy.paranoia_level,
+            body_inspection = policy.body_inspection,
+            max_body_size = policy.max_body_size,
+            whitelist = policy.whitelist,
+            blocked_response = policy.blocked_response,
+            profile_id = policy.profile_id,
+            created_at = policy.created_at,
+            updated_at = policy.updated_at
+        },
+        relationships = {
+            profile = {
+                type = "wslproxy.profile",
+                id = policy.profile_id
+            },
+            waf_rules = {
+                type = "wslproxy.waf_rule",
+                ids = policy.waf_rules
+            }
+        }
+    }
+end
+
+function _M.to_mcp(data)
+    if type(data) ~= "table" then
+        return data
+    end
+
+    if data.id then
+        return _M.map_one(data)
+    end
+
+    local resources = {}
+    for _, policy in ipairs(data) do
+        table.insert(resources, _M.map_one(policy))
+    end
+
+    return {
+        type = _M.resource_type .. ".list",
+        count = #resources,
+        items = resources
+    }
+end
+
+return _M

--- a/api/mcp/mappers/waf_rule.lua
+++ b/api/mcp/mappers/waf_rule.lua
@@ -1,0 +1,67 @@
+-- WAF Rule Resource Mapper
+-- Maps /api/waf_rules domain objects → MCP wslproxy.waf_rule resources
+
+local _M = {}
+
+local resource_schema = require("mcp.schemas.resource")
+
+_M.resource_type = "wslproxy.waf_rule"
+_M.schema = resource_schema.waf_rule
+_M.swagger_source = {
+    list = "GET /api/waf_rules",
+    detail = "GET /api/waf_rules/{id}"
+}
+
+function _M.map_one(rule)
+    if not rule then return nil end
+
+    return {
+        type = _M.resource_type,
+        id = rule.id,
+        attributes = {
+            name = rule.name,
+            description = rule.description,
+            category = rule.category,
+            severity = rule.severity,
+            enabled = rule.enabled,
+            target = rule.target,
+            pattern = rule.pattern,
+            pattern_type = rule.pattern_type,
+            action = rule.action,
+            score = rule.score,
+            tags = rule.tags,
+            profile_id = rule.profile_id,
+            created_at = rule.created_at,
+            updated_at = rule.updated_at
+        },
+        relationships = {
+            profile = {
+                type = "wslproxy.profile",
+                id = rule.profile_id
+            }
+        }
+    }
+end
+
+function _M.to_mcp(data)
+    if type(data) ~= "table" then
+        return data
+    end
+
+    if data.id then
+        return _M.map_one(data)
+    end
+
+    local resources = {}
+    for _, rule in ipairs(data) do
+        table.insert(resources, _M.map_one(rule))
+    end
+
+    return {
+        type = _M.resource_type .. ".list",
+        count = #resources,
+        items = resources
+    }
+end
+
+return _M

--- a/api/mcp/resources.lua
+++ b/api/mcp/resources.lua
@@ -496,8 +496,110 @@ _M.RESOURCE_REGISTRY = {
         mimeType = "application/json",
         category = "configuration",
         read_only = true
+    },
+    {
+        id = "waf_rules",
+        name = "WAF Rules",
+        description = "Web Application Firewall detection rules (SQLi, XSS, Command Injection, etc.)",
+        uri = "wslproxy://resources/waf_rules",
+        mimeType = "application/json",
+        category = "security",
+        read_only = true
+    },
+    {
+        id = "waf_policies",
+        name = "WAF Policies",
+        description = "WAF policies grouping rules with enforcement mode and thresholds",
+        uri = "wslproxy://resources/waf_policies",
+        mimeType = "application/json",
+        category = "security",
+        read_only = true
+    },
+    {
+        id = "waf_events",
+        name = "WAF Events",
+        description = "Recent WAF inspection events (blocked and monitored requests)",
+        uri = "wslproxy://resources/waf_events",
+        mimeType = "application/json",
+        category = "security",
+        read_only = true
     }
 }
+
+-----------------------------------------------------------
+-- Resource: WAF Rules
+-----------------------------------------------------------
+function _M.get_waf_rules(config, profile_id)
+    profile_id = profile_id or "prod"
+    local dir = configPath .. "data/waf_rules/" .. profile_id
+    local rules, err = read_json_directory(dir)
+    if err then
+        ngx.log(ngx.WARN, "MCP: Failed to read WAF rules for profile ", profile_id, ": ", err)
+    end
+    return rules
+end
+
+function _M.get_waf_rule(config, rule_id, profile_id)
+    profile_id = profile_id or "prod"
+    local path = configPath .. "data/waf_rules/" .. profile_id .. "/" .. rule_id .. ".json"
+    local data, err = read_json_file(path)
+    if not data then
+        return nil, "WAF rule not found: " .. rule_id
+    end
+    return data, nil
+end
+
+-----------------------------------------------------------
+-- Resource: WAF Policies
+-----------------------------------------------------------
+function _M.get_waf_policies(config, profile_id)
+    profile_id = profile_id or "prod"
+    local dir = configPath .. "data/waf_policies/" .. profile_id
+    local policies, err = read_json_directory(dir)
+    if err then
+        ngx.log(ngx.WARN, "MCP: Failed to read WAF policies for profile ", profile_id, ": ", err)
+    end
+    return policies
+end
+
+function _M.get_waf_policy(config, policy_id, profile_id)
+    profile_id = profile_id or "prod"
+    local path = configPath .. "data/waf_policies/" .. profile_id .. "/" .. policy_id .. ".json"
+    local data, err = read_json_file(path)
+    if not data then
+        return nil, "WAF policy not found: " .. policy_id
+    end
+    return data, nil
+end
+
+-----------------------------------------------------------
+-- Resource: WAF Events (from shared dict)
+-----------------------------------------------------------
+function _M.get_waf_events(config)
+    local events = {}
+    local waf_dict = ngx.shared.waf_events
+    if not waf_dict then
+        return events
+    end
+
+    local keys = waf_dict:get_keys(500)
+    for _, key in ipairs(keys) do
+        local val = waf_dict:get(key)
+        if val then
+            local ok, event = pcall(cjson.decode, val)
+            if ok and event then
+                table.insert(events, event)
+            end
+        end
+    end
+
+    -- Sort by timestamp descending
+    table.sort(events, function(a, b)
+        return (a.timestamp or 0) > (b.timestamp or 0)
+    end)
+
+    return events
+end
 
 -- Get a specific resource by ID
 function _M.get_resource(resource_id, config, params)
@@ -512,7 +614,10 @@ function _M.get_resource(resource_id, config, params)
         cache = function() return _M.get_cache_configs(config), nil end,
         health = function() return _M.get_health(config), nil end,
         metrics = function() return _M.get_metrics_summary(config), nil end,
-        settings = function() return _M.get_settings_safe(config) end
+        settings = function() return _M.get_settings_safe(config) end,
+        waf_rules = function() return _M.get_waf_rules(config, profile_id), nil end,
+        waf_policies = function() return _M.get_waf_policies(config, profile_id), nil end,
+        waf_events = function() return _M.get_waf_events(config), nil end
     }
 
     local handler = handlers[resource_id]

--- a/api/mcp/schemas/resource.lua
+++ b/api/mcp/schemas/resource.lua
@@ -319,4 +319,73 @@ _M.settings = {
     }
 }
 
+-- wslproxy.waf_rule resource schema
+_M.waf_rule = {
+    type = "wslproxy.waf_rule",
+    version = "1.0.0",
+    description = "WAF detection rule with regex/string pattern matching",
+    properties = {
+        id = { type = "string", required = true, description = "Unique WAF rule identifier" },
+        name = { type = "string", required = true, description = "Rule display name" },
+        description = { type = "string", required = false, description = "Rule description" },
+        category = { type = "string", required = true, description = "Attack category (sqli, xss, cmdi, lfi, rfi, protocol, custom)" },
+        severity = { type = "string", required = false, description = "Severity level (critical, high, medium, low, info)" },
+        enabled = { type = "boolean", required = false, description = "Whether this rule is active" },
+        target = { type = "string", required = true, description = "Request component to inspect (url, headers, body, args, cookies, user_agent, all)" },
+        pattern = { type = "string", required = true, description = "Detection pattern (regex or string)" },
+        pattern_type = { type = "string", required = false, description = "Pattern matching type (regex or string)" },
+        action = { type = "string", required = true, description = "Action when pattern matches (block, monitor, allow)" },
+        score = { type = "number", required = false, description = "Anomaly score contribution" },
+        tags = { type = "array", required = false, description = "Classification tags" },
+        profile_id = { type = "string", required = false, description = "Environment profile" },
+        created_at = { type = "number", required = false, description = "Creation timestamp" },
+        updated_at = { type = "number", required = false, description = "Last update timestamp" }
+    }
+}
+
+-- wslproxy.waf_policy resource schema
+_M.waf_policy = {
+    type = "wslproxy.waf_policy",
+    version = "1.0.0",
+    description = "WAF policy grouping rules with mode and threshold settings",
+    properties = {
+        id = { type = "string", required = true, description = "Unique WAF policy identifier" },
+        name = { type = "string", required = true, description = "Policy display name" },
+        description = { type = "string", required = false, description = "Policy description" },
+        mode = { type = "string", required = true, description = "Enforcement mode (block or monitor)" },
+        enabled = { type = "boolean", required = false, description = "Whether this policy is active" },
+        waf_rules = { type = "array", required = false, description = "List of WAF rule IDs" },
+        anomaly_threshold = { type = "number", required = false, description = "Score threshold for blocking" },
+        paranoia_level = { type = "number", required = false, description = "Detection sensitivity (1-4)" },
+        body_inspection = { type = "boolean", required = false, description = "Whether to inspect request bodies" },
+        max_body_size = { type = "number", required = false, description = "Max body size to inspect (bytes)" },
+        whitelist = { type = "object", required = false, description = "Whitelisted IPs, paths, user-agents" },
+        profile_id = { type = "string", required = false, description = "Environment profile" },
+        created_at = { type = "number", required = false, description = "Creation timestamp" },
+        updated_at = { type = "number", required = false, description = "Last update timestamp" }
+    }
+}
+
+-- wslproxy.waf_event resource schema
+_M.waf_event = {
+    type = "wslproxy.waf_event",
+    version = "1.0.0",
+    description = "WAF inspection event (blocked or monitored request)",
+    properties = {
+        id = { type = "string", required = true, description = "Event identifier" },
+        timestamp = { type = "number", required = true, description = "Event timestamp (epoch)" },
+        type = { type = "string", required = true, description = "Event type (blocked, monitored, error)" },
+        host = { type = "string", required = false, description = "Request host" },
+        rule_id = { type = "string", required = false, description = "Matching WAF rule ID" },
+        rule_name = { type = "string", required = false, description = "Matching WAF rule name" },
+        category = { type = "string", required = false, description = "Attack category" },
+        severity = { type = "string", required = false, description = "Rule severity" },
+        client_ip = { type = "string", required = false, description = "Client IP address" },
+        uri = { type = "string", required = false, description = "Request URI" },
+        method = { type = "string", required = false, description = "HTTP method" },
+        score = { type = "number", required = false, description = "Anomaly score" },
+        matched_data = { type = "string", required = false, description = "Matched pattern snippet" }
+    }
+}
+
 return _M

--- a/api/mcp/tools.lua
+++ b/api/mcp/tools.lua
@@ -66,6 +66,35 @@ _M.TOOL_REGISTRY = {
             idempotentHint = true,
             openWorldHint = false
         }
+    },
+    {
+        name = "test_waf_rule",
+        description = "Test a WAF rule pattern against sample input. Validates the regex pattern and checks if it matches the provided test string. Read-only, safe for AI agents.",
+        inputSchema = {
+            type = "object",
+            properties = {
+                pattern = {
+                    type = "string",
+                    description = "The regex or string pattern to test"
+                },
+                test_input = {
+                    type = "string",
+                    description = "The sample input string to test against"
+                },
+                pattern_type = {
+                    type = "string",
+                    description = "Pattern type: 'regex' (default) or 'string'"
+                }
+            },
+            required = {"pattern", "test_input"}
+        },
+        annotations = {
+            title = "Test WAF Rule Pattern",
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        }
     }
 }
 
@@ -206,6 +235,74 @@ function _M.reload_config(params)
     }
 end
 
+-- Tool: Test WAF rule pattern (read-only)
+function _M.test_waf_rule(params)
+    local pattern = params.pattern
+    local test_input = params.test_input
+    local pattern_type = params.pattern_type or "regex"
+
+    if not pattern or pattern == "" then
+        return {
+            tool = "test_waf_rule",
+            result = { error = "Pattern is required" },
+            isError = true
+        }
+    end
+    if not test_input then
+        return {
+            tool = "test_waf_rule",
+            result = { error = "Test input is required" },
+            isError = true
+        }
+    end
+
+    local matched = false
+    local match_pos = nil
+    local compile_error = nil
+
+    if pattern_type == "string" then
+        local pos = string.find(test_input, pattern, 1, true)
+        matched = pos ~= nil
+        match_pos = pos
+    else
+        local ok, compiled = pcall(ngx.re.compile, pattern, "ijo")
+        if not ok then
+            return {
+                tool = "test_waf_rule",
+                result = {
+                    valid_pattern = false,
+                    compile_error = tostring(compiled),
+                    pattern = pattern,
+                    pattern_type = pattern_type
+                },
+                isError = true
+            }
+        end
+
+        local from, to, err = ngx.re.find(test_input, pattern, "ijo")
+        if err then
+            compile_error = err
+        end
+        matched = from ~= nil
+        match_pos = from
+    end
+
+    return {
+        tool = "test_waf_rule",
+        result = {
+            valid_pattern = true,
+            matched = matched,
+            match_position = match_pos,
+            pattern = pattern,
+            pattern_type = pattern_type,
+            test_input_length = #test_input,
+            compile_error = compile_error,
+            timestamp = os.date("%Y-%m-%dT%H:%M:%SZ", ngx.time())
+        },
+        isError = false
+    }
+end
+
 -- Execute a tool by name
 function _M.execute(tool_name, params)
     local config = McpConfig.load()
@@ -220,7 +317,8 @@ function _M.execute(tool_name, params)
     local tool_handlers = {
         validate_config = function() return _M.validate_config() end,
         get_error_logs = function() return _M.get_error_logs(params) end,
-        reload_config = function() return _M.reload_config(params) end
+        reload_config = function() return _M.reload_config(params) end,
+        test_waf_rule = function() return _M.test_waf_rule(params) end
     }
 
     local handler = tool_handlers[tool_name]

--- a/api/prometheus_metrics.lua
+++ b/api/prometheus_metrics.lua
@@ -88,6 +88,13 @@ function _M.init()
     package.loaded._metric_cache_evictions = prometheus:counter("nginx_cache_evictions_total", "Number of cache evictions", {"host", "reason"})
     package.loaded._metric_cache_hit_ratio = prometheus:gauge("nginx_cache_hit_ratio", "Cache hit ratio (hits / (hits + misses))", {"host"})
 
+    -- WAF (Web Application Firewall) metrics
+    package.loaded._metric_waf_inspections = prometheus:counter("nginx_waf_inspections_total", "Total WAF inspection count", {"host"})
+    package.loaded._metric_waf_blocked = prometheus:counter("nginx_waf_blocked_total", "Requests blocked by WAF", {"host", "category", "severity"})
+    package.loaded._metric_waf_monitored = prometheus:counter("nginx_waf_monitored_total", "Requests flagged by WAF in monitor mode", {"host", "category", "severity"})
+    package.loaded._metric_waf_errors = prometheus:counter("nginx_waf_errors_total", "WAF engine errors (fail-open events)", {"host", "error_type"})
+    package.loaded._metric_waf_latency = prometheus:histogram("nginx_waf_inspection_duration_seconds", "WAF inspection duration", {"host"}, {0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1})
+
     ngx.log(ngx.NOTICE, "WSL Proxy Prometheus metrics initialized successfully")
     return true
 end
@@ -247,6 +254,27 @@ end
 
 function _M.get_metric_cache_hit_ratio()
     return package.loaded._metric_cache_hit_ratio
+end
+
+-- WAF metrics getters
+function _M.get_metric_waf_inspections()
+    return package.loaded._metric_waf_inspections
+end
+
+function _M.get_metric_waf_blocked()
+    return package.loaded._metric_waf_blocked
+end
+
+function _M.get_metric_waf_monitored()
+    return package.loaded._metric_waf_monitored
+end
+
+function _M.get_metric_waf_errors()
+    return package.loaded._metric_waf_errors
+end
+
+function _M.get_metric_waf_latency()
+    return package.loaded._metric_waf_latency
 end
 
 function _M.is_initialized()

--- a/api/waf_default_rules.lua
+++ b/api/waf_default_rules.lua
@@ -1,0 +1,370 @@
+-- WAF Default Rules Module
+-- Built-in OWASP-inspired detection patterns for common attack vectors
+-- These are used to seed data/waf_rules/{profile}/ via the /api/waf_rules/seed endpoint
+--
+-- Categories: sqli, xss, cmdi, lfi, protocol
+-- Severity: critical, high, medium, low, info
+-- Targets: url, headers, body, args, cookies, user_agent, all
+
+local _M = {}
+
+_M.rules = {
+    -- ========================================================================
+    -- SQL INJECTION (sqli)
+    -- ========================================================================
+    {
+        id = "waf-rule-sqli-001",
+        name = "SQL Injection - UNION SELECT",
+        description = "Detects UNION SELECT SQL injection attempts used to extract data from databases",
+        category = "sqli",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)(?:union\\s+(?:all\\s+)?select)",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "sqli", "a03" }
+    },
+    {
+        id = "waf-rule-sqli-002",
+        name = "SQL Injection - SELECT FROM",
+        description = "Detects SELECT ... FROM SQL query patterns in request parameters",
+        category = "sqli",
+        severity = "high",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)(?:select\\s+.{1,200}?\\s+from\\s+)",
+        pattern_type = "regex",
+        action = "block",
+        score = 8,
+        tags = { "owasp-top10", "sqli", "a03" }
+    },
+    {
+        id = "waf-rule-sqli-003",
+        name = "SQL Injection - INSERT/UPDATE/DELETE",
+        description = "Detects SQL data manipulation statements in request parameters",
+        category = "sqli",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)(?:(?:insert\\s+into|update\\s+.{1,200}?\\s+set|delete\\s+from)\\s+)",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "sqli", "a03" }
+    },
+    {
+        id = "waf-rule-sqli-004",
+        name = "SQL Injection - DROP/ALTER/TRUNCATE",
+        description = "Detects destructive SQL DDL statements (DROP TABLE, ALTER, TRUNCATE)",
+        category = "sqli",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)(?:(?:drop|alter|truncate)\\s+(?:table|database|column|index))",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "sqli", "a03" }
+    },
+    {
+        id = "waf-rule-sqli-005",
+        name = "SQL Injection - Boolean-Based (OR 1=1)",
+        description = "Detects boolean-based SQL injection tautologies (OR 1=1, OR 'a'='a')",
+        category = "sqli",
+        severity = "high",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)(?:\\bor\\b\\s+['\"]?\\d['\"]?\\s*=\\s*['\"]?\\d|\\bor\\b\\s+['\"][^'\"]+['\"]\\s*=\\s*['\"])",
+        pattern_type = "regex",
+        action = "block",
+        score = 8,
+        tags = { "owasp-top10", "sqli", "a03" }
+    },
+    {
+        id = "waf-rule-sqli-006",
+        name = "SQL Injection - Comment Sequences",
+        description = "Detects SQL comment patterns used to terminate injected queries (-- , /*, */)",
+        category = "sqli",
+        severity = "medium",
+        enabled = true,
+        target = "url",
+        pattern = "(?:--\\s*$|;\\s*--|/\\*|\\*/)",
+        pattern_type = "regex",
+        action = "monitor",
+        score = 4,
+        tags = { "owasp-top10", "sqli", "a03" }
+    },
+    {
+        id = "waf-rule-sqli-007",
+        name = "SQL Injection - Time-Based (SLEEP/BENCHMARK)",
+        description = "Detects time-based blind SQL injection using SLEEP() or BENCHMARK() functions",
+        category = "sqli",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)(?:benchmark\\s*\\(|sleep\\s*\\(|waitfor\\s+delay|pg_sleep)",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "sqli", "a03", "blind" }
+    },
+
+    -- ========================================================================
+    -- CROSS-SITE SCRIPTING (xss)
+    -- ========================================================================
+    {
+        id = "waf-rule-xss-001",
+        name = "XSS - Script Tag Injection",
+        description = "Detects <script> tag injection attempts",
+        category = "xss",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)<\\s*script[\\s>]",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "xss", "a07" }
+    },
+    {
+        id = "waf-rule-xss-002",
+        name = "XSS - JavaScript Protocol Handler",
+        description = "Detects javascript: protocol handler injection in URLs or attributes",
+        category = "xss",
+        severity = "high",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)javascript\\s*:",
+        pattern_type = "regex",
+        action = "block",
+        score = 8,
+        tags = { "owasp-top10", "xss", "a07" }
+    },
+    {
+        id = "waf-rule-xss-003",
+        name = "XSS - Event Handler Attributes",
+        description = "Detects HTML event handler injection (onerror, onload, onclick, etc.)",
+        category = "xss",
+        severity = "high",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)\\bon(?:error|load|click|mouseover|focus|blur|submit|change|input|keydown|keyup|mouseout|dblclick)\\s*=",
+        pattern_type = "regex",
+        action = "block",
+        score = 8,
+        tags = { "owasp-top10", "xss", "a07" }
+    },
+    {
+        id = "waf-rule-xss-004",
+        name = "XSS - HTML Tag Injection",
+        description = "Detects injection of HTML tags with src/data attributes (img, svg, iframe, object, embed)",
+        category = "xss",
+        severity = "high",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)<\\s*(?:img|svg|iframe|object|embed|video|audio|link|meta)\\b[^>]*(?:src|data|href|content)\\s*=",
+        pattern_type = "regex",
+        action = "block",
+        score = 8,
+        tags = { "owasp-top10", "xss", "a07" }
+    },
+    {
+        id = "waf-rule-xss-005",
+        name = "XSS - DOM Manipulation",
+        description = "Detects DOM-based XSS via document.cookie, document.location, window.location access",
+        category = "xss",
+        severity = "high",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)(?:document\\.(?:cookie|location|write|domain)|window\\.(?:location|open)|eval\\s*\\()",
+        pattern_type = "regex",
+        action = "block",
+        score = 8,
+        tags = { "owasp-top10", "xss", "a07", "dom" }
+    },
+
+    -- ========================================================================
+    -- COMMAND INJECTION (cmdi)
+    -- ========================================================================
+    {
+        id = "waf-rule-cmdi-001",
+        name = "Command Injection - Semicolon Chaining",
+        description = "Detects OS command injection via semicolon chaining (;cat, ;ls, ;id, etc.)",
+        category = "cmdi",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "(?:;\\s*(?:cat|ls|id|pwd|whoami|uname|wget|curl|nc|netcat|bash|sh|python|perl|ruby|php|chmod|chown)\\b)",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "cmdi", "a03" }
+    },
+    {
+        id = "waf-rule-cmdi-002",
+        name = "Command Injection - Pipe Injection",
+        description = "Detects OS command injection via pipe operator (|cat, |ls, |id, etc.)",
+        category = "cmdi",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "(?:\\|\\s*(?:cat|ls|id|pwd|whoami|uname|wget|curl|nc|netcat|bash|sh|python|perl|ruby|php)\\b)",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "cmdi", "a03" }
+    },
+    {
+        id = "waf-rule-cmdi-003",
+        name = "Command Injection - Backtick Execution",
+        description = "Detects command execution via backtick syntax (`command`)",
+        category = "cmdi",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "`[^`]+`",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "cmdi", "a03" }
+    },
+    {
+        id = "waf-rule-cmdi-004",
+        name = "Command Injection - Subshell Execution",
+        description = "Detects command execution via $() subshell syntax",
+        category = "cmdi",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "\\$\\([^)]+\\)",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "cmdi", "a03" }
+    },
+
+    -- ========================================================================
+    -- LOCAL FILE INCLUSION / PATH TRAVERSAL (lfi)
+    -- ========================================================================
+    {
+        id = "waf-rule-lfi-001",
+        name = "Path Traversal - Directory Traversal Sequences",
+        description = "Detects directory traversal attempts using ../ sequences",
+        category = "lfi",
+        severity = "high",
+        enabled = true,
+        target = "url",
+        pattern = "(?:\\.\\./){2,}",
+        pattern_type = "regex",
+        action = "block",
+        score = 8,
+        tags = { "owasp-top10", "lfi", "a01" }
+    },
+    {
+        id = "waf-rule-lfi-002",
+        name = "Path Traversal - Sensitive File Access",
+        description = "Detects attempts to access sensitive system files (passwd, shadow, hosts)",
+        category = "lfi",
+        severity = "critical",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)(?:etc/(?:passwd|shadow|hosts|group)|proc/self/(?:environ|cmdline|maps))",
+        pattern_type = "regex",
+        action = "block",
+        score = 10,
+        tags = { "owasp-top10", "lfi", "a01" }
+    },
+
+    -- ========================================================================
+    -- PROTOCOL VIOLATIONS (protocol)
+    -- ========================================================================
+    {
+        id = "waf-rule-proto-001",
+        name = "Protocol Violation - Null Byte Injection",
+        description = "Detects null byte injection (%00) used to bypass file extension checks",
+        category = "protocol",
+        severity = "high",
+        enabled = true,
+        target = "url",
+        pattern = "%00",
+        pattern_type = "string",
+        action = "block",
+        score = 8,
+        tags = { "protocol", "bypass" }
+    },
+    {
+        id = "waf-rule-proto-002",
+        name = "Protocol Violation - CRLF Injection",
+        description = "Detects CRLF injection (%0d%0a) used for HTTP response splitting",
+        category = "protocol",
+        severity = "high",
+        enabled = true,
+        target = "url",
+        pattern = "(?i)%0d%0a",
+        pattern_type = "string",
+        action = "block",
+        score = 8,
+        tags = { "protocol", "response-splitting" }
+    }
+}
+
+-- Return seed rules as a flat array
+function _M.get_rules()
+    return _M.rules
+end
+
+-- Get rules for writing to disk as JSON files
+function _M.get_seed_data(profile_id)
+    profile_id = profile_id or "prod"
+    local seed = {}
+    local now = os.time(os.date("!*t"))
+    for _, rule in ipairs(_M.rules) do
+        local r = {}
+        for k, v in pairs(rule) do
+            r[k] = v
+        end
+        r.profile_id = profile_id
+        r.created_at = now
+        r.updated_at = now
+        table.insert(seed, r)
+    end
+    return seed
+end
+
+-- Get default policy referencing all seed rules
+function _M.get_default_policy(profile_id)
+    profile_id = profile_id or "prod"
+    local rule_ids = {}
+    for _, rule in ipairs(_M.rules) do
+        table.insert(rule_ids, rule.id)
+    end
+    local now = os.time(os.date("!*t"))
+    return {
+        id = "waf-policy-default",
+        name = "Default WAF Policy",
+        description = "Standard WAF protection with OWASP-inspired rules. Starts in monitor mode for safe rollout.",
+        profile_id = profile_id,
+        enabled = true,
+        mode = "monitor",
+        waf_rules = rule_ids,
+        paranoia_level = 1,
+        anomaly_threshold = 5,
+        body_inspection = true,
+        max_body_size = 1048576,
+        blocked_response = {
+            status_code = 403,
+            content_type = "text/html"
+        },
+        whitelist = {
+            ips = { "127.0.0.1" },
+            paths = { "/health", "/ping", "/metrics", "/.well-known/acme-challenge/" },
+            user_agents = {}
+        },
+        created_at = now,
+        updated_at = now
+    }
+end
+
+return _M

--- a/api/waf_engine.lua
+++ b/api/waf_engine.lua
@@ -1,0 +1,513 @@
+-- WAF Engine Module for WSLProxy
+-- Inspects HTTP requests for malicious patterns (SQLi, XSS, Command Injection)
+-- Called from gateway_ack.lua after server config is loaded
+-- Fail-open: if WAF engine errors, request continues normally
+--
+-- Usage: local waf_result = WafEngine.inspect(server_config, profile_id)
+--        if waf_result and waf_result.action == "block" then
+--            WafEngine.block_request(policy, waf_result)
+--        end
+
+local _M = {}
+
+local cjson = Cjson or require("cjson")
+local configPath = os.getenv("NGINX_CONFIG_DIR") or "/opt/nginx/"
+if configPath:sub(-1) ~= "/" then
+    configPath = configPath .. "/"
+end
+
+-- Per-worker caches (persist across requests when lua_code_cache is ON)
+local compiled_patterns = {}
+local policy_cache = {}
+local rule_cache = {}
+local CACHE_TTL = 30 -- seconds
+
+-- ============================================================================
+-- PATTERN COMPILATION & MATCHING
+-- ============================================================================
+
+-- Get or compile a PCRE regex pattern (JIT compiled, cached per-worker)
+local function get_compiled_pattern(pattern_str)
+    local cached = compiled_patterns[pattern_str]
+    if cached then
+        return cached
+    end
+    local compiled, err = ngx.re.compile(pattern_str, "jois")
+    if compiled then
+        compiled_patterns[pattern_str] = compiled
+    else
+        ngx.log(ngx.WARN, "WAF: Failed to compile pattern: ", err, " pattern=", pattern_str)
+    end
+    return compiled, err
+end
+
+-- Inspect a single string value against a rule pattern
+local function inspect_single(value, rule)
+    if not value or value == "" then
+        return false
+    end
+    if rule.pattern_type == "string" then
+        return ngx.re.find(value, rule.pattern, "joi") ~= nil
+    end
+    -- Default: regex matching
+    local compiled, compile_err = get_compiled_pattern(rule.pattern)
+    if not compiled then
+        return false
+    end
+    local from = ngx.re.find(value, compiled, "jois")
+    return from ~= nil
+end
+
+-- Inspect a target (string or table of key-value pairs) against a rule
+local function inspect_target(target_value, rule)
+    if not target_value then
+        return false, nil
+    end
+    if type(target_value) == "table" then
+        for k, v in pairs(target_value) do
+            if type(v) == "string" and inspect_single(v, rule) then
+                return true, k
+            elseif type(v) == "table" then
+                -- Handle multi-value headers/args
+                for _, sv in ipairs(v) do
+                    if type(sv) == "string" and inspect_single(sv, rule) then
+                        return true, k
+                    end
+                end
+            end
+        end
+        return false, nil
+    end
+    return inspect_single(tostring(target_value), rule), nil
+end
+
+-- ============================================================================
+-- DATA LOADING (disk-based with TTL cache)
+-- ============================================================================
+
+-- Read and parse a JSON file
+local function read_json_file(path)
+    local file, err = io.open(path, "rb")
+    if not file then
+        return nil, err
+    end
+    local content = file:read("*a")
+    file:close()
+    if not content or content == "" then
+        return nil, "empty file"
+    end
+    local ok, data = pcall(cjson.decode, content)
+    if not ok then
+        return nil, "JSON decode error: " .. tostring(data)
+    end
+    return data
+end
+
+-- Load WAF policy for a server (cached with TTL)
+function _M.load_policy(server_config, profile_id)
+    local policy_id = server_config.waf_policy_id
+    if not policy_id or policy_id == "" then
+        return nil
+    end
+
+    local cache_key = profile_id .. ":" .. policy_id
+    local cached = policy_cache[cache_key]
+    if cached and cached.expires > ngx.time() then
+        return cached.data
+    end
+
+    local path = configPath .. "data/waf_policies/" .. profile_id .. "/" .. policy_id .. ".json"
+    local data, err = read_json_file(path)
+    if not data then
+        ngx.log(ngx.WARN, "WAF: Failed to load policy ", policy_id, ": ", err)
+        return nil
+    end
+
+    policy_cache[cache_key] = { data = data, expires = ngx.time() + CACHE_TTL }
+    return data
+end
+
+-- Load WAF rules referenced by a policy (cached with TTL)
+function _M.load_rules(policy, profile_id)
+    if not policy or not policy.waf_rules or #policy.waf_rules == 0 then
+        return {}
+    end
+
+    local rules = {}
+    for _, rule_id in ipairs(policy.waf_rules) do
+        local cache_key = profile_id .. ":" .. rule_id
+        local cached = rule_cache[cache_key]
+        if cached and cached.expires > ngx.time() then
+            table.insert(rules, cached.data)
+        else
+            local path = configPath .. "data/waf_rules/" .. profile_id .. "/" .. rule_id .. ".json"
+            local data, err = read_json_file(path)
+            if data then
+                rule_cache[cache_key] = { data = data, expires = ngx.time() + CACHE_TTL }
+                table.insert(rules, data)
+            else
+                ngx.log(ngx.WARN, "WAF: Failed to load rule ", rule_id, ": ", err)
+            end
+        end
+    end
+
+    return rules
+end
+
+-- ============================================================================
+-- REQUEST DATA EXTRACTION
+-- ============================================================================
+
+-- Extract inspection targets from the current request
+local function get_request_data()
+    return {
+        url = ngx.var.request_uri or "",
+        method = ngx.req.get_method() or "",
+        headers = ngx.req.get_headers(100) or {},
+        args = ngx.req.get_uri_args(100) or {},
+        cookies = ngx.var.http_cookie or "",
+        user_agent = ngx.var.http_user_agent or "",
+        body = nil -- loaded lazily
+    }
+end
+
+-- Load request body if body inspection is enabled (respects max size)
+local function load_body(max_size)
+    max_size = max_size or 1048576 -- 1MB default
+    local ok, err = pcall(ngx.req.read_body)
+    if not ok then
+        ngx.log(ngx.WARN, "WAF: Failed to read body: ", err)
+        return nil
+    end
+    local body = ngx.req.get_body_data()
+    if not body then
+        -- Body too large, may be written to temp file
+        local file = ngx.req.get_body_file()
+        if file then
+            local f = io.open(file, "rb")
+            if f then
+                body = f:read(max_size)
+                f:close()
+            end
+        end
+    end
+    if body and #body > max_size then
+        body = body:sub(1, max_size)
+    end
+    return body
+end
+
+-- Resolve which request parts to inspect based on the rule's target field
+local function resolve_targets(target, request_data)
+    local targets = {}
+    if target == "all" then
+        targets.url = request_data.url
+        targets.headers = request_data.headers
+        targets.body = request_data.body
+        targets.args = request_data.args
+        targets.cookies = request_data.cookies
+        targets.user_agent = request_data.user_agent
+    elseif target == "url" then
+        targets.url = request_data.url
+        targets.args = request_data.args
+    elseif target == "headers" then
+        targets.headers = request_data.headers
+    elseif target == "body" then
+        targets.body = request_data.body
+    elseif target == "args" then
+        targets.args = request_data.args
+    elseif target == "cookies" then
+        targets.cookies = request_data.cookies
+    elseif target == "user_agent" then
+        targets.user_agent = request_data.user_agent
+    else
+        targets.url = request_data.url
+    end
+    return targets
+end
+
+-- ============================================================================
+-- WHITELIST CHECK
+-- ============================================================================
+
+-- Check if the current request should bypass WAF inspection
+local function is_whitelisted(policy, request_data)
+    local wl = policy.whitelist
+    if not wl then
+        return false
+    end
+
+    -- Path whitelist
+    if wl.paths and type(wl.paths) == "table" then
+        local uri = ngx.var.uri or ""
+        for _, path in ipairs(wl.paths) do
+            if uri == path or uri:sub(1, #path) == path then
+                return true
+            end
+        end
+    end
+
+    -- IP whitelist (simple prefix/exact match)
+    if wl.ips and type(wl.ips) == "table" then
+        local remote_addr = ngx.var.remote_addr or ""
+        for _, ip_pattern in ipairs(wl.ips) do
+            if remote_addr == ip_pattern then
+                return true
+            end
+            -- CIDR-like prefix match (e.g. "10.0.0.0/8" → check "10.")
+            local prefix = ip_pattern:match("^([%d%.]+)/")
+            if prefix then
+                local parts = {}
+                for part in prefix:gmatch("(%d+)") do
+                    table.insert(parts, part)
+                end
+                local mask = tonumber(ip_pattern:match("/(%d+)$")) or 32
+                local check_prefix = ""
+                if mask <= 8 then
+                    check_prefix = parts[1] .. "."
+                elseif mask <= 16 then
+                    check_prefix = parts[1] .. "." .. (parts[2] or "0") .. "."
+                elseif mask <= 24 then
+                    check_prefix = parts[1] .. "." .. (parts[2] or "0") .. "." .. (parts[3] or "0") .. "."
+                end
+                if check_prefix ~= "" and remote_addr:sub(1, #check_prefix) == check_prefix then
+                    return true
+                end
+            end
+        end
+    end
+
+    -- User-agent whitelist
+    if wl.user_agents and type(wl.user_agents) == "table" then
+        local ua = request_data.user_agent or ""
+        for _, ua_pattern in ipairs(wl.user_agents) do
+            if ua:find(ua_pattern, 1, true) then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+-- ============================================================================
+-- EVENT RECORDING (Prometheus + shared dict)
+-- ============================================================================
+
+-- Record a WAF event for metrics and the events API
+function _M.record_event(event_type, rule, server_config, request_data)
+    -- Prometheus metrics
+    local metrics_ok, metrics = pcall(require, "prometheus_metrics")
+    if metrics_ok and metrics.is_initialized() then
+        local host = (server_config and server_config.server_name) or ngx.var.host or "unknown"
+        local category = (rule and rule.category) or "unknown"
+        local severity = (rule and rule.severity) or "unknown"
+
+        if event_type == "blocked" or event_type == "blocked_anomaly" then
+            local m = metrics.get_metric_waf_blocked()
+            if m then m:inc(1, { host, category, severity }) end
+        else
+            local m = metrics.get_metric_waf_monitored()
+            if m then m:inc(1, { host, category, severity }) end
+        end
+
+        local total = metrics.get_metric_waf_inspections()
+        if total then total:inc(1, { host }) end
+    end
+
+    -- Store event in shared dict for recent events API
+    local waf_events = ngx.shared.waf_events
+    if waf_events then
+        local event = cjson.encode({
+            timestamp = ngx.time(),
+            type = event_type,
+            host = (server_config and server_config.server_name) or ngx.var.host or "unknown",
+            rule_id = (rule and rule.id) or "anomaly",
+            rule_name = (rule and rule.name) or "Anomaly Score Exceeded",
+            category = (rule and rule.category) or "anomaly",
+            severity = (rule and rule.severity) or "high",
+            client_ip = ngx.var.remote_addr or "",
+            uri = ngx.var.request_uri or "",
+            method = ngx.req.get_method() or ""
+        })
+        local key = ngx.time() .. ":" .. math.random(100000)
+        waf_events:set(key, event, 3600) -- 1 hour TTL
+    end
+end
+
+-- ============================================================================
+-- MAIN INSPECTION
+-- ============================================================================
+
+-- Internal implementation (may throw errors)
+function _M._inspect_impl(server_config, profile_id)
+    if not server_config.waf_enabled or not server_config.waf_policy_id then
+        return nil
+    end
+
+    local policy = _M.load_policy(server_config, profile_id)
+    if not policy or not policy.enabled then
+        return nil
+    end
+
+    local request_data = get_request_data()
+
+    if is_whitelisted(policy, request_data) then
+        return nil
+    end
+
+    local rules = _M.load_rules(policy, profile_id)
+    if not rules or #rules == 0 then
+        return nil
+    end
+
+    -- Load body if enabled in policy
+    if policy.body_inspection ~= false then
+        request_data.body = load_body(policy.max_body_size or 1048576)
+    end
+
+    local total_score = 0
+    local matched_rules = {}
+
+    for _, rule in ipairs(rules) do
+        if rule.enabled then
+            local targets = resolve_targets(rule.target, request_data)
+            for target_name, target_value in pairs(targets) do
+                local matched, detail = inspect_target(target_value, rule)
+                if matched then
+                    total_score = total_score + (rule.score or 0)
+                    table.insert(matched_rules, {
+                        rule_id = rule.id,
+                        rule_name = rule.name,
+                        category = rule.category,
+                        severity = rule.severity,
+                        action = rule.action,
+                        target = target_name,
+                        detail = detail
+                    })
+
+                    -- Immediate block for "block" action rules in "block" mode
+                    if rule.action == "block" and policy.mode == "block" then
+                        _M.record_event("blocked", rule, server_config, request_data)
+                        return {
+                            action = "block",
+                            rule = rule,
+                            matched_rules = matched_rules,
+                            score = total_score
+                        }
+                    end
+                    break -- one match per rule is enough, move to next rule
+                end
+            end
+        end
+    end
+
+    -- Anomaly score threshold check
+    if #matched_rules > 0 and total_score >= (policy.anomaly_threshold or 5) and policy.mode == "block" then
+        _M.record_event("blocked_anomaly", matched_rules[1], server_config, request_data)
+        return {
+            action = "block",
+            matched_rules = matched_rules,
+            score = total_score
+        }
+    end
+
+    -- Monitor mode: log but don't block
+    if #matched_rules > 0 then
+        for _, mr in ipairs(matched_rules) do
+            _M.record_event("monitored", {
+                id = mr.rule_id,
+                name = mr.rule_name,
+                category = mr.category,
+                severity = mr.severity
+            }, server_config, request_data)
+        end
+    end
+
+    return nil -- allow request
+end
+
+-- Main entry point: inspect request (fail-open wrapper)
+function _M.inspect(server_config, profile_id)
+    local start_time = ngx.now()
+    local ok, result = pcall(_M._inspect_impl, server_config, profile_id)
+    local duration = ngx.now() - start_time
+
+    -- Record inspection latency
+    local metrics_ok, metrics = pcall(require, "prometheus_metrics")
+    if metrics_ok and metrics.is_initialized() then
+        local host = (server_config and server_config.server_name) or ngx.var.host or "unknown"
+        local latency = metrics.get_metric_waf_latency()
+        if latency then latency:observe(duration, { host }) end
+    end
+
+    if not ok then
+        ngx.log(ngx.ERR, "WAF: Engine error (fail-open): ", tostring(result))
+        -- Record error metric
+        if metrics_ok and metrics.is_initialized() then
+            local host = (server_config and server_config.server_name) or ngx.var.host or "unknown"
+            local err_metric = metrics.get_metric_waf_errors()
+            if err_metric then err_metric:inc(1, { host, "engine_error" }) end
+        end
+        return nil -- fail-open: allow request
+    end
+
+    return result
+end
+
+-- ============================================================================
+-- BLOCK PAGE
+-- ============================================================================
+
+_M.DEFAULT_BLOCK_PAGE = [[<!DOCTYPE html>
+<html>
+<head><title>403 Forbidden - Request Blocked</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; text-align: center; padding: 50px; background: #f8f9fa; color: #333; }
+  .container { max-width: 600px; margin: 0 auto; background: #fff; border-radius: 12px; padding: 48px; box-shadow: 0 4px 24px rgba(0,0,0,.08); }
+  h1 { color: #dc3545; font-size: 28px; margin-bottom: 16px; }
+  p { color: #6c757d; font-size: 16px; line-height: 1.6; }
+  .shield { font-size: 64px; margin-bottom: 16px; }
+  .ref { font-size: 12px; color: #adb5bd; margin-top: 32px; border-top: 1px solid #e9ecef; padding-top: 16px; }
+</style>
+</head>
+<body>
+<div class="container">
+  <div class="shield">&#128737;</div>
+  <h1>403 Forbidden</h1>
+  <p>Your request has been blocked by the Web Application Firewall.</p>
+  <p>If you believe this is an error, please contact the site administrator.</p>
+  <div class="ref">Protected by WSLProxy WAF</div>
+</div>
+</body>
+</html>]]
+
+-- Serve custom 403 block page
+function _M.block_request(policy, matched_result)
+    local response = policy and policy.blocked_response or {}
+    local status_code = response.status_code or 403
+    local content_type = response.content_type or "text/html"
+    local body_b64 = response.body_base64
+
+    ngx.status = status_code
+    ngx.header["Content-Type"] = content_type
+    ngx.header["X-WAF-Block"] = "true"
+    if matched_result and matched_result.rule then
+        ngx.header["X-WAF-Rule"] = matched_result.rule.id or "unknown"
+    end
+
+    if body_b64 then
+        local decode_ok, decoded = pcall(Base64.decode, body_b64)
+        if decode_ok and decoded then
+            ngx.say(decoded)
+        else
+            ngx.say(_M.DEFAULT_BLOCK_PAGE)
+        end
+    else
+        ngx.say(_M.DEFAULT_BLOCK_PAGE)
+    end
+
+    return ngx.exit(status_code)
+end
+
+return _M

--- a/data/sample-settings.json
+++ b/data/sample-settings.json
@@ -54,5 +54,11 @@
     "api_key_header": "X-MCP-API-Key",
     "rate_limit": 100,
     "redact_secrets": true
+  },
+  "waf": {
+    "enabled": true,
+    "default_policy": "waf-policy-default",
+    "body_inspection": true,
+    "max_body_size": 1048576
   }
 }

--- a/data/waf_policies/prod/waf-policy-default.json
+++ b/data/waf_policies/prod/waf-policy-default.json
@@ -1,0 +1,45 @@
+{
+  "id": "waf-policy-default",
+  "name": "Default WAF Policy",
+  "description": "Standard WAF protection with OWASP-inspired rules. Starts in monitor mode for safe rollout.",
+  "profile_id": "prod",
+  "enabled": true,
+  "mode": "monitor",
+  "waf_rules": [
+    "waf-rule-sqli-001",
+    "waf-rule-sqli-002",
+    "waf-rule-sqli-003",
+    "waf-rule-sqli-004",
+    "waf-rule-sqli-005",
+    "waf-rule-sqli-006",
+    "waf-rule-sqli-007",
+    "waf-rule-xss-001",
+    "waf-rule-xss-002",
+    "waf-rule-xss-003",
+    "waf-rule-xss-004",
+    "waf-rule-xss-005",
+    "waf-rule-cmdi-001",
+    "waf-rule-cmdi-002",
+    "waf-rule-cmdi-003",
+    "waf-rule-cmdi-004",
+    "waf-rule-lfi-001",
+    "waf-rule-lfi-002",
+    "waf-rule-proto-001",
+    "waf-rule-proto-002"
+  ],
+  "paranoia_level": 1,
+  "anomaly_threshold": 5,
+  "body_inspection": true,
+  "max_body_size": 1048576,
+  "blocked_response": {
+    "status_code": 403,
+    "content_type": "text/html"
+  },
+  "whitelist": {
+    "ips": ["127.0.0.1"],
+    "paths": ["/health", "/ping", "/metrics", "/.well-known/acme-challenge/"],
+    "user_agents": []
+  },
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-cmdi-001.json
+++ b/data/waf_rules/prod/waf-rule-cmdi-001.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-cmdi-001",
+  "name": "Command Injection - Semicolon Chaining",
+  "description": "Detects OS command injection attempts using semicolon chaining to execute arbitrary system commands after a legitimate command.",
+  "category": "cmdi",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?:;\\s*(?:cat|ls|id|pwd|whoami|uname|wget|curl|nc|netcat|bash|sh|python|perl|ruby|php|chmod|chown)\\b)",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "cmdi", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-cmdi-002.json
+++ b/data/waf_rules/prod/waf-rule-cmdi-002.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-cmdi-002",
+  "name": "Command Injection - Pipe Injection",
+  "description": "Detects OS command injection attempts using pipe operators to redirect output to arbitrary system commands.",
+  "category": "cmdi",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?:\\|\\s*(?:cat|ls|id|pwd|whoami|uname|wget|curl|nc|netcat|bash|sh|python|perl|ruby|php)\\b)",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "cmdi", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-cmdi-003.json
+++ b/data/waf_rules/prod/waf-rule-cmdi-003.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-cmdi-003",
+  "name": "Command Injection - Backtick Execution",
+  "description": "Detects OS command injection attempts using backtick syntax to execute commands within another command context.",
+  "category": "cmdi",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "`[^`]+`",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "cmdi", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-cmdi-004.json
+++ b/data/waf_rules/prod/waf-rule-cmdi-004.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-cmdi-004",
+  "name": "Command Injection - Subshell Execution",
+  "description": "Detects OS command injection attempts using $() subshell syntax to execute commands within another command context.",
+  "category": "cmdi",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "\\$\\([^)]+\\)",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "cmdi", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-lfi-001.json
+++ b/data/waf_rules/prod/waf-rule-lfi-001.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-lfi-001",
+  "name": "Path Traversal - Directory Traversal",
+  "description": "Detects path traversal attempts using repeated ../ sequences to navigate outside the intended directory structure.",
+  "category": "lfi",
+  "severity": "high",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?:\\.\\./){2,}",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 8,
+  "tags": ["owasp-top10", "lfi", "a01"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-lfi-002.json
+++ b/data/waf_rules/prod/waf-rule-lfi-002.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-lfi-002",
+  "name": "Path Traversal - Sensitive File Access",
+  "description": "Detects attempts to access sensitive system files such as /etc/passwd, /etc/shadow, /proc/self/environ, and other critical OS files.",
+  "category": "lfi",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)(?:etc/(?:passwd|shadow|hosts|group)|proc/self/(?:environ|cmdline|maps))",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "lfi", "a01"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-proto-001.json
+++ b/data/waf_rules/prod/waf-rule-proto-001.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-proto-001",
+  "name": "Protocol Violation - Null Byte Injection",
+  "description": "Detects null byte injection attempts (%00) used to bypass file extension checks and terminate strings prematurely.",
+  "category": "protocol",
+  "severity": "high",
+  "enabled": true,
+  "target": "url",
+  "pattern": "%00",
+  "pattern_type": "string",
+  "action": "block",
+  "score": 8,
+  "tags": ["protocol", "bypass"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-proto-002.json
+++ b/data/waf_rules/prod/waf-rule-proto-002.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-proto-002",
+  "name": "Protocol Violation - CRLF Injection",
+  "description": "Detects CRLF injection attempts (%0d%0a) used for HTTP response splitting and header injection attacks.",
+  "category": "protocol",
+  "severity": "high",
+  "enabled": true,
+  "target": "url",
+  "pattern": "%0d%0a",
+  "pattern_type": "string",
+  "action": "block",
+  "score": 8,
+  "tags": ["protocol", "response-splitting"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-sqli-001.json
+++ b/data/waf_rules/prod/waf-rule-sqli-001.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-sqli-001",
+  "name": "SQL Injection - UNION SELECT",
+  "description": "Detects SQL injection attempts using UNION SELECT statements to extract data from additional database tables.",
+  "category": "sqli",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)(?:union\\s+(?:all\\s+)?select)",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "sqli", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-sqli-002.json
+++ b/data/waf_rules/prod/waf-rule-sqli-002.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-sqli-002",
+  "name": "SQL Injection - SELECT FROM",
+  "description": "Detects SQL injection attempts using SELECT FROM statements to query database tables.",
+  "category": "sqli",
+  "severity": "high",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)(?:select\\s+.{1,200}?\\s+from\\s+)",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 8,
+  "tags": ["owasp-top10", "sqli", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-sqli-003.json
+++ b/data/waf_rules/prod/waf-rule-sqli-003.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-sqli-003",
+  "name": "SQL Injection - INSERT/UPDATE/DELETE",
+  "description": "Detects SQL injection attempts using INSERT INTO, UPDATE SET, or DELETE FROM statements to modify database records.",
+  "category": "sqli",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)(?:(?:insert\\s+into|update\\s+.{1,200}?\\s+set|delete\\s+from)\\s+)",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "sqli", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-sqli-004.json
+++ b/data/waf_rules/prod/waf-rule-sqli-004.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-sqli-004",
+  "name": "SQL Injection - DROP/ALTER/TRUNCATE",
+  "description": "Detects SQL injection attempts using DDL statements (DROP, ALTER, TRUNCATE) to destroy or modify database schema.",
+  "category": "sqli",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)(?:(?:drop|alter|truncate)\\s+(?:table|database|column|index))",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "sqli", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-sqli-005.json
+++ b/data/waf_rules/prod/waf-rule-sqli-005.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-sqli-005",
+  "name": "SQL Injection - Boolean-Based (OR 1=1)",
+  "description": "Detects boolean-based SQL injection attempts using tautologies like OR 1=1 to bypass authentication or extract data.",
+  "category": "sqli",
+  "severity": "high",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)(?:\\bor\\b\\s+['\"]?\\d['\"]?\\s*=\\s*['\"]?\\d|\\bor\\b\\s+['\"][^'\"]+['\"]\\s*=\\s*['\"])",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 8,
+  "tags": ["owasp-top10", "sqli", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-sqli-006.json
+++ b/data/waf_rules/prod/waf-rule-sqli-006.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-sqli-006",
+  "name": "SQL Injection - Comment Sequences",
+  "description": "Detects SQL comment sequences (--,  /* */) commonly used to terminate or obfuscate injected SQL statements.",
+  "category": "sqli",
+  "severity": "medium",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?:--\\s*$|;\\s*--|/\\*|\\*/)",
+  "pattern_type": "regex",
+  "action": "monitor",
+  "score": 4,
+  "tags": ["owasp-top10", "sqli", "a03"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-sqli-007.json
+++ b/data/waf_rules/prod/waf-rule-sqli-007.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-sqli-007",
+  "name": "SQL Injection - Time-Based (SLEEP/BENCHMARK)",
+  "description": "Detects time-based blind SQL injection attempts using SLEEP, BENCHMARK, WAITFOR DELAY, or pg_sleep functions.",
+  "category": "sqli",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)(?:benchmark\\s*\\(|sleep\\s*\\(|waitfor\\s+delay|pg_sleep)",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "sqli", "a03", "blind"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-xss-001.json
+++ b/data/waf_rules/prod/waf-rule-xss-001.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-xss-001",
+  "name": "XSS - Script Tag Injection",
+  "description": "Detects cross-site scripting attempts using script tag injection to execute arbitrary JavaScript in the browser.",
+  "category": "xss",
+  "severity": "critical",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)<\\s*script[\\s>]",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 10,
+  "tags": ["owasp-top10", "xss", "a07"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-xss-002.json
+++ b/data/waf_rules/prod/waf-rule-xss-002.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-xss-002",
+  "name": "XSS - JavaScript Protocol Handler",
+  "description": "Detects cross-site scripting attempts using the javascript: protocol handler in URLs or attributes.",
+  "category": "xss",
+  "severity": "high",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)javascript\\s*:",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 8,
+  "tags": ["owasp-top10", "xss", "a07"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-xss-003.json
+++ b/data/waf_rules/prod/waf-rule-xss-003.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-xss-003",
+  "name": "XSS - Event Handler Attributes",
+  "description": "Detects cross-site scripting attempts using HTML event handler attributes (onerror, onload, onclick, etc.) to execute JavaScript.",
+  "category": "xss",
+  "severity": "high",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)\\bon(?:error|load|click|mouseover|focus|blur|submit|change|input|keydown|keyup|mouseout|dblclick)\\s*=",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 8,
+  "tags": ["owasp-top10", "xss", "a07"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-xss-004.json
+++ b/data/waf_rules/prod/waf-rule-xss-004.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-xss-004",
+  "name": "XSS - HTML Tag Injection",
+  "description": "Detects cross-site scripting attempts using HTML tags (img, svg, iframe, object, embed, etc.) with source attributes to load malicious content.",
+  "category": "xss",
+  "severity": "high",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)<\\s*(?:img|svg|iframe|object|embed|video|audio|link|meta)\\b[^>]*(?:src|data|href|content)\\s*=",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 8,
+  "tags": ["owasp-top10", "xss", "a07"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/data/waf_rules/prod/waf-rule-xss-005.json
+++ b/data/waf_rules/prod/waf-rule-xss-005.json
@@ -1,0 +1,17 @@
+{
+  "id": "waf-rule-xss-005",
+  "name": "XSS - DOM Manipulation",
+  "description": "Detects cross-site scripting attempts using DOM manipulation methods (document.cookie, document.write, window.location, eval) to access or modify page content.",
+  "category": "xss",
+  "severity": "high",
+  "enabled": true,
+  "target": "url",
+  "pattern": "(?i)(?:document\\.(?:cookie|location|write|domain)|window\\.(?:location|open)|eval\\s*\\()",
+  "pattern_type": "regex",
+  "action": "block",
+  "score": 8,
+  "tags": ["owasp-top10", "xss", "a07", "dom"],
+  "profile_id": "prod",
+  "created_at": 1740000000,
+  "updated_at": 1740000000
+}

--- a/devops/ansible/roles/wslproxy/templates/fix-permissions.sh.j2
+++ b/devops/ansible/roles/wslproxy/templates/fix-permissions.sh.j2
@@ -66,6 +66,15 @@ touch /opt/nginx/data/upstreams/prod/upstreams.conf \
     && chmod 664 /opt/nginx/data/upstreams/prod/upstreams.conf \
     && chown www-data:root /opt/nginx/data/upstreams/prod/upstreams.conf
 
+# Create WAF rules and policies directories
+mkdir -p /opt/nginx/data/waf_rules/prod/ \
+    && chmod 775 -R /opt/nginx/data/waf_rules/ \
+    && chown -R www-data:root /opt/nginx/data/waf_rules/
+
+mkdir -p /opt/nginx/data/waf_policies/prod/ \
+    && chmod 775 -R /opt/nginx/data/waf_policies/ \
+    && chown -R www-data:root /opt/nginx/data/waf_policies/
+
 mkdir -p /opt/nginx/prod_cache/
 chmod 775 -R /opt/nginx/prod_cache/
 chown www-data:root -R /opt/nginx/prod_cache/

--- a/devops/ansible/roles/wslproxy/templates/nginx.conf.j2
+++ b/devops/ansible/roles/wslproxy/templates/nginx.conf.j2
@@ -92,6 +92,9 @@ http {
     # Traffic stats for dashboard (stores hourly request/response counts)
     lua_shared_dict traffic_stats 5m;
 
+    # WAF event log storage (stores recent WAF events for dashboard and API)
+    lua_shared_dict waf_events 10m;
+
     geo $limit {
         default 1;
         10.0.0.0/8 0;

--- a/openresty-admin/src/App.jsx
+++ b/openresty-admin/src/App.jsx
@@ -25,6 +25,9 @@ import Instances from "./Instances";
 import Rules from "./Rules";
 import Settings from "./Settings";
 import Upstreams from "./Upstreams";
+import WafRules from "./WafRules";
+import WafPolicies from "./WafPolicies";
+import WafEvents from "./WafEvents";
 
 import UserIcon from "@mui/icons-material/GroupRounded";
 import SessionIcon from "@mui/icons-material/HistoryToggleOffRounded";
@@ -34,6 +37,9 @@ import ProfileIcon from "@mui/icons-material/RecentActorsRounded";
 import SecretIcon from "@mui/icons-material/KeyRounded";
 import InstanceIcon from "@mui/icons-material/ViewInArRounded";
 import UpstreamIcon from "@mui/icons-material/AccountTree";
+import WafRuleIcon from "@mui/icons-material/ShieldRounded";
+import WafPolicyIcon from "@mui/icons-material/VerifiedUserRounded";
+import WafEventIcon from "@mui/icons-material/NotificationsActiveRounded";
 
 import { Puff } from "react-loader-spinner";
 import CheckModal from "./component/CheckModal";
@@ -183,6 +189,9 @@ const AppContent = () => {
         <Resource name="profiles" {...Profiles} icon={ProfileIcon} />
         <Resource name="secrets" {...Secrets} icon={SecretIcon} />
         <Resource name="instances" {...Instances} icon={InstanceIcon} />
+        <Resource name="waf_rules" {...WafRules} icon={WafRuleIcon} />
+        <Resource name="waf_policies" {...WafPolicies} icon={WafPolicyIcon} />
+        <Resource name="waf_events" {...WafEvents} icon={WafEventIcon} />
         <CustomRoutes>
           <Route path="/password/reset" element={<ResetForm />} />
           <Route path="/instance-info" element={<InstanceInfo />} />

--- a/openresty-admin/src/Dashboard/Dashboard.jsx
+++ b/openresty-admin/src/Dashboard/Dashboard.jsx
@@ -47,6 +47,10 @@ import LanguageIcon from "@mui/icons-material/LanguageRounded";
 import DataUsageIcon from "@mui/icons-material/DataUsageRounded";
 import MemoryIcon from "@mui/icons-material/MemoryRounded";
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFileRounded";
+import ShieldIcon from "@mui/icons-material/ShieldRounded";
+import VerifiedUserIcon from "@mui/icons-material/VerifiedUserRounded";
+import NotificationsActiveIcon from "@mui/icons-material/NotificationsActiveRounded";
+import BlockIcon from "@mui/icons-material/BlockRounded";
 
 import StorageModal from "./StorageModal";
 import Logs from "../component/Logs";
@@ -460,6 +464,14 @@ const Dashboard = () => {
     top_urls: [],
   });
 
+  // WAF stats state
+  const [wafStats, setWafStats] = React.useState({
+    totalRules: 0,
+    totalPolicies: 0,
+    recentEvents: 0,
+    blockedEvents: 0,
+  });
+
   const fetchErrorLogs = React.useCallback(() => {
     const logs = dataProvider.getLogs("openresty/error_logs");
     logs.then((log) => {
@@ -637,6 +649,39 @@ const Dashboard = () => {
           rules: rules?.total || 0,
           users: users?.total || 0,
           profiles: profiles?.total || 0,
+        });
+      })
+      .catch(() => {});
+
+    // Fetch WAF stats
+    Promise.all([
+      dataProvider.getList("waf_rules", {
+        pagination: { page: 1, perPage: 1 },
+        sort: { field: "id", order: "ASC" },
+        filter: {},
+      }),
+      dataProvider.getList("waf_policies", {
+        pagination: { page: 1, perPage: 1 },
+        sort: { field: "id", order: "ASC" },
+        filter: {},
+      }),
+      dataProvider.getList("waf_events", {
+        pagination: { page: 1, perPage: 1 },
+        sort: { field: "id", order: "ASC" },
+        filter: {},
+      }),
+      dataProvider.getList("waf_events", {
+        pagination: { page: 1, perPage: 1 },
+        sort: { field: "id", order: "ASC" },
+        filter: { type: "blocked" },
+      }),
+    ])
+      .then(([wafRules, wafPolicies, wafEvents, blockedEvents]) => {
+        setWafStats({
+          totalRules: wafRules?.total || 0,
+          totalPolicies: wafPolicies?.total || 0,
+          recentEvents: wafEvents?.total || 0,
+          blockedEvents: blockedEvents?.total || 0,
         });
       })
       .catch(() => {});
@@ -2378,6 +2423,57 @@ const Dashboard = () => {
               </Typography>
             </Box>
           )}
+        </ChartCard>
+      </Box>
+
+      {/* WAF Security Panel */}
+      <Box sx={{ mb: 4, width: "100%" }}>
+        <ChartCard
+          title="WAF Security Overview"
+          subtitle="Web Application Firewall status and recent activity"
+          height="auto"
+          accentColor="#10b981"
+        >
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: {
+                xs: "1fr",
+                sm: "repeat(2, 1fr)",
+                md: "repeat(4, 1fr)",
+              },
+              gap: 2,
+            }}
+          >
+            <StatCard
+              title="WAF Rules"
+              value={wafStats.totalRules}
+              icon={ShieldIcon}
+              color="#6366f1"
+              subtitle="Active detection rules"
+            />
+            <StatCard
+              title="WAF Policies"
+              value={wafStats.totalPolicies}
+              icon={VerifiedUserIcon}
+              color="#10b981"
+              subtitle="Configured policies"
+            />
+            <StatCard
+              title="Total Events"
+              value={formatNumber(wafStats.recentEvents)}
+              icon={NotificationsActiveIcon}
+              color="#f59e0b"
+              subtitle="WAF events recorded"
+            />
+            <StatCard
+              title="Blocked Threats"
+              value={formatNumber(wafStats.blockedEvents)}
+              icon={BlockIcon}
+              color="#ef4444"
+              subtitle="Requests blocked"
+            />
+          </Box>
         </ChartCard>
       </Box>
 

--- a/openresty-admin/src/Menu.jsx
+++ b/openresty-admin/src/Menu.jsx
@@ -8,6 +8,9 @@ import RuleIcon from "@mui/icons-material/RuleRounded";
 import ProfileIcon from "@mui/icons-material/RecentActorsRounded";
 import SecretIcon from "@mui/icons-material/KeyRounded";
 import InstanceIcon from "@mui/icons-material/ViewInArRounded";
+import WafRuleIcon from "@mui/icons-material/ShieldRounded";
+import WafPolicyIcon from "@mui/icons-material/VerifiedUserRounded";
+import WafEventIcon from "@mui/icons-material/NotificationsActiveRounded";
 import Logo from "./component/Logo";
 import { useThemeMode } from "./Theme";
 
@@ -135,7 +138,7 @@ export const Menu = () => {
       <Divider sx={{ my: 2, mx: 2, borderColor: theme.palette.divider }} />
 
       {/* Configuration Section */}
-      <Box sx={{ px: 1, flex: 1 }}>
+      <Box sx={{ px: 1 }}>
         {open && (
           <Typography
             variant="overline"
@@ -177,6 +180,44 @@ export const Menu = () => {
           to="/instances"
           primaryText="Instances"
           leftIcon={<InstanceIcon />}
+        />
+      </Box>
+
+      <Divider sx={{ my: 2, mx: 2, borderColor: theme.palette.divider }} />
+
+      {/* Security Section */}
+      <Box sx={{ px: 1, flex: 1 }}>
+        {open && (
+          <Typography
+            variant="overline"
+            sx={{
+              px: 2,
+              py: 1,
+              color: theme.palette.text.secondary,
+              fontSize: "0.65rem",
+              fontWeight: 700,
+              letterSpacing: "0.1em",
+              display: "block",
+            }}
+          >
+            Security
+          </Typography>
+        )}
+
+        <StyledMenuItem
+          to="/waf_rules"
+          primaryText="WAF Rules"
+          leftIcon={<WafRuleIcon />}
+        />
+        <StyledMenuItem
+          to="/waf_policies"
+          primaryText="WAF Policies"
+          leftIcon={<WafPolicyIcon />}
+        />
+        <StyledMenuItem
+          to="/waf_events"
+          primaryText="WAF Events"
+          leftIcon={<WafEventIcon />}
         />
       </Box>
 

--- a/openresty-admin/src/Servers/Form.jsx
+++ b/openresty-admin/src/Servers/Form.jsx
@@ -638,6 +638,45 @@ const Form = ({ type }) => {
           )}
         </div>
       </TabbedForm.Tab>
+
+      <TabbedForm.Tab label="WAF Protection">
+        <div className="form-container">
+          <SectionCard
+            title="WAF Protection"
+            subtitle="Enable and configure Web Application Firewall protection for this server"
+          >
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={6} md={4}>
+                <BooleanInput
+                  source="waf_enabled"
+                  label="Enable WAF"
+                  defaultValue={false}
+                  helperText="Enable Web Application Firewall protection"
+                />
+              </Grid>
+              <FormDataConsumer>
+                {({ formData }) =>
+                  formData?.waf_enabled && (
+                    <Grid item xs={12} sm={6} md={8}>
+                      <ReferenceInput
+                        source="waf_policy_id"
+                        reference="waf_policies"
+                      >
+                        <SelectInput
+                          fullWidth
+                          optionText="name"
+                          label="WAF Policy"
+                          helperText="Select a WAF policy to apply to this server"
+                        />
+                      </ReferenceInput>
+                    </Grid>
+                  )
+                }
+              </FormDataConsumer>
+            </Grid>
+          </SectionCard>
+        </div>
+      </TabbedForm.Tab>
     </TabbedForm>
   );
 };

--- a/openresty-admin/src/WafEvents/List.jsx
+++ b/openresty-admin/src/WafEvents/List.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {
+  Datagrid,
+  DateField,
+  NumberField,
+  List as RaList,
+  TextField,
+  FunctionField,
+  SearchInput,
+  SelectInput,
+  TopToolbar,
+  FilterButton,
+  ExportButton,
+} from 'react-admin'
+import { MyPagination } from '../component/MyPagination';
+import { Chip } from '@mui/material';
+
+const typeColors = {
+  blocked: '#ef4444',
+  monitored: '#f97316',
+  error: '#6b7280',
+};
+
+const severityColors = {
+  critical: '#ef4444',
+  high: '#f97316',
+  medium: '#eab308',
+  low: '#3b82f6',
+  info: '#6b7280',
+};
+
+const wafEventsFilters = [
+  <SearchInput source="q" alwaysOn fullWidth />,
+  <SelectInput
+    source="type"
+    choices={[
+      { id: 'blocked', name: 'Blocked' },
+      { id: 'monitored', name: 'Monitored' },
+      { id: 'error', name: 'Error' },
+    ]}
+    alwaysOn
+  />,
+];
+
+// Read-only toolbar (no create button)
+const WafEventsToolbar = () => (
+  <TopToolbar>
+    <FilterButton />
+    <ExportButton />
+  </TopToolbar>
+);
+
+const List = () => {
+  return (
+    <RaList
+      title={"WAF Events"}
+      perPage={1000}
+      pagination={<MyPagination />}
+      filters={wafEventsFilters}
+      actions={<WafEventsToolbar />}
+    >
+      <Datagrid bulkActionButtons={false}>
+        <DateField source='timestamp' showTime />
+        <FunctionField
+          source='type'
+          render={(record) => {
+            const color = typeColors[record.type] || '#6b7280';
+            return (
+              <Chip
+                label={record.type}
+                size="small"
+                sx={{
+                  backgroundColor: `${color}20`,
+                  color: color,
+                  fontWeight: 600,
+                  fontSize: '0.75rem',
+                }}
+              />
+            );
+          }}
+        />
+        <TextField source='host' />
+        <TextField source='rule_name' />
+        <TextField source='category' />
+        <FunctionField
+          source='severity'
+          render={(record) => {
+            const color = severityColors[record.severity] || '#6b7280';
+            return (
+              <Chip
+                label={record.severity}
+                size="small"
+                sx={{
+                  backgroundColor: `${color}20`,
+                  color: color,
+                  fontWeight: 600,
+                  fontSize: '0.75rem',
+                }}
+              />
+            );
+          }}
+        />
+        <TextField source='client_ip' />
+        <TextField source='uri' />
+        <TextField source='method' />
+        <NumberField source='score' />
+      </Datagrid>
+    </RaList>
+  )
+}
+
+export default List

--- a/openresty-admin/src/WafEvents/index.jsx
+++ b/openresty-admin/src/WafEvents/index.jsx
@@ -1,0 +1,9 @@
+import List from "./List";
+
+export default {
+  options: {
+    group: "admin",
+    roles: ["administrator"],
+  },
+  list: List,
+};

--- a/openresty-admin/src/WafPolicies/Create.jsx
+++ b/openresty-admin/src/WafPolicies/Create.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Create as RaCreate } from 'react-admin';
+import Form from './Form'
+
+const Create = () => {
+  return (
+    <RaCreate title={"WAF Policy"} redirect="list">
+        <Form />
+    </RaCreate>
+  )
+}
+
+export default Create

--- a/openresty-admin/src/WafPolicies/Edit.jsx
+++ b/openresty-admin/src/WafPolicies/Edit.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Edit as RaEdit } from "react-admin";
+import Form from "./Form";
+
+const Edit = () => {
+  return (
+    <RaEdit title={"WAF Policy"} redirect="list">
+      <Form />
+    </RaEdit>
+  );
+};
+
+export default Edit;

--- a/openresty-admin/src/WafPolicies/Form.jsx
+++ b/openresty-admin/src/WafPolicies/Form.jsx
@@ -1,0 +1,213 @@
+import { Card, CardContent, Divider, Grid, Typography } from "@mui/material";
+import React from "react";
+import {
+  BooleanInput,
+  NumberInput,
+  SimpleForm,
+  TextInput,
+  SelectInput,
+  ArrayInput,
+  SimpleFormIterator,
+  required,
+} from "react-admin";
+import "../styles/forms.css";
+
+// Section Card component for consistent styling
+const SectionCard = ({ title, subtitle, children }) => (
+  <Card variant="outlined" className="section-card">
+    <CardContent>
+      <Typography variant="subtitle1" className="section-card__title">
+        {title}
+      </Typography>
+      {subtitle && (
+        <Typography variant="body2" color="text.secondary" className="section-card__subtitle">
+          {subtitle}
+        </Typography>
+      )}
+      {!subtitle && <div className="section-card__spacer" />}
+      {children}
+    </CardContent>
+  </Card>
+);
+
+// Sub-section label
+const SubSectionLabel = ({ children }) => (
+  <Typography variant="body2" color="text.secondary" className="sub-section-label">
+    {children}
+  </Typography>
+);
+
+const Form = () => {
+  return (
+    <SimpleForm>
+      <div className="form-container">
+
+        {/* Basic Policy Information */}
+        <SectionCard title="Basic Policy Information" subtitle="Configure the WAF policy name and enforcement mode">
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} md={4}>
+              <TextInput
+                source="name"
+                label="Policy Name"
+                validate={[required()]}
+                fullWidth
+                helperText="Unique name for this WAF policy"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={4}>
+              <SelectInput
+                source="mode"
+                label="Enforcement Mode"
+                validate={[required()]}
+                fullWidth
+                choices={[
+                  { id: 'block', name: 'Block' },
+                  { id: 'monitor', name: 'Monitor' },
+                ]}
+                helperText="Block threats or monitor only"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={4}>
+              <BooleanInput
+                source="enabled"
+                label="Enabled"
+                defaultValue={true}
+                helperText="Enable or disable this policy"
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextInput
+                source="description"
+                label="Description"
+                multiline
+                fullWidth
+                minRows={2}
+                helperText="Describe the purpose of this policy"
+              />
+            </Grid>
+          </Grid>
+        </SectionCard>
+
+        {/* Detection Configuration */}
+        <SectionCard title="Detection Configuration" subtitle="Configure anomaly scoring and paranoia level">
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} md={4}>
+              <NumberInput
+                source="anomaly_threshold"
+                label="Anomaly Threshold"
+                defaultValue={5}
+                fullWidth
+                helperText="Score threshold to trigger action"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={4}>
+              <SelectInput
+                source="paranoia_level"
+                label="Paranoia Level"
+                fullWidth
+                choices={[
+                  { id: 1, name: 'Level 1 - Low (Recommended)' },
+                  { id: 2, name: 'Level 2 - Medium' },
+                  { id: 3, name: 'Level 3 - High' },
+                  { id: 4, name: 'Level 4 - Maximum' },
+                ]}
+                helperText="Higher levels detect more but may have false positives"
+              />
+            </Grid>
+          </Grid>
+        </SectionCard>
+
+        {/* Body Inspection */}
+        <SectionCard title="Body Inspection" subtitle="Configure request body inspection settings">
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} md={4}>
+              <BooleanInput
+                source="body_inspection"
+                label="Enable Body Inspection"
+                helperText="Inspect request body content"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={4}>
+              <NumberInput
+                source="max_body_size"
+                label="Max Body Size (bytes)"
+                fullWidth
+                helperText="Maximum body size to inspect"
+              />
+            </Grid>
+          </Grid>
+        </SectionCard>
+
+        {/* WAF Rules */}
+        <SectionCard title="WAF Rules" subtitle="Assign WAF rules to this policy">
+          <ArrayInput source="waf_rules" label="">
+            <SimpleFormIterator
+              inline
+              disableReordering
+            >
+              <TextInput
+                source=""
+                label="Rule ID"
+                helperText="WAF rule identifier"
+              />
+            </SimpleFormIterator>
+          </ArrayInput>
+        </SectionCard>
+
+        {/* Whitelist Configuration */}
+        <SectionCard title="Whitelist Configuration" subtitle="Define exceptions that bypass WAF inspection">
+
+          <SubSectionLabel>Whitelisted IP Addresses</SubSectionLabel>
+          <ArrayInput source="whitelist.ips" label="">
+            <SimpleFormIterator
+              inline
+              disableReordering
+            >
+              <TextInput
+                source=""
+                label="IP Address"
+                helperText="e.g., 192.168.1.0/24"
+              />
+            </SimpleFormIterator>
+          </ArrayInput>
+
+          <Divider className="form-divider" />
+
+          <SubSectionLabel>Whitelisted Paths</SubSectionLabel>
+          <ArrayInput source="whitelist.paths" label="">
+            <SimpleFormIterator
+              inline
+              disableReordering
+            >
+              <TextInput
+                source=""
+                label="Path"
+                helperText="e.g., /api/health"
+              />
+            </SimpleFormIterator>
+          </ArrayInput>
+
+          <Divider className="form-divider" />
+
+          <SubSectionLabel>Whitelisted User Agents</SubSectionLabel>
+          <ArrayInput source="whitelist.user_agents" label="">
+            <SimpleFormIterator
+              inline
+              disableReordering
+            >
+              <TextInput
+                source=""
+                label="User Agent"
+                helperText="e.g., Googlebot"
+              />
+            </SimpleFormIterator>
+          </ArrayInput>
+
+        </SectionCard>
+
+      </div>
+    </SimpleForm>
+  );
+};
+
+export default Form;

--- a/openresty-admin/src/WafPolicies/List.jsx
+++ b/openresty-admin/src/WafPolicies/List.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import {
+  BooleanField,
+  Datagrid,
+  NumberField,
+  List as RaList,
+  TextField,
+  FunctionField,
+  SearchInput,
+} from 'react-admin'
+import Empty from '../component/Empty';
+import ToolBar from '../component/ToolBar';
+import { MyPagination } from '../component/MyPagination';
+import { Chip } from '@mui/material';
+
+const modeColors = {
+  block: '#ef4444',
+  monitor: '#f97316',
+};
+
+const wafPoliciesFilters = [
+  <SearchInput source="q" alwaysOn fullWidth />,
+];
+
+const List = () => {
+  return (
+    <RaList
+      title={"WAF Policies"}
+      perPage={1000}
+      pagination={<MyPagination />}
+      empty={<Empty resource={"waf_policies"} />}
+      filters={wafPoliciesFilters}
+      actions={<ToolBar resource={"waf_policies"} />}
+    >
+      <Datagrid rowClick="edit">
+        <TextField source='name' />
+        <FunctionField
+          source='mode'
+          render={(record) => {
+            const color = modeColors[record.mode] || '#6b7280';
+            return (
+              <Chip
+                label={record.mode}
+                size="small"
+                sx={{
+                  backgroundColor: `${color}20`,
+                  color: color,
+                  fontWeight: 600,
+                  fontSize: '0.75rem',
+                }}
+              />
+            );
+          }}
+        />
+        <BooleanField source='enabled' />
+        <NumberField source='anomaly_threshold' />
+        <NumberField source='paranoia_level' />
+      </Datagrid>
+    </RaList>
+  )
+}
+
+export default List

--- a/openresty-admin/src/WafPolicies/index.jsx
+++ b/openresty-admin/src/WafPolicies/index.jsx
@@ -1,0 +1,13 @@
+import List from "./List";
+import Create from "./Create";
+import Edit from "./Edit";
+
+export default {
+  options: {
+    group: "admin",
+    roles: ["administrator"],
+  },
+  list: List,
+  create: Create,
+  edit: Edit
+};

--- a/openresty-admin/src/WafRules/Create.jsx
+++ b/openresty-admin/src/WafRules/Create.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Create as RaCreate } from 'react-admin';
+import Form from './Form'
+
+const Create = () => {
+  return (
+    <RaCreate title={"WAF Rule"} redirect="list">
+        <Form />
+    </RaCreate>
+  )
+}
+
+export default Create

--- a/openresty-admin/src/WafRules/Edit.jsx
+++ b/openresty-admin/src/WafRules/Edit.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Edit as RaEdit } from "react-admin";
+import Form from "./Form";
+
+const Edit = () => {
+  return (
+    <RaEdit title={"WAF Rule"} redirect="list">
+      <Form />
+    </RaEdit>
+  );
+};
+
+export default Edit;

--- a/openresty-admin/src/WafRules/Form.jsx
+++ b/openresty-admin/src/WafRules/Form.jsx
@@ -1,0 +1,198 @@
+import { Card, CardContent, Grid, Typography } from "@mui/material";
+import React from "react";
+import {
+  BooleanInput,
+  NumberInput,
+  SimpleForm,
+  TextInput,
+  SelectInput,
+  ArrayInput,
+  SimpleFormIterator,
+  required,
+} from "react-admin";
+import "../styles/forms.css";
+
+// Section Card component for consistent styling
+const SectionCard = ({ title, subtitle, children }) => (
+  <Card variant="outlined" className="section-card">
+    <CardContent>
+      <Typography variant="subtitle1" className="section-card__title">
+        {title}
+      </Typography>
+      {subtitle && (
+        <Typography variant="body2" color="text.secondary" className="section-card__subtitle">
+          {subtitle}
+        </Typography>
+      )}
+      {!subtitle && <div className="section-card__spacer" />}
+      {children}
+    </CardContent>
+  </Card>
+);
+
+const Form = () => {
+  return (
+    <SimpleForm>
+      <div className="form-container">
+
+        {/* Basic Rule Information */}
+        <SectionCard title="Basic Rule Information" subtitle="Configure the WAF rule name, category, and severity">
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} md={4}>
+              <TextInput
+                source="name"
+                label="Rule Name"
+                validate={[required()]}
+                fullWidth
+                helperText="Unique name for this WAF rule"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={4}>
+              <SelectInput
+                source="category"
+                label="Category"
+                fullWidth
+                choices={[
+                  { id: 'sqli', name: 'SQL Injection' },
+                  { id: 'xss', name: 'Cross-Site Scripting' },
+                  { id: 'cmdi', name: 'Command Injection' },
+                  { id: 'lfi', name: 'Local File Inclusion' },
+                  { id: 'rfi', name: 'Remote File Inclusion' },
+                  { id: 'protocol', name: 'Protocol Violation' },
+                  { id: 'custom', name: 'Custom Rule' },
+                ]}
+                helperText="Attack category this rule detects"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={4}>
+              <SelectInput
+                source="severity"
+                label="Severity"
+                fullWidth
+                choices={[
+                  { id: 'critical', name: 'Critical' },
+                  { id: 'high', name: 'High' },
+                  { id: 'medium', name: 'Medium' },
+                  { id: 'low', name: 'Low' },
+                  { id: 'info', name: 'Info' },
+                ]}
+                helperText="Severity level of the threat"
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextInput
+                source="description"
+                label="Description"
+                multiline
+                fullWidth
+                minRows={2}
+                helperText="Describe what this rule detects"
+              />
+            </Grid>
+          </Grid>
+        </SectionCard>
+
+        {/* Pattern Configuration */}
+        <SectionCard title="Pattern Configuration" subtitle="Define the detection pattern and target for this rule">
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} md={4}>
+              <SelectInput
+                source="target"
+                label="Target"
+                fullWidth
+                choices={[
+                  { id: 'url', name: 'URL' },
+                  { id: 'headers', name: 'Headers' },
+                  { id: 'body', name: 'Body' },
+                  { id: 'args', name: 'Arguments' },
+                  { id: 'cookies', name: 'Cookies' },
+                  { id: 'user_agent', name: 'User Agent' },
+                  { id: 'all', name: 'All' },
+                ]}
+                helperText="Part of the request to inspect"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={4}>
+              <SelectInput
+                source="pattern_type"
+                label="Pattern Type"
+                fullWidth
+                defaultValue="regex"
+                choices={[
+                  { id: 'regex', name: 'Regular Expression' },
+                  { id: 'string', name: 'String Match' },
+                ]}
+                helperText="Type of pattern matching"
+              />
+            </Grid>
+            <Grid item xs={12}>
+              <TextInput
+                source="pattern"
+                label="Pattern"
+                validate={[required()]}
+                multiline
+                fullWidth
+                minRows={3}
+                helperText="Detection pattern (regex or string)"
+              />
+            </Grid>
+          </Grid>
+        </SectionCard>
+
+        {/* Action Configuration */}
+        <SectionCard title="Action Configuration" subtitle="Define what happens when this rule matches">
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} md={4}>
+              <SelectInput
+                source="action"
+                label="Action"
+                fullWidth
+                choices={[
+                  { id: 'block', name: 'Block' },
+                  { id: 'monitor', name: 'Monitor' },
+                  { id: 'allow', name: 'Allow' },
+                ]}
+                helperText="Action to take on match"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={4}>
+              <NumberInput
+                source="score"
+                label="Anomaly Score"
+                fullWidth
+                helperText="Score added to anomaly threshold"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} md={4}>
+              <BooleanInput
+                source="enabled"
+                label="Enabled"
+                defaultValue={true}
+                helperText="Enable or disable this rule"
+              />
+            </Grid>
+          </Grid>
+        </SectionCard>
+
+        {/* Tags */}
+        <SectionCard title="Tags" subtitle="Add tags for organizing and filtering rules">
+          <ArrayInput source="tags" label="">
+            <SimpleFormIterator
+              inline
+              disableReordering
+            >
+              <TextInput
+                source=""
+                label="Tag"
+                helperText="Rule tag"
+              />
+            </SimpleFormIterator>
+          </ArrayInput>
+        </SectionCard>
+
+      </div>
+    </SimpleForm>
+  );
+};
+
+export default Form;

--- a/openresty-admin/src/WafRules/List.jsx
+++ b/openresty-admin/src/WafRules/List.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import {
+  BooleanField,
+  Datagrid,
+  NumberField,
+  List as RaList,
+  TextField,
+  FunctionField,
+  SearchInput,
+  SelectInput,
+} from 'react-admin'
+import Empty from '../component/Empty';
+import ToolBar from '../component/ToolBar';
+import { MyPagination } from '../component/MyPagination';
+import { Chip } from '@mui/material';
+
+const categoryColors = {
+  sqli: '#ef4444',
+  xss: '#f97316',
+  cmdi: '#a855f7',
+  lfi: '#3b82f6',
+  rfi: '#6366f1',
+  protocol: '#6b7280',
+  custom: '#14b8a6',
+};
+
+const severityColors = {
+  critical: '#ef4444',
+  high: '#f97316',
+  medium: '#eab308',
+  low: '#3b82f6',
+  info: '#6b7280',
+};
+
+const actionColors = {
+  block: '#ef4444',
+  monitor: '#f97316',
+  allow: '#22c55e',
+};
+
+const wafRulesFilters = [
+  <SearchInput source="q" alwaysOn fullWidth />,
+  <SelectInput
+    source="category"
+    choices={[
+      { id: 'sqli', name: 'SQL Injection' },
+      { id: 'xss', name: 'XSS' },
+      { id: 'cmdi', name: 'Command Injection' },
+      { id: 'lfi', name: 'Local File Inclusion' },
+      { id: 'rfi', name: 'Remote File Inclusion' },
+      { id: 'protocol', name: 'Protocol' },
+      { id: 'custom', name: 'Custom' },
+    ]}
+    alwaysOn
+  />,
+];
+
+const List = () => {
+  return (
+    <RaList
+      title={"WAF Rules"}
+      perPage={1000}
+      pagination={<MyPagination />}
+      empty={<Empty resource={"waf_rules"} />}
+      filters={wafRulesFilters}
+      actions={<ToolBar resource={"waf_rules"} />}
+    >
+      <Datagrid rowClick="edit">
+        <TextField source='name' />
+        <FunctionField
+          source='category'
+          render={(record) => {
+            const color = categoryColors[record.category] || '#6b7280';
+            return (
+              <Chip
+                label={record.category}
+                size="small"
+                sx={{
+                  backgroundColor: `${color}20`,
+                  color: color,
+                  fontWeight: 600,
+                  fontSize: '0.75rem',
+                }}
+              />
+            );
+          }}
+        />
+        <FunctionField
+          source='severity'
+          render={(record) => {
+            const color = severityColors[record.severity] || '#6b7280';
+            return (
+              <Chip
+                label={record.severity}
+                size="small"
+                sx={{
+                  backgroundColor: `${color}20`,
+                  color: color,
+                  fontWeight: 600,
+                  fontSize: '0.75rem',
+                }}
+              />
+            );
+          }}
+        />
+        <TextField source='target' />
+        <FunctionField
+          source='action'
+          render={(record) => {
+            const color = actionColors[record.action] || '#6b7280';
+            return (
+              <Chip
+                label={record.action}
+                size="small"
+                sx={{
+                  backgroundColor: `${color}20`,
+                  color: color,
+                  fontWeight: 600,
+                  fontSize: '0.75rem',
+                }}
+              />
+            );
+          }}
+        />
+        <BooleanField source='enabled' />
+        <NumberField source='score' />
+      </Datagrid>
+    </RaList>
+  )
+}
+
+export default List

--- a/openresty-admin/src/WafRules/index.jsx
+++ b/openresty-admin/src/WafRules/index.jsx
@@ -1,0 +1,13 @@
+import List from "./List";
+import Create from "./Create";
+import Edit from "./Edit";
+
+export default {
+  options: {
+    group: "admin",
+    roles: ["administrator"],
+  },
+  list: List,
+  create: Create,
+  edit: Edit
+};


### PR DESCRIPTION
## Summary

- Adds a complete, production-grade WAF with fail-open design and OWASP-inspired detection rules
- Implements full-stack integration: Lua engine, REST API, MCP server, Prometheus metrics, and React Admin dashboard
- Ships in **monitor mode** by default — safe to deploy, blocks nothing until explicitly switched to block mode

## What's included

### Core Engine (`api/waf_engine.lua`)
- Request inspection across URL, headers, body, args, cookies, user-agent
- Anomaly scoring with configurable thresholds
- Per-worker regex caching with JIT-compiled PCRE via `ngx.re.find()`
- Whitelist support (IPs with CIDR, paths, user-agents)
- Fail-open: all errors are caught via `pcall`, requests continue on failure

### 20 Seed Rules (`data/waf_rules/prod/`)
- **SQLi** (7): UNION SELECT, SELECT FROM, INSERT/UPDATE/DELETE, DROP/ALTER, OR 1=1, SQL comments, SLEEP/BENCHMARK
- **XSS** (5): script tags, javascript: protocol, event handlers, HTML injection, DOM manipulation
- **CMDI** (4): semicolon chaining, pipe injection, backtick execution, subshell $()
- **LFI** (2): directory traversal, sensitive file access
- **Protocol** (2): null byte injection, CRLF injection

### REST API (`api/api.lua`)
- Full CRUD for `/api/waf_rules`, `/api/waf_policies`
- Read-only `/api/waf_events` (from shared dict)
- `POST /api/waf_rules/seed` to deploy default rules
- Input validation with regex compilation testing

### MCP Server Extensions
- 3 new resources: `waf_rules`, `waf_policies`, `waf_events`
- 3 mappers, 3 schemas
- `test_waf_rule` tool for AI agents to validate patterns

### Prometheus Metrics
- `nginx_waf_inspections_total`, `nginx_waf_blocked_total`, `nginx_waf_monitored_total`
- `nginx_waf_errors_total`, `nginx_waf_inspection_duration_seconds`

### Dashboard UI
- WAF Rules: list with color-coded category/severity/action chips, full CRUD form
- WAF Policies: list/CRUD with whitelist, anomaly threshold, rule assignment
- WAF Events: read-only event log with severity coloring
- Security menu section, Server WAF Protection tab, Dashboard WAF stats panel

### Deployment
- `lua_shared_dict waf_events 10m` in nginx.conf
- WAF directory creation in fix-permissions.sh
- WAF settings section in sample-settings.json

## Test plan

- [ ] Deploy to INT environment and verify OpenResty starts without errors
- [ ] Confirm `/api/waf_rules` returns seed rules
- [ ] Confirm `/api/waf_policies` returns default policy
- [ ] Verify WAF dashboard panel appears with rule/policy counts
- [ ] Test SQLi detection: `curl "https://test.example.com/?id=1%20UNION%20SELECT%201,2,3--"`
- [ ] Verify monitor mode logs events without blocking
- [ ] Switch policy to block mode and verify 403 response on attacks
- [ ] Confirm normal requests pass through unaffected
- [ ] Verify fail-open by temporarily breaking WAF module

🤖 Generated with [Claude Code](https://claude.com/claude-code)