### PR TITLE
Fix 500 error when using least-busy backend routing

### DIFF
--- a/api/gateway_ack.lua
+++ b/api/gateway_ack.lua
@@ -266,7 +266,7 @@ local function gatewayHostAuthenticate(rule)
 end
 
 local function gatewayHostRulesParser(rules, ruleId, priority, message, statusCode, redirectUri, isConsul,
-                                      consulDomainName, stripPath)
+                                      consulDomainName, stripPath, ruleResponse)
     local chk_path = (rules.path ~= nil and type(rules.path) ~= "userdata") and trimWhitespace(rules.path) or rules.path
     local isPathPass, failMessage, isTokenPass = false, "", false
     local finalResult, results = {}, {}
@@ -364,6 +364,10 @@ local function gatewayHostRulesParser(rules, ruleId, priority, message, statusCo
     rules.isConsul = isConsul
     rules.consulDomainName = consulDomainName
     rules.strip_path = stripPath
+    rules.id = ruleId
+    if ruleResponse then
+        rules.response = ruleResponse
+    end
     results["country"] = isCountryPass
     results["priority"] = priority
     results["message"] = message
@@ -404,7 +408,8 @@ local function gatewayRequestHandler(ruleId)
             local results = gatewayHostRulesParser(ruleFromRedis.match.rules, ruleFromRedis.id, ruleFromRedis.priority,
                 ruleFromRedis.match.response.message, ruleFromRedis.match.response.code,
                 ruleFromRedis.match.response.redirect_uri, ruleFromRedis.match.response.is_consul,
-                ruleFromRedis.match.response.consul_domain_name, ruleFromRedis.match.response.strip_path)
+                ruleFromRedis.match.response.consul_domain_name, ruleFromRedis.match.response.strip_path,
+                ruleFromRedis.match.response)
             return results
         end
     end

--- a/api/gateway_resp.lua
+++ b/api/gateway_resp.lua
@@ -37,12 +37,8 @@ elseif selectedRule.statusCode == 302 then
 elseif selectedRule.statusCode == 305 then
     local proxy_server_name = primaryNameserver
 
-    if selectedRule.redirectUri == nil then
-        ngx.say("Redirect url not found: ")
-        ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
-    end
-
     -- Traffic Router: multi-backend weighted routing (fail-open)
+    -- Must run BEFORE the redirectUri nil check so backends can populate redirectUri
     local tr_ok, TrafficRouter = pcall(require, "traffic_router")
     if tr_ok and TrafficRouter and selectedRule.rule_data then
         local response = selectedRule.rule_data.response or selectedRule.rule_data
@@ -67,6 +63,11 @@ elseif selectedRule.statusCode == 305 then
                 ngx.header["Set-Cookie"] = ngx.ctx._traffic_router_set_cookie
             end
         end
+    end
+
+    if selectedRule.redirectUri == nil then
+        ngx.say("Redirect url not found: ")
+        ngx.exit(ngx.HTTP_INTERNAL_SERVER_ERROR)
     end
 
     -- Strip matched path prefix from URI before proxying (like K8s Ingress rewrite-target)


### PR DESCRIPTION
## Summary

- **`api/gateway_ack.lua`**: `rule_data` was set to `match.rules` (path-matching config only), never including `match.response` where `backends` and `routing.mode` are defined. The traffic router could never see backends — `selectedRule.rule_data.response` was always `nil`. Fixed by passing `match.response` as an extra argument to `gatewayHostRulesParser` and attaching it as `rules.response` (plus `rules.id` for rule ID lookups).
- **`api/gateway_resp.lua`**: The `redirectUri == nil → 500` guard fired **before** the traffic router ran. Rules that define backends without a `redirect_uri` (the typical least-busy setup) would always 500 before backend selection could populate `redirectUri`. Fixed by moving the traffic router block above the nil check.

## Test plan

- [ ] Create a rule with backends (e.g. `host1:8080` + `host2:8080`) and routing mode set to **Least Busy**
- [ ] Attach the rule to a virtual server (no `redirect_uri` needed)
- [ ] Send requests — should route to backends without 500
- [ ] Verify other routing modes (weighted, round_robin, header, cookie) still work
- [ ] Verify rules with a `redirect_uri` and no backends still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)