### PR TITLE
Fix sidebar selector strict mode violation in dashboard e2e test

### DIFF
--- a/openresty-admin/e2e/dashboard.spec.js
+++ b/openresty-admin/e2e/dashboard.spec.js
@@ -50,8 +50,8 @@ test.describe('Dashboard Integration', { tag: '@regression' }, () => {
   test('navigation sidebar contains key menu items', async ({ page }) => {
     await page.goto('/#/');
     await expect(page.locator('#main-content')).toBeVisible({ timeout: 15000 });
-    await expect(page.locator('a[href*="#/servers"]')).toBeVisible({ timeout: 10000 });
-    await expect(page.locator('a[href*="#/rules"]')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('a[role="menuitem"][href*="#/servers"]')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('a[role="menuitem"][href*="#/rules"]')).toBeVisible({ timeout: 10000 });
   });
 
   test('profiles page loads', async ({ page }) => {


### PR DESCRIPTION
Scope menu item selectors with role="menuitem" to avoid matching duplicate links in #main-content.