### PR TITLE
Redesign deployment pipeline: 5-stage automated CI/CD with fail-fast

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,158 @@
+# WSLProxy CI/CD Pipeline
+
+## Build & Deploy Pipeline (`build-deploy-wslproxy.yml`)
+
+Fully automated 5-stage deployment pipeline with fail-fast behavior and Slack notifications at every gate. No human approval required — the pipeline promotes code from validation through integration testing to production automatically.
+
+### Triggers
+
+| Trigger | Branches | Behavior |
+|---------|----------|----------|
+| Push | `main` | Runs stages 1–4 (int deploy + test only) |
+| Push | `release` | Runs all 5 stages (through to production) |
+| Manual (`workflow_dispatch`) | any | Choose target host and environment |
+
+### Pipeline Stages
+
+```
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │                        PUSH TO main / release                       │
+ └──────────────────────────┬───────────────────────────────────────────┘
+                            │
+                            ▼
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │  STAGE 1: Build & Validate                        [ubuntu-latest]   │
+ │                                                                      │
+ │  - Validate all JSON configs (servers, rules, WAF rules, policies)  │
+ │  - Validate Jinja2 templates (Ansible roles)                        │
+ │                                                                      │
+ │  ✗ Failure → Slack alert → pipeline stops                           │
+ └──────────────────────────┬───────────────────────────────────────────┘
+                            │ pass
+                            ▼
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │  STAGE 2: Smoke Test (Docker Compose)             [slworker00]      │
+ │                                                                      │
+ │  - docker compose -f docker-compose-prod.yml up -d                  │
+ │  - Wait for /health endpoint (20 retries × 5s)                     │
+ │  - Verify /ping returns "pong"                                      │
+ │  - API smoke tests: /api/servers, /api/rules,                       │
+ │    /api/waf_rules, /api/waf_policies                                │
+ │  - docker compose down -v (always, even on failure)                 │
+ │                                                                      │
+ │  ✗ Failure → Slack alert → pipeline stops                           │
+ └──────────────────────────┬───────────────────────────────────────────┘
+                            │ pass
+                            ▼
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │  STAGE 3: Deploy Int (Ansible native)             [slworker00]      │
+ │                                                                      │
+ │  - Decode INT settings + env from GitHub Secrets                    │
+ │  - ansible-playbook wslproxy-ops.yml -l slworker00 (env: int)      │
+ │  - Post-deploy gates:                                               │
+ │      • openresty -t (nginx config syntax)                           │
+ │      • systemctl is-active openresty                                │
+ │      • curl /ping (12 retries × 5s)                                │
+ │                                                                      │
+ │  ✗ Failure → Slack alert → pipeline stops                           │
+ └──────────────────────────┬───────────────────────────────────────────┘
+                            │ pass
+                            ▼
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │  STAGE 4: Test Environment                        [slworker00]      │
+ │                                                                      │
+ │  - Go health check tests (QA/01_healthcheck_test.go)                │
+ │  - API endpoint verification: /ping, /health, /api/servers,         │
+ │    /api/rules, /api/waf_rules, /api/waf_policies                   │
+ │                                                                      │
+ │  ✗ Failure → Slack alert → pipeline stops before production         │
+ └──────────────────────────┬───────────────────────────────────────────┘
+                            │ pass
+                            │
+                    ┌───────┴────────┐
+                    │ release branch │──── main branch pushes STOP here
+                    │  or manual     │
+                    └───────┬────────┘
+                            │
+                            ▼
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │  STAGE 5: Deploy Production                       [self-hosted]     │
+ │                                                                      │
+ │  Target: 185.237.99.238 (pop0)                                      │
+ │                                                                      │
+ │  - Decode PROD settings + env from GitHub Secrets                   │
+ │  - SSH connectivity test to root@185.237.99.238                     │
+ │  - ansible-playbook wslproxy-ops.yml -l 185.237.99.238 (env: prod) │
+ │  - Post-deploy gates:                                               │
+ │      • openresty -t via SSH                                         │
+ │      • systemctl is-active openresty via SSH                        │
+ │      • curl https://prod-our.wslproxy.com/ping (10 retries × 5s)   │
+ │                                                                      │
+ │  ✓ Success → Slack: "deployed to production"                        │
+ │  ✗ Failure → Slack: "production deployment FAILED"                  │
+ └──────────────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+ ┌──────────────────────────────────────────────────────────────────────┐
+ │  PIPELINE SUMMARY (always runs)                   [ubuntu-latest]   │
+ │                                                                      │
+ │  Reports pass/fail for all 5 stages.                                │
+ │  Exits with error if any stage failed.                              │
+ └──────────────────────────────────────────────────────────────────────┘
+```
+
+### Environments & Hosts
+
+| Environment | Host | Runner | Ansible user | Deploy method |
+|-------------|------|--------|-------------|---------------|
+| int | slworker00 | `[self-hosted, slworker00]` | bwalia | Ansible native (local) |
+| prod | 185.237.99.238 | `[self-hosted]` | root | Ansible native (SSH) |
+
+### Secrets Required
+
+| Secret | Used by | Description |
+|--------|---------|-------------|
+| `DOT_WSLPROXY_SETTINGS_INT` | Stage 3 | Base64-encoded settings.json for int |
+| `DOT_WSLPROXY_ENV_CREDS_INT` | Stage 3 | Base64-encoded .env for int |
+| `DOT_WSLPROXY_SETTINGS_PROD` | Stage 5 | Base64-encoded settings.json for prod |
+| `DOT_WSLPROXY_ENV_CREDS_PROD` | Stage 5 | Base64-encoded .env for prod |
+| `SLACK_WEBHOOK` | All stages | Slack incoming webhook URL |
+
+### Fail-Fast Behavior
+
+Every stage sends a Slack notification on failure and stops the pipeline immediately:
+
+```
+Stage 1 fails → "Stage 1 FAILED: Build & Validate"      → pipeline stops
+Stage 2 fails → "Stage 2 FAILED: Docker Compose Smoke"   → pipeline stops
+Stage 3 fails → "Stage 3 FAILED: Ansible Deploy to int"  → pipeline stops
+Stage 4 fails → "Stage 4 FAILED: Integration Tests"      → pipeline stops (before prod)
+Stage 5 fails → "Stage 5 FAILED: Production Deployment"  → alert + manual rollback needed
+```
+
+### Rollback
+
+- **Stages 1–4 failure**: Production is never touched. Fix the issue and push again.
+- **Stage 5 failure**: Re-run the workflow from a previous known-good commit on the `release` branch, or use `workflow_dispatch` to target a specific commit.
+
+### Concurrency
+
+```yaml
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+```
+
+Only one deployment per branch at a time. In-progress deployments are **not** cancelled to avoid partial deploys.
+
+---
+
+## Other Workflows
+
+| Workflow | File | Purpose |
+|----------|------|---------|
+| Deploy Configs | `deploy-configs.yml` | Deploy server/rule JSON configs via Ansible |
+| E2E Tests | `e2e-tests.yml` | Playwright browser tests against deployed frontend |
+| API Test Suite | `automated-api-test-suite.yml` | Go-based API integration tests |
+| UI Smoke Test | `automated-ui-smoke-test.yml` | Cypress UI smoke tests |
+| Backup Data | `backup-wslproxy-data.yml` | Backup WSLProxy data from production |

--- a/.github/workflows/build-deploy-wslproxy.yml
+++ b/.github/workflows/build-deploy-wslproxy.yml
@@ -1,9 +1,13 @@
 name: Build and Deploy WSLProxy
-  # Auto-deploys to 185.237.99.238 on push to main branch
+# Fully automated 5-stage pipeline — no human in loop
+# Validate → Smoke Test (Docker Compose) → Deploy Int (Ansible) → Test → Deploy Prod (Ansible)
+# Fail-fast: any stage failure stops the pipeline and sends Slack notification immediately
+
 on:
   push:
     branches:
       - main
+      - release
   pull_request:
     branches:
       - dummy-branch-for-wslproxy-deploy
@@ -28,24 +32,190 @@ on:
         required: true
         options:
           - 185.237.99.238
-          - whisky03
-          # - whisky10
-          # - whisky08
+          - slworker00
 
-# Auto-map TARGET_ENV from TARGET_HOST if not set, and ensure consistency
+# Prevent concurrent deployments to same ref (but don't cancel in-progress)
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   TARGET_HOST: ${{ github.event.inputs.TARGET_HOST || '185.237.99.238' }}
-  # Map host to env (add more as needed)
-  TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '185.237.99.238' && 'prod' || github.event.inputs.TARGET_HOST == 'whisky03' && 'int' || 'prod') }}
-  API_DOMAINNAME_ENDPOINT: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '185.237.99.238' && 'prod' || github.event.inputs.TARGET_HOST == 'whisky03' && 'int' || 'prod') }}.wslproxy.com
+  TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '185.237.99.238' && 'prod' || github.event.inputs.TARGET_HOST == 'slworker00' && 'int' || 'prod') }}
+  API_DOMAINNAME_ENDPOINT: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '185.237.99.238' && 'prod' || github.event.inputs.TARGET_HOST == 'slworker00' && 'int' || 'prod') }}.wslproxy.com
 
 jobs:
-  build:
-    runs-on: [self-hosted]
+  # ──────────────────────────────────────────────────────
+  # Stage 1: Build & Validate
+  # ──────────────────────────────────────────────────────
+  build-validate:
+    name: "Stage 1: Build & Validate"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
-      - name: Checkout code from repository
-        uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate all JSON config files
+        run: |
+          echo "=== Validating All JSON Configs ==="
+          ERRORS=0
+          VALID=0
+          for dir in data/servers data/rules data/waf_rules data/waf_policies; do
+            for file in $(find "$dir" -name '*.json' 2>/dev/null); do
+              if python3 -m json.tool "$file" > /dev/null 2>&1; then
+                VALID=$((VALID+1))
+              else
+                echo "::error file=$file::Invalid JSON syntax"
+                ERRORS=$((ERRORS+1))
+              fi
+            done
+          done
+          echo "Total: $VALID valid, $ERRORS invalid"
+          if [ $ERRORS -gt 0 ]; then exit 1; fi
+
+      - name: Validate Jinja2 templates
+        run: |
+          pip3 -q install jinja2
+          ERRORS=0
+          for file in $(find devops/ansible/roles -name '*.j2' 2>/dev/null); do
+            if python3 -c "
+          from jinja2 import Environment, BaseLoader, exceptions
+          env = Environment(loader=BaseLoader(), undefined=__import__('jinja2').Undefined)
+          try:
+              env.parse(open('$file').read())
+          except exceptions.TemplateSyntaxError as e:
+              print(f'Syntax error in $file: {e}')
+              exit(1)
+          " 2>/dev/null; then
+              true
+            else
+              echo "::error file=$file::Invalid Jinja2 template"
+              ERRORS=$((ERRORS+1))
+            fi
+          done
+          if [ $ERRORS -gt 0 ]; then exit 1; fi
+          echo "All templates valid"
+
+      - name: Slack notify - Validation failed
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: github-updates
+          SLACK_COLOR: danger
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: |
+            :x: *Stage 1 FAILED: Build & Validate*
+            Config validation errors found — pipeline stopped.
+            *Branch:* ${{ github.ref_name }} | *Commit:* `${{ github.sha }}`
+            *Triggered by:* ${{ github.actor }} (${{ github.event_name }})
+            *Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_TITLE: "WSLProxy Pipeline Failed — Stage 1"
+          SLACK_USERNAME: GitHub Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
+  # Stage 2: Smoke Test (Docker Compose on slworker00)
+  # ──────────────────────────────────────────────────────
+  smoke-test:
+    name: "Stage 2: Smoke Test (Docker Compose)"
+    runs-on: [self-hosted, slworker00]
+    needs: [build-validate]
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Clean up previous containers
+        run: |
+          docker compose -f docker-compose-prod.yml down -v 2>/dev/null || true
+          docker rm -f wslproxy-prod wslproxy-redis 2>/dev/null || true
+
+      - name: Pull latest images
+        run: docker compose -f docker-compose-prod.yml pull
+
+      - name: Start services
+        run: docker compose -f docker-compose-prod.yml up -d
+
+      - name: Wait for health check
+        run: |
+          MAX_ATTEMPTS=20
+          INTERVAL=5
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:8080/health 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "WSLProxy healthy (attempt $i/$MAX_ATTEMPTS)"
+              exit 0
+            fi
+            echo "Attempt $i/$MAX_ATTEMPTS: HTTP $STATUS — waiting ${INTERVAL}s..."
+            sleep $INTERVAL
+          done
+          echo "::error::WSLProxy not healthy after $((MAX_ATTEMPTS * INTERVAL))s"
+          docker compose -f docker-compose-prod.yml logs --tail=50 wslproxy
+          exit 1
+
+      - name: Verify /ping
+        run: |
+          RESPONSE=$(curl -sf http://localhost:8080/ping 2>&1)
+          echo "$RESPONSE" | grep -q "pong" || { echo "::error::Ping check failed: $RESPONSE"; exit 1; }
+          echo "Ping OK"
+
+      - name: API smoke tests
+        run: |
+          FAILED=0
+          for ENDPOINT in /api/servers /api/rules /api/waf_rules /api/waf_policies; do
+            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "http://localhost:8080${ENDPOINT}" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              printf "  GET %-25s OK (%s)\n" "$ENDPOINT" "$STATUS"
+            else
+              printf "  GET %-25s FAIL (%s)\n" "$ENDPOINT" "$STATUS"
+              FAILED=$((FAILED+1))
+            fi
+          done
+          if [ $FAILED -gt 0 ]; then
+            echo "::error::$FAILED smoke test(s) failed"
+            exit 1
+          fi
+          echo "All smoke tests passed"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker compose -f docker-compose-prod.yml down -v 2>/dev/null || true
+          docker rm -f wslproxy-prod wslproxy-redis 2>/dev/null || true
+
+      - name: Slack notify - Smoke test failed
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: github-updates
+          SLACK_COLOR: danger
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: |
+            :x: *Stage 2 FAILED: Docker Compose Smoke Test*
+            Container health check or API tests failed on slworker00 — pipeline stopped.
+            *Branch:* ${{ github.ref_name }} | *Commit:* `${{ github.sha }}`
+            *Triggered by:* ${{ github.actor }} (${{ github.event_name }})
+            *Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_TITLE: "WSLProxy Pipeline Failed — Stage 2"
+          SLACK_USERNAME: GitHub Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
+  # Stage 3: Deploy Int Environment (Ansible native to slworker00)
+  # ──────────────────────────────────────────────────────
+  deploy-int:
+    name: "Stage 3: Deploy Int (Ansible to slworker00)"
+    runs-on: [self-hosted, slworker00]
+    needs: [smoke-test]
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Install Ansible
         run: |
           if command -v zypper &> /dev/null; then
@@ -58,110 +228,311 @@ jobs:
           fi
           export ANSIBLE_HOST_KEY_CHECKING=False
 
-      - name: Decode settings file (INT environment)
-        if: ${{ env.TARGET_HOST == 'whisky03' }}
+      - name: Decode settings file (INT)
         run: |
-          echo "${{ secrets.DOT_WSLPROXY_SETTINGS_INT }}" | base64 -d > /tmp/settings_brahmstra_whisky03.json
-          # Verify file was created and is not empty
-          if [ ! -s /tmp/settings_brahmstra_whisky03.json ]; then
-            echo "::error::Settings file is empty or failed to decode"
+          echo "${{ secrets.DOT_WSLPROXY_SETTINGS_INT }}" | base64 -d > /tmp/settings_brahmstra_slworker00.json
+          if [ ! -s /tmp/settings_brahmstra_slworker00.json ]; then
+            echo "::error::INT settings file is empty or failed to decode"
             exit 1
           fi
-          # Validate JSON syntax
-          if ! python3 -m json.tool /tmp/settings_brahmstra_whisky03.json > /dev/null 2>&1; then
-            echo "::error::Settings file contains invalid JSON"
-            exit 1
-          fi
-          echo "✅ Settings file validated successfully"
+          python3 -m json.tool /tmp/settings_brahmstra_slworker00.json > /dev/null 2>&1 || {
+            echo "::error::INT settings file contains invalid JSON"; exit 1;
+          }
+          echo "INT settings validated"
 
-      - name: Decode env file (INT environment)
-        if: ${{ env.TARGET_HOST == 'whisky03' }}
+      - name: Decode env file (INT)
         run: |
-          echo "${{ secrets.DOT_WSLPROXY_ENV_CREDS_INT }}" | base64 -d > /tmp/.env_brahmstra_whisky03
-          # Verify file was created and is not empty
-          if [ ! -s /tmp/.env_brahmstra_whisky03 ]; then
-            echo "::warning::Env file is empty (this may be expected)"
+          echo "${{ secrets.DOT_WSLPROXY_ENV_CREDS_INT }}" | base64 -d > /tmp/.env_brahmstra_slworker00
+          if [ ! -s /tmp/.env_brahmstra_slworker00 ]; then
+            echo "::warning::INT env file is empty (may be expected)"
+          fi
+
+      - name: Run Ansible Playbook (slworker00 / int)
+        run: |
+          echo "Deploying natively to slworker00 (env: int)"
+          ansible-playbook devops/ansible/wslproxy-ops.yml \
+            -i devops/ansible/hosts \
+            -l slworker00 \
+            --extra-vars "nginx_user_password=THISCOMESFROMSECRETS target_env=int local_settings_file_path=/tmp/settings_brahmstra_slworker00.json local_env_file_path=/tmp/.env_brahmstra_slworker00"
+        env:
+          ANSIBLE_PRIVATE_KEY_FILE: ~/.ssh/id_rsa
+
+      - name: Post-deploy health gate
+        run: |
+          echo "Verifying int deployment on slworker00..."
+
+          sudo /usr/local/openresty/bin/openresty -t 2>&1 || {
+            echo "::error::Nginx config syntax check failed on slworker00"; exit 1;
+          }
+
+          sudo systemctl is-active openresty 2>&1 || {
+            echo "::error::OpenResty service is not running on slworker00"; exit 1;
+          }
+
+          for i in $(seq 1 12); do
+            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:8080/ping 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "OpenResty responding (HTTP $STATUS)"
+              exit 0
+            fi
+            echo "Attempt $i/12: HTTP $STATUS — waiting 5s..."
+            sleep 5
+          done
+          echo "::error::OpenResty not responding on slworker00 after 60s"
+          exit 1
+
+      - name: Slack notify - Int deploy failed
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: github-updates
+          SLACK_COLOR: danger
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: |
+            :x: *Stage 3 FAILED: Ansible Deploy to slworker00 (int)*
+            Native OpenResty deployment or post-deploy health check failed — pipeline stopped.
+            *Branch:* ${{ github.ref_name }} | *Commit:* `${{ github.sha }}`
+            *Triggered by:* ${{ github.actor }} (${{ github.event_name }})
+            *Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_TITLE: "WSLProxy Pipeline Failed — Stage 3"
+          SLACK_USERNAME: GitHub Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
+  # Stage 4: Test Environment
+  # Runs integration tests against natively deployed slworker00
+  # ──────────────────────────────────────────────────────
+  test-environment:
+    name: "Stage 4: Test Environment"
+    runs-on: [self-hosted, slworker00]
+    needs: [deploy-int]
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.19'
+
+      - name: Run health check tests (Go)
+        working-directory: QA
+        env:
+          TARGET_HOST: "http://localhost:8080"
+        run: |
+          go test -v -run TestHealthCheck -timeout 60s 2>&1 | tee health-results.txt
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            echo "::error::Go health check tests failed"
+            exit 1
+          fi
+          echo "Health check tests passed"
+
+      - name: Verify API endpoints
+        run: |
+          FAILED=0
+          for ENDPOINT in /ping /health /api/servers /api/rules /api/waf_rules /api/waf_policies; do
+            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "http://localhost:8080${ENDPOINT}" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              printf "  GET %-25s OK (%s)\n" "$ENDPOINT" "$STATUS"
+            else
+              printf "  GET %-25s FAIL (%s)\n" "$ENDPOINT" "$STATUS"
+              FAILED=$((FAILED+1))
+            fi
+          done
+          if [ $FAILED -gt 0 ]; then
+            echo "::error::$FAILED endpoint check(s) failed on slworker00"
+            exit 1
+          fi
+          echo "All endpoint checks passed"
+
+      - name: Slack notify - Tests failed
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: github-updates
+          SLACK_COLOR: danger
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: |
+            :x: *Stage 4 FAILED: Integration Tests on slworker00*
+            Health check or API endpoint tests failed — pipeline stopped before production.
+            *Branch:* ${{ github.ref_name }} | *Commit:* `${{ github.sha }}`
+            *Triggered by:* ${{ github.actor }} (${{ github.event_name }})
+            *Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_TITLE: "WSLProxy Pipeline Failed — Stage 4"
+          SLACK_USERNAME: GitHub Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
+  # Stage 5: Deploy Production (185.237.99.238 / pop0)
+  # Fully automated — no manual approval gate
+  # Only from release branch push or manual dispatch targeting prod
+  # ──────────────────────────────────────────────────────
+  deploy-production:
+    name: "Stage 5: Deploy Production (pop0)"
+    runs-on: [self-hosted]
+    needs: [test-environment]
+    if: >
+      (github.event_name == 'push' && github.ref == 'refs/heads/release') ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.TARGET_HOST == '185.237.99.238')
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Ansible
+        run: |
+          if command -v zypper &> /dev/null; then
+            sudo zypper install -y ansible
+          elif command -v apt-get &> /dev/null; then
+            sudo apt-get install -y ansible
           else
-            echo "✅ Env file decoded successfully"
+            echo "::error::No supported package manager found (zypper or apt-get)"
+            exit 1
           fi
+          export ANSIBLE_HOST_KEY_CHECKING=False
 
-      - name: Decode settings file (PROD environment)
-        if: ${{ env.TARGET_HOST == '185.237.99.238' }}
+      - name: Decode settings file (PROD)
         run: |
           echo "${{ secrets.DOT_WSLPROXY_SETTINGS_PROD }}" | base64 -d > /tmp/settings_brahmstra_prod.json
-          # Verify file was created and is not empty
           if [ ! -s /tmp/settings_brahmstra_prod.json ]; then
-            echo "::error::Settings file is empty or failed to decode"
+            echo "::error::PROD settings file is empty or failed to decode"
             exit 1
           fi
-          # Validate JSON syntax
-          if ! python3 -m json.tool /tmp/settings_brahmstra_prod.json > /dev/null 2>&1; then
-            echo "::error::Settings file contains invalid JSON"
-            exit 1
-          fi
-          echo "✅ Settings file validated successfully"
+          python3 -m json.tool /tmp/settings_brahmstra_prod.json > /dev/null 2>&1 || {
+            echo "::error::PROD settings file contains invalid JSON"; exit 1;
+          }
+          echo "PROD settings validated"
 
-      - name: Decode env file (PROD environment)
-        if: ${{ env.TARGET_HOST == '185.237.99.238' }}
+      - name: Decode env file (PROD)
         run: |
           echo "${{ secrets.DOT_WSLPROXY_ENV_CREDS_PROD }}" | base64 -d > /tmp/.env_brahmstra_prod
-          # Verify file was created and is not empty
           if [ ! -s /tmp/.env_brahmstra_prod ]; then
-            echo "::warning::Env file is empty (this may be expected)"
-          else
-            echo "✅ Env file decoded successfully"
+            echo "::warning::PROD env file is empty (may be expected)"
           fi
 
       - name: Setup SSH and test connectivity
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          
-          # Check if SSH key exists on self-hosted runner
           if [[ -f ~/.ssh/id_rsa ]]; then
-            echo "✅ Using existing SSH key at ~/.ssh/id_rsa"
+            echo "Using existing SSH key"
           else
-            echo "::error::SSH key not found at ~/.ssh/id_rsa on self-hosted runner"
+            echo "::error::SSH key not found at ~/.ssh/id_rsa"
             exit 1
           fi
-          
-          # Add host keys to known_hosts
-          echo "Adding SSH host keys..."
-          ssh-keyscan -H ${{ env.TARGET_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
-          
-          # Test SSH connectivity
-          echo "Testing SSH connection to ${{ env.TARGET_HOST }}..."
-          if ssh -i ~/.ssh/id_rsa -o BatchMode=yes -o ConnectTimeout=10 root@${{ env.TARGET_HOST }} "echo 'SSH connection successful'" 2>&1; then
-            echo "✅ SSH connection test passed"
-          else
-            echo "::error::SSH connection test failed to root@${{ env.TARGET_HOST }}"
-            echo "Possible causes:"
-            echo "  1. The public key is not in /root/.ssh/authorized_keys on the target server"
-            echo "  2. The SSH key on this runner doesn't match"
-            echo "  3. The server is not reachable or SSH is not running"
-            exit 1
-          fi
-
-      - name: Run Ansible Playbook (INT)
-        if: ${{ env.TARGET_HOST == 'whisky03' }}
-        run: |
-          echo "Running OpenResty/Nginx playbook for ${{ env.TARGET_HOST }} (env: ${{ env.TARGET_ENV }})"
-          ansible-playbook devops/ansible/wslproxy-ops.yml -i devops/ansible/hosts -l ${{ env.TARGET_HOST }} --extra-vars "nginx_user_password=THISCOMESFROMSECRETS target_env=${{ env.TARGET_ENV }} local_settings_file_path=/tmp/settings_brahmstra_whisky03.json local_env_file_path=/tmp/.env_brahmstra_whisky03"
-        env:
-          ANSIBLE_PRIVATE_KEY_FILE: ~/.ssh/id_rsa
+          ssh-keyscan -H 185.237.99.238 >> ~/.ssh/known_hosts 2>/dev/null || true
+          ssh -i ~/.ssh/id_rsa -o BatchMode=yes -o ConnectTimeout=10 root@185.237.99.238 "echo 'SSH OK'" 2>&1 || {
+            echo "::error::SSH connection failed to root@185.237.99.238"; exit 1;
+          }
 
       - name: Run Ansible Playbook (PROD)
-        if: ${{ env.TARGET_HOST == '185.237.99.238' }}
         run: |
-          echo "Running OpenResty/Nginx playbook for ${{ env.TARGET_HOST }} (env: ${{ env.TARGET_ENV }})"
-          ansible-playbook devops/ansible/wslproxy-ops.yml -i devops/ansible/hosts -l ${{ env.TARGET_HOST }} --extra-vars "nginx_user_password=THISCOMESFROMSECRETS target_env=${{ env.TARGET_ENV }} local_settings_file_path=/tmp/settings_brahmstra_prod.json local_env_file_path=/tmp/.env_brahmstra_prod"
+          echo "Deploying to production: 185.237.99.238 (env: prod)"
+          ansible-playbook devops/ansible/wslproxy-ops.yml \
+            -i devops/ansible/hosts \
+            -l 185.237.99.238 \
+            --extra-vars "nginx_user_password=THISCOMESFROMSECRETS target_env=prod local_settings_file_path=/tmp/settings_brahmstra_prod.json local_env_file_path=/tmp/.env_brahmstra_prod"
         env:
           ANSIBLE_PRIVATE_KEY_FILE: ~/.ssh/id_rsa
 
-      - name: Workflow Summary
+      - name: Post-deploy health gate
         run: |
-          echo "=================================="
-          echo "OpenResty installation completed for host: ${{ env.TARGET_HOST }} (env: ${{ env.TARGET_ENV }})"
-          echo "=================================="
+          echo "Verifying production deployment..."
+
+          ssh -i ~/.ssh/id_rsa -o BatchMode=yes root@185.237.99.238 \
+            "/usr/local/openresty/bin/openresty -t" 2>&1 || {
+            echo "::error::Nginx config test failed on production"; exit 1;
+          }
+
+          ssh -i ~/.ssh/id_rsa -o BatchMode=yes root@185.237.99.238 \
+            "systemctl is-active openresty" 2>&1 || {
+            echo "::error::OpenResty not running on production"; exit 1;
+          }
+
+          for i in $(seq 1 10); do
+            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "https://prod-our.wslproxy.com/ping" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "Production endpoint healthy (HTTP $STATUS)"
+              exit 0
+            fi
+            echo "Attempt $i/10: HTTP $STATUS — waiting 5s..."
+            sleep 5
+          done
+          echo "::error::Production endpoint not responding after 50s"
+          exit 1
+        env:
+          ANSIBLE_PRIVATE_KEY_FILE: ~/.ssh/id_rsa
+
+      - name: Slack notify - Production deployed
+        if: success()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: github-updates
+          SLACK_COLOR: good
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: |
+            :white_check_mark: *WSLProxy deployed to production*
+            All 5 pipeline stages passed. Zero-downtime deployment complete.
+            *Host:* 185.237.99.238 (pop0)
+            *Branch:* ${{ github.ref_name }} | *Commit:* `${{ github.sha }}`
+            *Triggered by:* ${{ github.actor }} (${{ github.event_name }})
+          SLACK_TITLE: "WSLProxy Production Deployment — Success"
+          SLACK_USERNAME: GitHub Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+      - name: Slack notify - Production deploy failed
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: github-updates
+          SLACK_COLOR: danger
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: |
+            :rotating_light: *Stage 5 FAILED: Production Deployment*
+            Ansible deploy or post-deploy health check failed on 185.237.99.238.
+            *Branch:* ${{ github.ref_name }} | *Commit:* `${{ github.sha }}`
+            *Triggered by:* ${{ github.actor }} (${{ github.event_name }})
+            *Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            *Rollback:* Re-run from a previous known-good commit on the release branch.
+          SLACK_TITLE: "WSLProxy Production Deployment — FAILED"
+          SLACK_USERNAME: GitHub Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
+  # Pipeline Summary (always runs — final Slack report)
+  # ──────────────────────────────────────────────────────
+  pipeline-summary:
+    name: Pipeline Summary
+    runs-on: ubuntu-latest
+    needs: [build-validate, smoke-test, deploy-int, test-environment, deploy-production]
+    if: always()
+    steps:
+      - name: Pipeline Summary
+        run: |
+          echo "============================================"
+          echo "  WSLProxy Deployment Pipeline Summary"
+          echo "============================================"
           echo ""
-          echo "To deploy configs, run the 'Deploy Server Configs and Rules' workflow separately."
+          echo "  Stage 1 — Build & Validate:      ${{ needs.build-validate.result }}"
+          echo "  Stage 2 — Smoke Test (Docker):    ${{ needs.smoke-test.result }}"
+          echo "  Stage 3 — Deploy Int (Ansible):   ${{ needs.deploy-int.result }}"
+          echo "  Stage 4 — Test Environment:       ${{ needs.test-environment.result }}"
+          echo "  Stage 5 — Deploy Production:      ${{ needs.deploy-production.result }}"
+          echo ""
+          echo "  Commit:  ${{ github.sha }}"
+          echo "  Branch:  ${{ github.ref_name }}"
+          echo "  Trigger: ${{ github.event_name }}"
+          echo "============================================"
+
+          # Fail this job if any required stage failed (makes the overall workflow status red)
+          if [[ "${{ needs.build-validate.result }}" == "failure" ]] || \
+             [[ "${{ needs.smoke-test.result }}" == "failure" ]] || \
+             [[ "${{ needs.deploy-int.result }}" == "failure" ]] || \
+             [[ "${{ needs.test-environment.result }}" == "failure" ]] || \
+             [[ "${{ needs.deploy-production.result }}" == "failure" ]]; then
+            echo "::error::Pipeline failed — see stage results above"
+            exit 1
+          fi

--- a/.github/workflows/deploy-configs.yml
+++ b/.github/workflows/deploy-configs.yml
@@ -29,7 +29,7 @@ on:
         required: true
         options:
           - 185.237.99.238
-          - whisky03
+          - slworker00
 
       DRY_RUN:
         type: boolean

--- a/devops/ansible/host_vars/slworker00/vars.yaml
+++ b/devops/ansible/host_vars/slworker00/vars.yaml
@@ -1,0 +1,13 @@
+local_settings_file_path: "/Users/balinderwalia/Documents/Work/aws_keys/settings_slworker00.json"
+local_env_file_path: "/Users/balinderwalia/Documents/Work/aws_keys/.env_slworker00"
+nginx_user_password: "!!REDACTED!!" # This is the password for the user www-data but must be encrypted using Ansible Vault
+host_lan_ip: "192.168.1.189"
+nginx_web_ui_enabled: ""
+nginx_rest_api_server_enabled: ""
+nginx_data_sync_enabled: ""
+node_max_old_space_size: 1024
+nginx_s3_proxy_pass_host_ip: "192.168.1.200"
+nginx_s3_server_name: "s3.workstation.co.uk"
+nginx_s3_cli_server_name: "s3-cli.workstation.co.uk"
+nginx_k3s_dashboard_server_name: "k3s-dashboard.workstation.co.uk"
+openresty_admin_secondary_color: "#D91656"

--- a/devops/ansible/hosts
+++ b/devops/ansible/hosts
@@ -3,7 +3,7 @@
 3.9.40.237 ansible_user=ubuntu
 
 ubworker01 ansible_user=bwalia
-whisky03 ansible_user=bwalia
+slworker00 ansible_user=bwalia
 192.168.1.189 ansible_user=bwalia
 whisky10 ansible_user=bwalia
 whisky06 ansible_user=bwalia
@@ -18,7 +18,7 @@ whisky08 ansible_user=bwalia
 192.168.1.77 ansible_user=bwalia
 
 [openresty_int]
-whisky03 ansible_user=bwalia
+slworker00 ansible_user=bwalia
 
 [openresty_test]
 # Add test servers here


### PR DESCRIPTION
## Summary

- Replaces the single-job deployment workflow with a fully automated **5-stage gated pipeline**: Build & Validate → Docker Compose Smoke Test → Ansible Int Deploy → Integration Tests → Production Deploy
- **No human-in-loop** — every stage sends Slack notification on failure and stops the pipeline immediately (fail-fast)
- Stages 2–4 run on `slworker00` (replaces `whisky03` everywhere); production deploys to `185.237.99.238` (pop0) via Ansible over SSH
- Production deploy only triggers from `release` branch pushes (main branch stops after stage 4)
- Adds visual pipeline README at `.github/workflows/README.md` for developer reference

### Pipeline Stages

```
Stage 1: Build & Validate       [ubuntu-latest]   — JSON + Jinja2 config validation
Stage 2: Smoke Test              [slworker00]      — Docker Compose up, health + API checks, cleanup
Stage 3: Deploy Int (Ansible)    [slworker00]      — Ansible native deploy, nginx + systemctl gates
Stage 4: Test Environment        [slworker00]      — Go health check tests, API endpoint verification
Stage 5: Deploy Production       [self-hosted]     — Ansible deploy to pop0, health gate, Slack notify
```

### Files Changed

| File | Change |
|------|--------|
| `.github/workflows/build-deploy-wslproxy.yml` | Complete rewrite — 5-stage pipeline |
| `.github/workflows/deploy-configs.yml` | whisky03 → slworker00 in target host options |
| `.github/workflows/README.md` | New — visual pipeline diagram + docs |
| `devops/ansible/hosts` | whisky03 → slworker00 in inventory groups |
| `devops/ansible/host_vars/slworker00/vars.yaml` | New — host vars for slworker00 |

## Test plan

- [ ] Manual dispatch with TARGET_ENV=int, TARGET_HOST=slworker00 — verify stages 1–4 run, stage 5 skipped
- [ ] Push to main — verify stages 1–4 run, stage 5 skipped (main branch stops before prod)
- [ ] Push to release — verify all 5 stages run sequentially with fail-fast
- [ ] Introduce invalid JSON in data/ — verify stage 1 fails and Slack notification fires
- [ ] Verify Slack notifications fire on any stage failure
- [ ] Verify Docker Compose cleanup runs even on smoke test failure (stage 2 if: always())

🤖 Generated with [Claude Code](https://claude.com/claude-code)