### PR TITLE
Fast deploy: skip OpenResty build and OS updates by default

### DIFF
--- a/.github/workflows/build-deploy-wslproxy.yml
+++ b/.github/workflows/build-deploy-wslproxy.yml
@@ -2,6 +2,7 @@ name: Build and Deploy WSLProxy
 # Pipeline: Validate → Deploy Int → Test → Deploy WSL1 (auto on push)
 # Prod & DIYTaxReturn deploy manually or via "all" target
 # Fail-fast: any stage failure stops the pipeline and sends Slack notification immediately
+# Default: code-only deploy (lua, nginx conf, data, admin UI). Tick FULL_BUILD to compile OpenResty & update OS packages.
 
 on:
   push:
@@ -49,6 +50,11 @@ on:
         description: "Only rebuild & deploy openresty-admin dashboard UI (skip full build)"
         default: false
 
+      FULL_BUILD:
+        type: boolean
+        description: "Full build: compile OpenResty, install luarocks, update OS packages (slow). Default: off (code-only deploy)"
+        default: false
+
 # Prevent concurrent deployments to same ref (but don't cancel in-progress)
 concurrency:
   group: deploy-${{ github.ref }}
@@ -57,6 +63,7 @@ concurrency:
 env:
   DEPLOY_BRANCH: ${{ github.event.inputs.DEPLOY_BRANCH || github.ref_name }}
   DEPLOY_DASHBOARD_ONLY: ${{ github.event.inputs.DEPLOY_DASHBOARD_ONLY || 'false' }}
+  FULL_BUILD: ${{ github.event.inputs.FULL_BUILD || 'false' }}
   TARGET_HOST: ${{ github.event.inputs.TARGET_HOST || '187.124.112.155' }}
   TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '187.124.112.155' && 'prod' || github.event.inputs.TARGET_HOST == 'slworker00' && 'int' || 'prod') }}
   API_DOMAINNAME_ENDPOINT: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '187.124.112.155' && 'prod' || github.event.inputs.TARGET_HOST == 'slworker00' && 'int' || 'prod') }}.wslproxy.com
@@ -191,8 +198,11 @@ jobs:
           if [[ "${{ env.DEPLOY_DASHBOARD_ONLY }}" == "true" ]]; then
             TAGS_FLAG="--tags dashboard"
             echo "Dashboard-only deploy to slworker00 (env: int)"
+          elif [[ "${{ env.FULL_BUILD }}" != "true" ]]; then
+            TAGS_FLAG="--skip-tags base_packages,build"
+            echo "Code-only deploy to slworker00 (env: int) — skipping OS updates and OpenResty build"
           else
-            echo "Deploying natively to slworker00 (env: int) via local connection"
+            echo "Full build + deploy to slworker00 (env: int) via local connection"
           fi
           sudo ansible-playbook devops/ansible/wslproxy-ops.yml \
             -i devops/ansible/hosts \
@@ -412,8 +422,11 @@ jobs:
           if [[ "${{ env.DEPLOY_DASHBOARD_ONLY }}" == "true" ]]; then
             TAGS_FLAG="--tags dashboard"
             echo "Dashboard-only deploy to production: 187.124.112.155"
+          elif [[ "${{ env.FULL_BUILD }}" != "true" ]]; then
+            TAGS_FLAG="--skip-tags base_packages,build"
+            echo "Code-only deploy to production: 187.124.112.155 — skipping OS updates and OpenResty build"
           else
-            echo "Deploying to production: 187.124.112.155 (env: prod)"
+            echo "Full build + deploy to production: 187.124.112.155 (env: prod)"
           fi
           ansible-playbook devops/ansible/wslproxy-ops.yml \
             -i devops/ansible/hosts \
@@ -573,8 +586,11 @@ jobs:
           if [[ "${{ env.DEPLOY_DASHBOARD_ONLY }}" == "true" ]]; then
             TAGS_FLAG="--tags dashboard"
             echo "Dashboard-only deploy to DIYTaxReturn: 187.77.179.206"
+          elif [[ "${{ env.FULL_BUILD }}" != "true" ]]; then
+            TAGS_FLAG="--skip-tags base_packages,build"
+            echo "Code-only deploy to DIYTaxReturn: 187.77.179.206 — skipping OS updates and OpenResty build"
           else
-            echo "Deploying to DIYTaxReturn: 187.77.179.206 (env: diytaxreturn)"
+            echo "Full build + deploy to DIYTaxReturn: 187.77.179.206 (env: diytaxreturn)"
           fi
           export ANSIBLE_HOST_KEY_CHECKING=False
           ansible-playbook devops/ansible/wslproxy-ops.yml \
@@ -732,8 +748,11 @@ jobs:
           if [[ "${{ env.DEPLOY_DASHBOARD_ONLY }}" == "true" ]]; then
             TAGS_FLAG="--tags dashboard"
             echo "Dashboard-only deploy to WSL1: 187.124.112.156"
+          elif [[ "${{ env.FULL_BUILD }}" != "true" ]]; then
+            TAGS_FLAG="--skip-tags base_packages,build"
+            echo "Code-only deploy to WSL1: 187.124.112.156 — skipping OS updates and OpenResty build"
           else
-            echo "Deploying to WSL1: 187.124.112.156 (env: wsl1)"
+            echo "Full build + deploy to WSL1: 187.124.112.156 (env: wsl1)"
           fi
           export ANSIBLE_HOST_KEY_CHECKING=False
           ansible-playbook devops/ansible/wslproxy-ops.yml \

--- a/api/api.lua
+++ b/api/api.lua
@@ -4154,6 +4154,50 @@ local function handle_get_request(args, path)
         ngx.exit(ngx.HTTP_OK)
     end
 
+    -- GET /api/change-requests/config - Get CR config (whether passphrase is set, etc.)
+    if path == "change-requests/config" then
+        local config = CRManager.get_cr_config()
+        ngx.say(cjson.encode({ data = {
+            has_passphrase = (config.approval_passphrase ~= nil and config.approval_passphrase ~= ""),
+            required_approvals = config.required_approvals or 2,
+            passphrase_set_by = config.passphrase_set_by,
+            passphrase_set_at = config.passphrase_set_at,
+        }}))
+        ngx.exit(ngx.HTTP_OK)
+    end
+
+    -- GET /api/versions/status/{type}/{profile} - Bulk version status for all resources
+    if string.find(path, "^versions/status/[^/]+/[^/]+$") then
+        local res_type, profile = path:match("^versions/status/([^/]+)/([^/]+)$")
+        if res_type and profile then
+            local statuses = {}
+            local versions_base = configPath .. "data/versions/" .. res_type .. "/" .. profile
+            local dir_ok, iter, dir_obj = pcall(LFS.dir, versions_base)
+            if dir_ok and iter then
+                for entry in iter, dir_obj do
+                    if entry ~= "." and entry ~= ".." then
+                        local meta_path = versions_base .. "/" .. entry .. "/meta.json"
+                        local meta_file = io.open(meta_path, "rb")
+                        if meta_file then
+                            local content = meta_file:read("*a")
+                            meta_file:close()
+                            local ok, meta = pcall(cjson.decode, content)
+                            if ok and meta then
+                                statuses[entry] = {
+                                    live_version = meta.live_version,
+                                    latest_version = meta.latest_version,
+                                    managed = true,
+                                }
+                            end
+                        end
+                    end
+                end
+            end
+            ngx.say(cjson.encode({ data = statuses }))
+            ngx.exit(ngx.HTTP_OK)
+        end
+    end
+
     -- GET /api/change-requests/{cr_id} - Get specific CR
     if string.find(path, "^change%-requests/CR%-") then
         local cr_id = path:match("^change%-requests/(CR%-%d+)$")
@@ -4730,7 +4774,8 @@ local function handle_put_request(args, path)
                 local payloads = Helper.GetPayloads(args)
                 local user = (payloads and payloads.user) or ngx.req.get_headers()["x-user"] or "system"
                 local comment = payloads and payloads.comment
-                local cr, err = CRManager.approve_cr(cr_id, user, comment)
+                local passphrase = payloads and payloads.passphrase
+                local cr, err = CRManager.approve_cr(cr_id, user, comment, passphrase)
                 if cr then
                     ngx.say(cjson.encode({ data = cr, message = "CR approved" }))
                 else
@@ -4771,6 +4816,23 @@ local function handle_put_request(args, path)
                 end
                 ngx.exit(ngx.HTTP_OK)
             end
+        end
+
+        -- PUT /api/change-requests/config/passphrase - Set CR approval passphrase
+        if path == "change-requests/config/passphrase" then
+            local payloads = Helper.GetPayloads(args)
+            if not payloads or not payloads.passphrase then
+                Errors.throwError("passphrase is required", ngx.HTTP_BAD_REQUEST)
+                ngx.exit(ngx.HTTP_BAD_REQUEST)
+            end
+            local user = (payloads and payloads.user) or ngx.req.get_headers()["x-user"] or "system"
+            local ok, err = CRManager.set_passphrase(payloads.passphrase, user)
+            if ok then
+                ngx.say(cjson.encode({ message = "CR approval passphrase updated" }))
+            else
+                Errors.throwError(err or "Failed to set passphrase", ngx.HTTP_BAD_REQUEST)
+            end
+            ngx.exit(ngx.HTTP_OK)
         end
 
         -- PUT /api/versions/{type}/{profile}/{name}/{version} - Update a draft version

--- a/api/cr_manager.lua
+++ b/api/cr_manager.lua
@@ -27,6 +27,10 @@ local function get_cr_dir()
     return configPath .. "data/change_requests"
 end
 
+local function get_cr_config_path()
+    return get_cr_dir() .. "/cr_config.json"
+end
+
 local function ensure_directory(path)
     local ok, attr = pcall(function()
         return lfs.attributes(path)
@@ -106,6 +110,65 @@ end
 
 local function get_cr_path(cr_id)
     return get_cr_dir() .. "/" .. cr_id .. ".json"
+end
+
+-- ============================================================
+-- Passphrase management
+-- ============================================================
+
+--- Get CR config (passphrase, settings)
+function _M.get_cr_config()
+    local config = read_json_file(get_cr_config_path())
+    if not config then
+        config = {
+            approval_passphrase = nil,
+            required_approvals = 2,
+        }
+    end
+    return config
+end
+
+--- Set the CR approval passphrase
+-- @param passphrase string: The passphrase to set
+-- @param user string: User setting the passphrase
+-- @return boolean, string|nil
+function _M.set_passphrase(passphrase, user)
+    if not passphrase or passphrase == "" then
+        return false, "Passphrase cannot be empty"
+    end
+    local config = _M.get_cr_config()
+    config.approval_passphrase = passphrase
+    config.passphrase_set_by = user
+    config.passphrase_set_at = os.time()
+    local cr_dir = get_cr_dir()
+    local ok, err = write_json_file(get_cr_config_path(), config, cr_dir)
+    if not ok then
+        return false, err
+    end
+    AuditLogger.log("cr_passphrase_updated", user, "system", "cr_config", {})
+    return true
+end
+
+--- Check if passphrase is configured
+function _M.has_passphrase()
+    local config = _M.get_cr_config()
+    return config.approval_passphrase ~= nil and config.approval_passphrase ~= ""
+end
+
+--- Validate a passphrase
+local function validate_passphrase(passphrase)
+    local config = _M.get_cr_config()
+    if not config.approval_passphrase or config.approval_passphrase == "" then
+        -- No passphrase configured, allow through
+        return true
+    end
+    if not passphrase or passphrase == "" then
+        return false, "Approval passphrase is required. Contact your admin for the CR approval code."
+    end
+    if passphrase ~= config.approval_passphrase then
+        return false, "Invalid approval passphrase"
+    end
+    return true
 end
 
 -- ============================================================
@@ -211,7 +274,7 @@ end
 -- @param comment string|nil: Approval comment
 -- @return table|nil: Updated CR
 -- @return string|nil: Error message
-function _M.approve_cr(cr_id, user, comment)
+function _M.approve_cr(cr_id, user, comment, passphrase)
     local cr, err = _M.get_cr(cr_id)
     if not cr then
         return nil, err or "CR not found"
@@ -219,6 +282,12 @@ function _M.approve_cr(cr_id, user, comment)
 
     if cr.state ~= "pending_approval" then
         return nil, "CR is not in 'pending_approval' state, current state: " .. cr.state
+    end
+
+    -- Validate approval passphrase
+    local pass_ok, pass_err = validate_passphrase(passphrase)
+    if not pass_ok then
+        return nil, pass_err
     end
 
     -- 4-eyes: Creator cannot approve their own CR

--- a/api/version_manager.lua
+++ b/api/version_manager.lua
@@ -359,11 +359,23 @@ function _M.activate_version(resource_type, profile, resource_name, version, use
     meta.live_version = version
     write_meta(resource_type, profile, resource_name, meta)
 
-    -- Step 4: Copy config to main data directory
+    -- Step 4: Copy config to main data directory with _version_control metadata
     local live_data_path = get_live_data_path(resource_type, profile, resource_name)
     if live_data_path and entry.config_payload then
         local data_dir = live_data_path:match("^(.*)/[^/]+$")
-        write_json_file(live_data_path, entry.config_payload, data_dir)
+        -- Clone config and embed version control metadata
+        local live_config = {}
+        for k, v in pairs(entry.config_payload) do
+            live_config[k] = v
+        end
+        live_config._version_control = {
+            managed = true,
+            live_version = version,
+            activated_at = os.time(),
+            activated_by = user,
+            cr_id = entry.cr_id,
+        }
+        write_json_file(live_data_path, live_config, data_dir)
     end
 
     -- Step 5: Trigger nginx reload
@@ -558,6 +570,19 @@ function _M.initialize_resource(resource_type, profile, resource_name, user)
     meta.latest_version = 1
     meta.live_version = 1
     write_meta(resource_type, profile, resource_name, meta)
+
+    -- Write _version_control metadata to the live config file
+    local live_config = {}
+    for k, v in pairs(config) do
+        live_config[k] = v
+    end
+    live_config._version_control = {
+        managed = true,
+        live_version = 1,
+        activated_at = os.time(),
+        activated_by = user or "system",
+    }
+    write_json_file(live_data_path, live_config)
 
     AuditLogger.log("version_migrated", user or "system", resource_type, resource_name, {
         version = 1,

--- a/devops/ansible/roles/wslproxy/tasks/deploy_app.yml
+++ b/devops/ansible/roles/wslproxy/tasks/deploy_app.yml
@@ -29,7 +29,7 @@
     src: cdn-dependencies.sh.j2
     dest: /tmp/cdn-dependencies.sh
     mode: 0777
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 - name: Ensure nginx data directory exists
   ansible.builtin.file:
@@ -104,23 +104,23 @@
     exit $FAILED
   register: luarocks_install_result
   ignore_errors: true
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 - name: Show luarocks install output
   debug:
     msg: "{{ luarocks_install_result.stdout_lines }}"
   when: luarocks_install_result is defined
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 - name: Execute the cdn-dependencies.sh script
   shell: /tmp/cdn-dependencies.sh 2>&1
   register: cdn_deps_result
   async: 300
   poll: 15
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 - name: Show cdn-dependencies output (last 40 lines)
   debug:
     msg: "{{ cdn_deps_result.stdout_lines[-40:] }}"
   when: cdn_deps_result is defined
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]

--- a/devops/ansible/roles/wslproxy/tasks/main.yml
+++ b/devops/ansible/roles/wslproxy/tasks/main.yml
@@ -11,10 +11,10 @@
     - "Debian.yml"
   tags: [always]
 
-# Step 1: OS-specific package refresh
+# Step 1: OS-specific package refresh (heavy — skip with --skip-tags build)
 - name: Run OS-specific setup
   include_tasks: "os_setup_{{ ansible_os_family | lower }}.yml"
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 # Step 2: Load host variables
 - name: Load host variables
@@ -25,10 +25,10 @@
   include_tasks: user_setup.yml
   tags: [openresty, lapis, dashboard, nginx]
 
-# Step 4: Bootstrap and compile OpenResty from source
+# Step 4: Bootstrap and compile OpenResty from source (heavy — skip with --skip-tags build)
 - name: Bootstrap and build OpenResty
   include_tasks: openresty_build.yml
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 # Step 5: Nginx configuration directories and base configs
 - name: Configure nginx

--- a/openresty-admin/src/ChangeRequests/ChangeRequestList.jsx
+++ b/openresty-admin/src/ChangeRequests/ChangeRequestList.jsx
@@ -30,6 +30,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import SettingsIcon from "@mui/icons-material/Settings";
 import { useNotify } from "react-admin";
 import StatusBadge from "../component/StatusBadge";
 
@@ -65,7 +66,12 @@ const ChangeRequestList = () => {
   const [actionCR, setActionCR] = useState(null);
   const [approverUser, setApproverUser] = useState("");
   const [approveComment, setApproveComment] = useState("");
+  const [approvePassphrase, setApprovePassphrase] = useState("");
   const [rejectReason, setRejectReason] = useState("");
+  const [crConfig, setCrConfig] = useState({});
+  const [passphraseDialogOpen, setPassphraseDialogOpen] = useState(false);
+  const [newPassphrase, setNewPassphrase] = useState("");
+  const [passphraseUser, setPassphraseUser] = useState("");
 
   const fetchCRs = useCallback(async () => {
     setLoading(true);
@@ -95,10 +101,22 @@ const ChangeRequestList = () => {
     }
   }, []);
 
+  const fetchCRConfig = useCallback(async () => {
+    try {
+      const url = `${API_URL}/change-requests/config?timestamp=${Date.now()}`;
+      const response = await fetch(url, { method: "GET", headers: getHeaders() });
+      const result = await response.json();
+      setCrConfig(result.data || {});
+    } catch (error) {
+      console.error("Failed to fetch CR config:", error);
+    }
+  }, []);
+
   useEffect(() => {
     fetchCRs();
     fetchPendingCount();
-  }, [fetchCRs, fetchPendingCount]);
+    fetchCRConfig();
+  }, [fetchCRs, fetchPendingCount, fetchCRConfig]);
 
   const handleViewCR = (cr) => {
     setSelectedCR(cr);
@@ -112,7 +130,7 @@ const ChangeRequestList = () => {
       const response = await fetch(url, {
         method: "PUT",
         headers: getHeaders(),
-        body: JSON.stringify({ user: approverUser, comment: approveComment }),
+        body: JSON.stringify({ user: approverUser, comment: approveComment, passphrase: approvePassphrase }),
       });
       const result = await response.json();
       if (response.ok) {
@@ -120,6 +138,7 @@ const ChangeRequestList = () => {
         setApproveDialogOpen(false);
         setApproverUser("");
         setApproveComment("");
+        setApprovePassphrase("");
         fetchCRs();
         fetchPendingCount();
       } else {
@@ -127,6 +146,30 @@ const ChangeRequestList = () => {
       }
     } catch (error) {
       notify("Failed to approve CR", { type: "error" });
+    }
+  };
+
+  const handleSetPassphrase = async () => {
+    if (!newPassphrase || !passphraseUser) return;
+    try {
+      const url = `${API_URL}/change-requests/config/passphrase`;
+      const response = await fetch(url, {
+        method: "PUT",
+        headers: getHeaders(),
+        body: JSON.stringify({ passphrase: newPassphrase, user: passphraseUser }),
+      });
+      if (response.ok) {
+        notify("CR approval passphrase updated", { type: "success" });
+        setPassphraseDialogOpen(false);
+        setNewPassphrase("");
+        setPassphraseUser("");
+        fetchCRConfig();
+      } else {
+        const result = await response.json();
+        notify(result?.data?.message || "Failed to set passphrase", { type: "error" });
+      }
+    } catch (error) {
+      notify("Failed to set passphrase", { type: "error" });
     }
   };
 
@@ -199,6 +242,15 @@ const ChangeRequestList = () => {
         </TextField>
         <Button variant="outlined" size="small" startIcon={<RefreshIcon />} onClick={fetchCRs}>
           Refresh
+        </Button>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<SettingsIcon />}
+          onClick={() => setPassphraseDialogOpen(true)}
+          color={crConfig.has_passphrase ? "success" : "warning"}
+        >
+          {crConfig.has_passphrase ? "Passphrase Set" : "Set Approval Passphrase"}
         </Button>
       </Stack>
 
@@ -444,6 +496,9 @@ const ChangeRequestList = () => {
           <Alert severity="info" sx={{ mb: 2 }}>
             <strong>4-Eyes Principle:</strong> You cannot approve a CR you created.
             Two different users must approve before the change goes live.
+            {crConfig.has_passphrase && (
+              <><br /><strong>Approval passphrase required.</strong> Contact your admin if you don't have it.</>
+            )}
           </Alert>
           <Typography variant="body2" sx={{ mb: 2 }}>
             Resource: {actionCR?.resource_name} (v{actionCR?.version})
@@ -457,6 +512,19 @@ const ChangeRequestList = () => {
             required
             helperText="Must be different from the CR creator"
           />
+          {crConfig.has_passphrase && (
+            <TextField
+              label="Approval Passphrase"
+              fullWidth
+              type="password"
+              value={approvePassphrase}
+              onChange={(e) => setApprovePassphrase(e.target.value)}
+              sx={{ mb: 2 }}
+              required
+              helperText="Secret code required to approve changes"
+              inputProps={{ autoComplete: "new-password" }}
+            />
+          )}
           <TextField
             label="Comment (optional)"
             fullWidth
@@ -468,8 +536,54 @@ const ChangeRequestList = () => {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setApproveDialogOpen(false)}>Cancel</Button>
-          <Button variant="contained" color="success" onClick={handleApprove} disabled={!approverUser}>
+          <Button
+            variant="contained"
+            color="success"
+            onClick={handleApprove}
+            disabled={!approverUser || (crConfig.has_passphrase && !approvePassphrase)}
+          >
             Approve
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Set Passphrase Dialog */}
+      <Dialog open={passphraseDialogOpen} onClose={() => setPassphraseDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>CR Approval Passphrase</DialogTitle>
+        <DialogContent>
+          <Alert severity={crConfig.has_passphrase ? "success" : "warning"} sx={{ mb: 2 }}>
+            {crConfig.has_passphrase
+              ? `Passphrase is configured (set by ${crConfig.passphrase_set_by || "unknown"}).
+                 Anyone approving a CR must provide this passphrase.`
+              : "No passphrase is configured. Anyone can approve CRs without a secret code. Set one to secure the approval process."}
+          </Alert>
+          <TextField
+            label="Your Username"
+            fullWidth
+            value={passphraseUser}
+            onChange={(e) => setPassphraseUser(e.target.value)}
+            sx={{ mb: 2 }}
+            required
+          />
+          <TextField
+            label={crConfig.has_passphrase ? "New Passphrase (replaces existing)" : "Set Passphrase"}
+            fullWidth
+            type="password"
+            value={newPassphrase}
+            onChange={(e) => setNewPassphrase(e.target.value)}
+            required
+            helperText="This passphrase will be required for all future CR approvals"
+            inputProps={{ autoComplete: "new-password" }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPassphraseDialogOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleSetPassphrase}
+            disabled={!newPassphrase || !passphraseUser}
+          >
+            {crConfig.has_passphrase ? "Update Passphrase" : "Set Passphrase"}
           </Button>
         </DialogActions>
       </Dialog>

--- a/openresty-admin/src/Rules/Form.jsx
+++ b/openresty-admin/src/Rules/Form.jsx
@@ -785,9 +785,29 @@ const Form = () => {
         </FormDataConsumer>
 
         {/* Version History */}
-        <SectionCard title="Version History" subtitle="Track configuration versions, create drafts, and manage change requests">
-          <VersionHistoryTab resourceType="rules" />
-        </SectionCard>
+        <Card
+          variant="outlined"
+          className="section-card"
+          sx={{
+            borderColor: "primary.main",
+            borderWidth: 2,
+          }}
+        >
+          <CardContent>
+            <Typography
+              variant="subtitle1"
+              className="section-card__title"
+              sx={{ color: "primary.main" }}
+            >
+              Version History & Change Control
+            </Typography>
+            <Typography variant="body2" color="text.secondary" className="section-card__subtitle">
+              All changes stay in draft until a Change Request is created and approved.
+              Two approvers are required (4-eyes principle).
+            </Typography>
+            <VersionHistoryTab resourceType="rules" />
+          </CardContent>
+        </Card>
 
       </div>
     </SimpleForm>

--- a/openresty-admin/src/Rules/List.jsx
+++ b/openresty-admin/src/Rules/List.jsx
@@ -8,8 +8,11 @@ import {
   ReferenceInput,
   SelectInput,
   SearchInput,
-  CloneButton
+  CloneButton,
+  FunctionField,
 } from 'react-admin'
+import { Chip, useTheme, alpha } from "@mui/material";
+import HistoryIcon from "@mui/icons-material/HistoryRounded";
 import ExportJsonButton from './toolbar/ExportJsonButton';
 import ImportJsonButton from '../component/ImportJsonButton';
 import Empty from '../component/Empty';
@@ -31,6 +34,8 @@ const rulesFilters = [
 ];
 
 const List = () => {
+  const theme = useTheme();
+
   return (
     <RaList
       title={"Server Rules"}
@@ -48,6 +53,42 @@ const List = () => {
         <TextField source='match.rules.path' />
         <NumberField source='match.rules.client_ip' />
         <BooleanField source='match.response.allow' />
+        <FunctionField
+          source="_version_control"
+          label="Version"
+          sortable={false}
+          render={record => {
+            const vc = record._version_control;
+            if (vc && vc.managed) {
+              return (
+                <Chip
+                  icon={<HistoryIcon />}
+                  label={`v${vc.live_version}`}
+                  size="small"
+                  sx={{
+                    backgroundColor: alpha(theme.palette.success.main, 0.12),
+                    color: theme.palette.success.main,
+                    fontWeight: 600,
+                    fontSize: '0.75rem',
+                    '& .MuiChip-icon': { fontSize: 14, color: 'inherit' },
+                  }}
+                />
+              );
+            }
+            return (
+              <Chip
+                label="No VC"
+                size="small"
+                variant="outlined"
+                sx={{
+                  color: theme.palette.text.disabled,
+                  borderColor: theme.palette.divider,
+                  fontSize: '0.75rem',
+                }}
+              />
+            );
+          }}
+        />
         <CloneButton />
       </Datagrid>
       {/* <ImportJsonButton resource={"rules"} /> */}

--- a/openresty-admin/src/Servers/List.jsx
+++ b/openresty-admin/src/Servers/List.jsx
@@ -17,6 +17,7 @@ import CancelIcon from "@mui/icons-material/CancelRounded";
 import LockIcon from "@mui/icons-material/LockRounded";
 import CachedIcon from "@mui/icons-material/CachedRounded";
 import ShieldIcon from "@mui/icons-material/ShieldRounded";
+import HistoryIcon from "@mui/icons-material/HistoryRounded";
 import ExportJsonButton from './toolbar/ExportJsonButton';
 import Empty from '../component/Empty';
 import ToolBar from "../component/ToolBar";
@@ -312,6 +313,45 @@ const List = () => {
                 }}
               />
             )}
+          />
+          <FunctionField
+            source="_version_control"
+            label="Version"
+            sortable={false}
+            render={record => {
+              const vc = record._version_control;
+              if (vc && vc.managed) {
+                return (
+                  <Chip
+                    icon={<HistoryIcon />}
+                    label={`v${vc.live_version}`}
+                    size="small"
+                    sx={{
+                      backgroundColor: alpha(theme.palette.success.main, 0.12),
+                      color: theme.palette.success.main,
+                      fontWeight: 600,
+                      fontSize: '0.75rem',
+                      '& .MuiChip-icon': {
+                        fontSize: 14,
+                        color: 'inherit',
+                      },
+                    }}
+                  />
+                );
+              }
+              return (
+                <Chip
+                  label="No VC"
+                  size="small"
+                  variant="outlined"
+                  sx={{
+                    color: theme.palette.text.disabled,
+                    borderColor: theme.palette.divider,
+                    fontSize: '0.75rem',
+                  }}
+                />
+              );
+            }}
           />
           <StatusChip source="config_status" label="Status" successLabel="Active" failLabel="Inactive" />
           <CloneButton />


### PR DESCRIPTION
## Summary
- **Default deploy is now code-only**: syncs lua code, nginx conf, data configs, and admin UI — no compilation or OS updates
- **FULL_BUILD checkbox**: tick it in workflow_dispatch when you need to compile OpenResty, install luarocks modules, or update OS packages
- **Ansible `build` tag**: added to heavy steps (OS setup, OpenResty compile, luarocks install, CDN deps) so they can be skipped with `--skip-tags base_packages,build`
- Also includes version control enhancements from PR #982

## What runs by default (fast)
- JSON/Jinja2 validation
- Sync API lua files
- Sync HTML files
- Nginx config templates
- Deploy settings/env files
- Admin UI build & deploy
- Data configs (servers/rules)
- Cron, systemd, PAM, SSL, finalize
- Health gate checks

## What's skipped by default (slow)
- `apt-get upgrade` / `zypper update` (OS packages)
- OpenResty bootstrap & compile from source
- luarocks module installation
- CDN dependencies script

## Test plan
- [ ] Trigger pipeline on release push — verify it skips build steps and completes faster
- [ ] Trigger manual dispatch with FULL_BUILD=true — verify full build runs
- [ ] Verify DEPLOY_DASHBOARD_ONLY still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)