### PR TITLE
Fix e2e workflow YAML parse errors

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,19 +18,33 @@ on:
           - prod
           - int
 
-concurrency:
-  group: e2e-tests-${{ github.ref }}-${{ matrix.environment || 'prod' }}
-  cancel-in-progress: true
-
 jobs:
+  setup:
+    name: "Setup test matrix"
+    runs-on: [self-hosted]
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Determine environments to test
+        id: set-matrix
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo 'matrix={"environment":["${{ inputs.TARGET_ENV }}"]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"environment":["prod","int"]}' >> "$GITHUB_OUTPUT"
+          fi
+
   e2e:
     name: "E2E Tests (${{ matrix.environment }})"
+    needs: setup
     runs-on: [self-hosted]
     timeout-minutes: 10
+    concurrency:
+      group: e2e-tests-${{ github.ref }}-${{ matrix.environment }}
+      cancel-in-progress: true
     strategy:
       fail-fast: false
-      matrix:
-        environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.TARGET_ENV)) || fromJSON('["prod", "int"]') }}
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Summary
- Fixes workflow file syntax errors causing all E2E runs to fail with "workflow file issue"
- Moved `concurrency` from workflow level to job level (can't reference `matrix` context at workflow level)
- Replaced fragile inline `fromJSON(format(...))` matrix expression with a dedicated `setup` job that computes the matrix JSON dynamically
- On schedule/push: both `prod` and `int` environments run
- On `workflow_dispatch`: only the selected environment runs

## Test plan
- [ ] Merge this PR and verify the daily scheduled E2E run succeeds
- [ ] Manually trigger workflow_dispatch with `TARGET_ENV=prod` — only prod job runs
- [ ] Manually trigger workflow_dispatch with `TARGET_ENV=int` — only int job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)