### PR TITLE
Fix OpenResty startup: pin lua-resty-jwt to 0.2.3

### DIFF
--- a/devops/ansible/roles/wslproxy/tasks/deploy_app.yml
+++ b/devops/ansible/roles/wslproxy/tasks/deploy_app.yml
@@ -71,7 +71,18 @@
     # Install rocks to OpenResty tree so nginx can find them
     TREE="/usr/local/openresty/luajit"
     FAILED=0
-    for rock in lua-resty-jwt lua-resty-session lua-resty-http lua-resty-openidc base64 lua-resty-redis-connector lua-resty-dns lua-resty-resolver luafilesystem lua-resty-auto-ssl pgmoon lua-resty-consul; do
+
+    # Pin lua-resty-jwt to 0.2.3 — version 0.3.1 requires resty.utils which
+    # is not available, causing OpenResty to fail on startup
+    echo "=== Installing lua-resty-jwt 0.2.3 (pinned) ==="
+    if luarocks install --tree="$TREE" lua-resty-jwt 0.2.3 2>&1; then
+      echo "+++ lua-resty-jwt 0.2.3 OK"
+    else
+      echo "--- lua-resty-jwt 0.2.3 FAILED"
+      FAILED=1
+    fi
+
+    for rock in lua-resty-session lua-resty-http lua-resty-openidc base64 lua-resty-redis-connector lua-resty-dns lua-resty-resolver luafilesystem lua-resty-auto-ssl pgmoon lua-resty-consul; do
       echo "=== Installing $rock ==="
       if luarocks install --tree="$TREE" "$rock" 2>&1; then
         echo "+++ $rock OK"


### PR DESCRIPTION
## Summary
- **Root cause**: `lua-resty-jwt` was auto-upgraded from `0.2.3` to `0.3.1` by luarocks, and the new version requires `resty.utils` which is not available in the OpenResty Lua path
- **Error**: OpenResty fails to start with `module 'resty.utils' not found` at `resty/jwt.lua:11` → `api/init.lua:3`
- **Fix**: Pin `lua-resty-jwt` to version `0.2.3` (last known working version) by installing it with an explicit version before the other rocks

## Test plan
- [ ] Pipeline Stage 2 (Deploy Int) should pass — OpenResty starts successfully
- [ ] Health gate (`/ping`) returns 200
- [ ] Verify `lua-resty-jwt 0.2.3` appears in luarocks install output (not 0.3.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)