### PR TITLE
Add LON1 prod deployment target (lon1.pop0.uk)

### DIFF
--- a/.github/workflows/build-deploy-wslproxy.yml
+++ b/.github/workflows/build-deploy-wslproxy.yml
@@ -2,6 +2,7 @@ name: Build and Deploy WSLProxy
 # Pipeline: Validate → Deploy Int → Test → Deploy WSL1 (auto on push)
 # Prod & DIYTaxReturn deploy manually or via "all" target
 # Fail-fast: any stage failure stops the pipeline and sends Slack notification immediately
+# Default: code-only deploy (lua, nginx conf, data, admin UI). Tick FULL_BUILD to compile OpenResty & update OS packages.
 
 on:
   push:
@@ -49,6 +50,11 @@ on:
         description: "Only rebuild & deploy openresty-admin dashboard UI (skip full build)"
         default: false
 
+      FULL_BUILD:
+        type: boolean
+        description: "Full build: compile OpenResty, install luarocks, update OS packages (slow). Default: off (code-only deploy)"
+        default: false
+
 # Prevent concurrent deployments to same ref (but don't cancel in-progress)
 concurrency:
   group: deploy-${{ github.ref }}
@@ -57,6 +63,7 @@ concurrency:
 env:
   DEPLOY_BRANCH: ${{ github.event.inputs.DEPLOY_BRANCH || github.ref_name }}
   DEPLOY_DASHBOARD_ONLY: ${{ github.event.inputs.DEPLOY_DASHBOARD_ONLY || 'false' }}
+  FULL_BUILD: ${{ github.event.inputs.FULL_BUILD || 'false' }}
   TARGET_HOST: ${{ github.event.inputs.TARGET_HOST || '187.124.112.155' }}
   TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '187.124.112.155' && 'prod' || github.event.inputs.TARGET_HOST == 'slworker00' && 'int' || 'prod') }}
   API_DOMAINNAME_ENDPOINT: ${{ github.event.inputs.TARGET_ENV || (github.event.inputs.TARGET_HOST == '187.124.112.155' && 'prod' || github.event.inputs.TARGET_HOST == 'slworker00' && 'int' || 'prod') }}.wslproxy.com
@@ -191,8 +198,11 @@ jobs:
           if [[ "${{ env.DEPLOY_DASHBOARD_ONLY }}" == "true" ]]; then
             TAGS_FLAG="--tags dashboard"
             echo "Dashboard-only deploy to slworker00 (env: int)"
+          elif [[ "${{ env.FULL_BUILD }}" != "true" ]]; then
+            TAGS_FLAG="--skip-tags base_packages,build"
+            echo "Code-only deploy to slworker00 (env: int) — skipping OS updates and OpenResty build"
           else
-            echo "Deploying natively to slworker00 (env: int) via local connection"
+            echo "Full build + deploy to slworker00 (env: int) via local connection"
           fi
           sudo ansible-playbook devops/ansible/wslproxy-ops.yml \
             -i devops/ansible/hosts \
@@ -412,8 +422,11 @@ jobs:
           if [[ "${{ env.DEPLOY_DASHBOARD_ONLY }}" == "true" ]]; then
             TAGS_FLAG="--tags dashboard"
             echo "Dashboard-only deploy to production: 187.124.112.155"
+          elif [[ "${{ env.FULL_BUILD }}" != "true" ]]; then
+            TAGS_FLAG="--skip-tags base_packages,build"
+            echo "Code-only deploy to production: 187.124.112.155 — skipping OS updates and OpenResty build"
           else
-            echo "Deploying to production: 187.124.112.155 (env: prod)"
+            echo "Full build + deploy to production: 187.124.112.155 (env: prod)"
           fi
           ansible-playbook devops/ansible/wslproxy-ops.yml \
             -i devops/ansible/hosts \
@@ -573,8 +586,11 @@ jobs:
           if [[ "${{ env.DEPLOY_DASHBOARD_ONLY }}" == "true" ]]; then
             TAGS_FLAG="--tags dashboard"
             echo "Dashboard-only deploy to DIYTaxReturn: 187.77.179.206"
+          elif [[ "${{ env.FULL_BUILD }}" != "true" ]]; then
+            TAGS_FLAG="--skip-tags base_packages,build"
+            echo "Code-only deploy to DIYTaxReturn: 187.77.179.206 — skipping OS updates and OpenResty build"
           else
-            echo "Deploying to DIYTaxReturn: 187.77.179.206 (env: diytaxreturn)"
+            echo "Full build + deploy to DIYTaxReturn: 187.77.179.206 (env: diytaxreturn)"
           fi
           export ANSIBLE_HOST_KEY_CHECKING=False
           ansible-playbook devops/ansible/wslproxy-ops.yml \
@@ -732,8 +748,11 @@ jobs:
           if [[ "${{ env.DEPLOY_DASHBOARD_ONLY }}" == "true" ]]; then
             TAGS_FLAG="--tags dashboard"
             echo "Dashboard-only deploy to WSL1: 187.124.112.156"
+          elif [[ "${{ env.FULL_BUILD }}" != "true" ]]; then
+            TAGS_FLAG="--skip-tags base_packages,build"
+            echo "Code-only deploy to WSL1: 187.124.112.156 — skipping OS updates and OpenResty build"
           else
-            echo "Deploying to WSL1: 187.124.112.156 (env: wsl1)"
+            echo "Full build + deploy to WSL1: 187.124.112.156 (env: wsl1)"
           fi
           export ANSIBLE_HOST_KEY_CHECKING=False
           ansible-playbook devops/ansible/wslproxy-ops.yml \

--- a/.github/workflows/build-deploy-wslproxy.yml
+++ b/.github/workflows/build-deploy-wslproxy.yml
@@ -27,6 +27,7 @@ on:
         required: true
         options:
           - prod
+          - lon1
           - int
           - test
           - acc
@@ -40,6 +41,7 @@ on:
         required: true
         options:
           - 187.124.112.155
+          - lon1.pop0.uk
           - 187.77.179.206
           - 187.124.112.156
           - slworker00
@@ -512,6 +514,169 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   # ──────────────────────────────────────────────────────
+  # Stage 4b: Deploy LON1 (lon1.pop0.uk / 72.62.211.28)
+  # Runs after prod succeeds (auto on push) or manual dispatch
+  # ──────────────────────────────────────────────────────
+  deploy-lon1:
+    name: "Stage 4b: Deploy LON1 (lon1.pop0.uk)"
+    runs-on: [self-hosted]
+    needs: [deploy-production]
+    if: >
+      (github.event_name == 'push' && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/main')) ||
+      (github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.TARGET_HOST == 'lon1.pop0.uk' || github.event.inputs.TARGET_HOST == 'all'))
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_BRANCH }}
+
+      - name: Install Ansible
+        run: |
+          if command -v zypper &> /dev/null; then
+            sudo zypper install -y ansible
+          elif command -v apt-get &> /dev/null; then
+            sudo apt-get install -y ansible
+          else
+            echo "::error::No supported package manager found (zypper or apt-get)"
+            exit 1
+          fi
+          export ANSIBLE_HOST_KEY_CHECKING=False
+
+      - name: Validate secrets files exist (LON1)
+        run: |
+          SETTINGS="/home/bwalia/.secrets/wslproxy/lon1/settings.json"
+          ENVFILE="/home/bwalia/.secrets/wslproxy/lon1/.env"
+          if [ ! -f "$SETTINGS" ]; then
+            echo "::error::Settings file not found: $SETTINGS"
+            exit 1
+          fi
+          python3 -m json.tool "$SETTINGS" > /dev/null 2>&1 || {
+            echo "::error::Settings file contains invalid JSON"; exit 1;
+          }
+          if [ ! -f "$ENVFILE" ]; then
+            echo "::warning::Env file not found: $ENVFILE (may be expected)"
+          fi
+          echo "LON1 secrets validated"
+
+      - name: Setup SSH and test connectivity
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          if [[ -f ~/.ssh/id_rsa ]]; then
+            echo "Using existing SSH key"
+          else
+            echo "::error::SSH key not found at ~/.ssh/id_rsa"
+            exit 1
+          fi
+          ssh-keyscan -H lon1.pop0.uk >> ~/.ssh/known_hosts 2>/dev/null || true
+          ssh -i ~/.ssh/id_rsa -o BatchMode=yes -o ConnectTimeout=10 root@lon1.pop0.uk "echo 'SSH OK'" 2>&1 || {
+            echo "::error::SSH connection failed to root@lon1.pop0.uk"; exit 1;
+          }
+
+      - name: "Prepare: Clean up Docker resources"
+        run: |
+          echo "Pruning unused Docker resources on lon1.pop0.uk..."
+          ssh -i ~/.ssh/id_rsa -o BatchMode=yes -o ConnectTimeout=10 root@lon1.pop0.uk \
+            "docker system prune -y" 2>&1 || echo "::warning::Docker prune failed on LON1"
+          echo "Docker cleanup complete"
+
+      - name: Run Ansible Playbook (LON1)
+        timeout-minutes: 25
+        run: |
+          TAGS_FLAG=""
+          if [[ "${{ env.DEPLOY_DASHBOARD_ONLY }}" == "true" ]]; then
+            TAGS_FLAG="--tags dashboard"
+            echo "Dashboard-only deploy to LON1: lon1.pop0.uk"
+          elif [[ "${{ env.FULL_BUILD }}" != "true" ]]; then
+            TAGS_FLAG="--skip-tags base_packages,build"
+            echo "Code-only deploy to LON1: lon1.pop0.uk — skipping OS updates and OpenResty build"
+          else
+            echo "Full build + deploy to LON1: lon1.pop0.uk (env: prod)"
+          fi
+          export ANSIBLE_HOST_KEY_CHECKING=False
+          ansible-playbook devops/ansible/wslproxy-ops.yml \
+            -i devops/ansible/hosts \
+            -l lon1.pop0.uk \
+            --private-key /home/bwalia/.ssh/id_rsa \
+            --timeout 30 \
+            $TAGS_FLAG \
+            --extra-vars "nginx_user_password=THISCOMESFROMSECRETS target_env=prod local_settings_file_path=/home/bwalia/.secrets/wslproxy/lon1/settings.json local_env_file_path=/home/bwalia/.secrets/wslproxy/lon1/.env"
+
+      - name: Deploy server configs and rules (lon1 / prod)
+        timeout-minutes: 5
+        run: |
+          echo "Deploying server configs for env: prod to lon1.pop0.uk"
+          export ANSIBLE_HOST_KEY_CHECKING=False
+          ansible-playbook devops/ansible/deploy-configs.yml \
+            -i devops/ansible/hosts \
+            -e "target_env=prod local_data_dir=${{ github.workspace }}/data" \
+            -l lon1.pop0.uk \
+            --private-key /home/bwalia/.ssh/id_rsa
+
+      - name: Post-deploy health gate
+        run: |
+          echo "Verifying LON1 deployment on lon1.pop0.uk..."
+
+          ssh -i ~/.ssh/id_rsa -o BatchMode=yes -o ConnectTimeout=10 root@lon1.pop0.uk \
+            "/usr/local/openresty/bin/openresty -t" 2>&1 || {
+            echo "::error::Nginx config test failed on lon1.pop0.uk"; exit 1;
+          }
+
+          ssh -i ~/.ssh/id_rsa -o BatchMode=yes -o ConnectTimeout=10 root@lon1.pop0.uk \
+            "systemctl is-active openresty" 2>&1 || {
+            echo "::error::OpenResty not running on lon1.pop0.uk"; exit 1;
+          }
+
+          for i in $(seq 1 10); do
+            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "http://lon1.pop0.uk:8080/health" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "LON1 endpoint healthy (HTTP $STATUS)"
+              exit 0
+            fi
+            echo "Attempt $i/10: HTTP $STATUS — waiting 5s..."
+            sleep 5
+          done
+          echo "::error::LON1 not responding on lon1.pop0.uk after 50s"
+          exit 1
+
+      - name: Slack notify - LON1 deployed
+        if: success()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: github-updates
+          SLACK_COLOR: good
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: |
+            :white_check_mark: *WSLProxy deployed to LON1*
+            All pipeline stages passed. Zero-downtime deployment complete.
+            *Host:* lon1.pop0.uk (72.62.211.28) | *Env:* prod
+            *Branch:* ${{ github.ref_name }} | *Commit:* `${{ github.sha }}`
+            *Triggered by:* ${{ github.actor }} (${{ github.event_name }})
+          SLACK_TITLE: "WSLProxy LON1 Deployment — Success"
+          SLACK_USERNAME: GitHub Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+      - name: Slack notify - LON1 deploy failed
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: github-updates
+          SLACK_COLOR: danger
+          SLACK_ICON: https://github.com/rtCamp.png?size=48
+          SLACK_MESSAGE: |
+            :rotating_light: *Stage 4b FAILED: LON1 Deployment*
+            Ansible deploy or health check failed on lon1.pop0.uk.
+            *Branch:* ${{ github.ref_name }} | *Commit:* `${{ github.sha }}`
+            *Triggered by:* ${{ github.actor }} (${{ github.event_name }})
+            *Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_TITLE: "WSLProxy LON1 Deployment — FAILED"
+          SLACK_USERNAME: GitHub Actions
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
   # Stage 5: Deploy DIYTaxReturn (187.77.179.206)
   # Manual dispatch only (or "all")
   # ──────────────────────────────────────────────────────
@@ -841,7 +1006,7 @@ jobs:
   pipeline-summary:
     name: Pipeline Summary
     runs-on: ubuntu-latest
-    needs: [build-validate, deploy-int, test-environment, deploy-production, deploy-diytaxreturn, deploy-diytaxreturn-wsl1]
+    needs: [build-validate, deploy-int, test-environment, deploy-production, deploy-lon1, deploy-diytaxreturn, deploy-diytaxreturn-wsl1]
     if: always()
     steps:
       - name: Pipeline Summary
@@ -854,6 +1019,7 @@ jobs:
           echo "  Stage 2 — Deploy Int (Ansible):   ${{ needs.deploy-int.result }}"
           echo "  Stage 3 — Smoke Test Int Environment Dashboard Endpoint:       ${{ needs.test-environment.result }}"
           echo "  Stage 4 — Deploy Production:      ${{ needs.deploy-production.result }}"
+          echo "  Stage 4b — Deploy LON1:           ${{ needs.deploy-lon1.result }}"
           echo "  Stage 5 — Deploy DIYTaxReturn:    ${{ needs.deploy-diytaxreturn.result }}"
           echo "  Stage 6 — Deploy WSL1:            ${{ needs.deploy-diytaxreturn-wsl1.result }}"
           echo ""
@@ -867,6 +1033,7 @@ jobs:
              [[ "${{ needs.deploy-int.result }}" == "failure" ]] || \
              [[ "${{ needs.test-environment.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-production.result }}" == "failure" ]] || \
+             [[ "${{ needs.deploy-lon1.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-diytaxreturn.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-diytaxreturn-wsl1.result }}" == "failure" ]]; then
             echo "::error::Pipeline failed — see stage results above"

--- a/api/api.lua
+++ b/api/api.lua
@@ -4154,6 +4154,50 @@ local function handle_get_request(args, path)
         ngx.exit(ngx.HTTP_OK)
     end
 
+    -- GET /api/change-requests/config - Get CR config (whether passphrase is set, etc.)
+    if path == "change-requests/config" then
+        local config = CRManager.get_cr_config()
+        ngx.say(cjson.encode({ data = {
+            has_passphrase = (config.approval_passphrase ~= nil and config.approval_passphrase ~= ""),
+            required_approvals = config.required_approvals or 2,
+            passphrase_set_by = config.passphrase_set_by,
+            passphrase_set_at = config.passphrase_set_at,
+        }}))
+        ngx.exit(ngx.HTTP_OK)
+    end
+
+    -- GET /api/versions/status/{type}/{profile} - Bulk version status for all resources
+    if string.find(path, "^versions/status/[^/]+/[^/]+$") then
+        local res_type, profile = path:match("^versions/status/([^/]+)/([^/]+)$")
+        if res_type and profile then
+            local statuses = {}
+            local versions_base = configPath .. "data/versions/" .. res_type .. "/" .. profile
+            local dir_ok, iter, dir_obj = pcall(LFS.dir, versions_base)
+            if dir_ok and iter then
+                for entry in iter, dir_obj do
+                    if entry ~= "." and entry ~= ".." then
+                        local meta_path = versions_base .. "/" .. entry .. "/meta.json"
+                        local meta_file = io.open(meta_path, "rb")
+                        if meta_file then
+                            local content = meta_file:read("*a")
+                            meta_file:close()
+                            local ok, meta = pcall(cjson.decode, content)
+                            if ok and meta then
+                                statuses[entry] = {
+                                    live_version = meta.live_version,
+                                    latest_version = meta.latest_version,
+                                    managed = true,
+                                }
+                            end
+                        end
+                    end
+                end
+            end
+            ngx.say(cjson.encode({ data = statuses }))
+            ngx.exit(ngx.HTTP_OK)
+        end
+    end
+
     -- GET /api/change-requests/{cr_id} - Get specific CR
     if string.find(path, "^change%-requests/CR%-") then
         local cr_id = path:match("^change%-requests/(CR%-%d+)$")
@@ -4730,7 +4774,8 @@ local function handle_put_request(args, path)
                 local payloads = Helper.GetPayloads(args)
                 local user = (payloads and payloads.user) or ngx.req.get_headers()["x-user"] or "system"
                 local comment = payloads and payloads.comment
-                local cr, err = CRManager.approve_cr(cr_id, user, comment)
+                local passphrase = payloads and payloads.passphrase
+                local cr, err = CRManager.approve_cr(cr_id, user, comment, passphrase)
                 if cr then
                     ngx.say(cjson.encode({ data = cr, message = "CR approved" }))
                 else
@@ -4771,6 +4816,23 @@ local function handle_put_request(args, path)
                 end
                 ngx.exit(ngx.HTTP_OK)
             end
+        end
+
+        -- PUT /api/change-requests/config/passphrase - Set CR approval passphrase
+        if path == "change-requests/config/passphrase" then
+            local payloads = Helper.GetPayloads(args)
+            if not payloads or not payloads.passphrase then
+                Errors.throwError("passphrase is required", ngx.HTTP_BAD_REQUEST)
+                ngx.exit(ngx.HTTP_BAD_REQUEST)
+            end
+            local user = (payloads and payloads.user) or ngx.req.get_headers()["x-user"] or "system"
+            local ok, err = CRManager.set_passphrase(payloads.passphrase, user)
+            if ok then
+                ngx.say(cjson.encode({ message = "CR approval passphrase updated" }))
+            else
+                Errors.throwError(err or "Failed to set passphrase", ngx.HTTP_BAD_REQUEST)
+            end
+            ngx.exit(ngx.HTTP_OK)
         end
 
         -- PUT /api/versions/{type}/{profile}/{name}/{version} - Update a draft version

--- a/api/cr_manager.lua
+++ b/api/cr_manager.lua
@@ -27,6 +27,10 @@ local function get_cr_dir()
     return configPath .. "data/change_requests"
 end
 
+local function get_cr_config_path()
+    return get_cr_dir() .. "/cr_config.json"
+end
+
 local function ensure_directory(path)
     local ok, attr = pcall(function()
         return lfs.attributes(path)
@@ -106,6 +110,65 @@ end
 
 local function get_cr_path(cr_id)
     return get_cr_dir() .. "/" .. cr_id .. ".json"
+end
+
+-- ============================================================
+-- Passphrase management
+-- ============================================================
+
+--- Get CR config (passphrase, settings)
+function _M.get_cr_config()
+    local config = read_json_file(get_cr_config_path())
+    if not config then
+        config = {
+            approval_passphrase = nil,
+            required_approvals = 2,
+        }
+    end
+    return config
+end
+
+--- Set the CR approval passphrase
+-- @param passphrase string: The passphrase to set
+-- @param user string: User setting the passphrase
+-- @return boolean, string|nil
+function _M.set_passphrase(passphrase, user)
+    if not passphrase or passphrase == "" then
+        return false, "Passphrase cannot be empty"
+    end
+    local config = _M.get_cr_config()
+    config.approval_passphrase = passphrase
+    config.passphrase_set_by = user
+    config.passphrase_set_at = os.time()
+    local cr_dir = get_cr_dir()
+    local ok, err = write_json_file(get_cr_config_path(), config, cr_dir)
+    if not ok then
+        return false, err
+    end
+    AuditLogger.log("cr_passphrase_updated", user, "system", "cr_config", {})
+    return true
+end
+
+--- Check if passphrase is configured
+function _M.has_passphrase()
+    local config = _M.get_cr_config()
+    return config.approval_passphrase ~= nil and config.approval_passphrase ~= ""
+end
+
+--- Validate a passphrase
+local function validate_passphrase(passphrase)
+    local config = _M.get_cr_config()
+    if not config.approval_passphrase or config.approval_passphrase == "" then
+        -- No passphrase configured, allow through
+        return true
+    end
+    if not passphrase or passphrase == "" then
+        return false, "Approval passphrase is required. Contact your admin for the CR approval code."
+    end
+    if passphrase ~= config.approval_passphrase then
+        return false, "Invalid approval passphrase"
+    end
+    return true
 end
 
 -- ============================================================
@@ -211,7 +274,7 @@ end
 -- @param comment string|nil: Approval comment
 -- @return table|nil: Updated CR
 -- @return string|nil: Error message
-function _M.approve_cr(cr_id, user, comment)
+function _M.approve_cr(cr_id, user, comment, passphrase)
     local cr, err = _M.get_cr(cr_id)
     if not cr then
         return nil, err or "CR not found"
@@ -219,6 +282,12 @@ function _M.approve_cr(cr_id, user, comment)
 
     if cr.state ~= "pending_approval" then
         return nil, "CR is not in 'pending_approval' state, current state: " .. cr.state
+    end
+
+    -- Validate approval passphrase
+    local pass_ok, pass_err = validate_passphrase(passphrase)
+    if not pass_ok then
+        return nil, pass_err
     end
 
     -- 4-eyes: Creator cannot approve their own CR

--- a/api/version_manager.lua
+++ b/api/version_manager.lua
@@ -359,11 +359,23 @@ function _M.activate_version(resource_type, profile, resource_name, version, use
     meta.live_version = version
     write_meta(resource_type, profile, resource_name, meta)
 
-    -- Step 4: Copy config to main data directory
+    -- Step 4: Copy config to main data directory with _version_control metadata
     local live_data_path = get_live_data_path(resource_type, profile, resource_name)
     if live_data_path and entry.config_payload then
         local data_dir = live_data_path:match("^(.*)/[^/]+$")
-        write_json_file(live_data_path, entry.config_payload, data_dir)
+        -- Clone config and embed version control metadata
+        local live_config = {}
+        for k, v in pairs(entry.config_payload) do
+            live_config[k] = v
+        end
+        live_config._version_control = {
+            managed = true,
+            live_version = version,
+            activated_at = os.time(),
+            activated_by = user,
+            cr_id = entry.cr_id,
+        }
+        write_json_file(live_data_path, live_config, data_dir)
     end
 
     -- Step 5: Trigger nginx reload
@@ -558,6 +570,19 @@ function _M.initialize_resource(resource_type, profile, resource_name, user)
     meta.latest_version = 1
     meta.live_version = 1
     write_meta(resource_type, profile, resource_name, meta)
+
+    -- Write _version_control metadata to the live config file
+    local live_config = {}
+    for k, v in pairs(config) do
+        live_config[k] = v
+    end
+    live_config._version_control = {
+        managed = true,
+        live_version = 1,
+        activated_at = os.time(),
+        activated_by = user or "system",
+    }
+    write_json_file(live_data_path, live_config)
 
     AuditLogger.log("version_migrated", user or "system", resource_type, resource_name, {
         version = 1,

--- a/devops/ansible/deploy-configs.yml
+++ b/devops/ansible/deploy-configs.yml
@@ -61,8 +61,8 @@
     - name: Validate target environment
       assert:
         that:
-          - target_env in ['dev', 'int', 'test', 'acc', 'prod', 'diytaxreturn', 'diytaxreturn_wsl1']
-        fail_msg: "Invalid target_env: {{ target_env }}. Must be one of: dev, int, test, acc, prod, diytaxreturn, diytaxreturn_wsl1"
+          - target_env in ['dev', 'int', 'test', 'acc', 'prod', 'lon1', 'diytaxreturn', 'diytaxreturn_wsl1']
+        fail_msg: "Invalid target_env: {{ target_env }}. Must be one of: dev, int, test, acc, prod, lon1, diytaxreturn, diytaxreturn_wsl1"
         success_msg: "Target environment validated: {{ target_env }}"
 
     - name: Ensure remote directories exist

--- a/devops/ansible/host_vars/lon1.pop0.uk/vars.yaml
+++ b/devops/ansible/host_vars/lon1.pop0.uk/vars.yaml
@@ -1,0 +1,16 @@
+local_settings_file_path: "/home/bwalia/.secrets/wslproxy/lon1/settings.json"
+local_env_file_path: "/home/bwalia/.secrets/wslproxy/lon1/.env"
+nginx_user_password: "!!REDACTED!!" # This is the password for the user www-data but must be encrypted using Ansible Vault
+host_lan_ip: "72.62.211.28"
+nginx_web_ui_enabled: "yes"
+nginx_rest_api_server_enabled: ""
+nginx_data_sync_enabled: ""
+nginx_s3_proxy_pass_host_ip: "127.0.0.1"
+nginx_s3_server_name: "dummy-s3.workstation.co.uk"
+nginx_s3_cli_server_name: "dummy-s3-cli.workstation.co.uk"
+nginx_k3s_dashboard_server_name: "k3s-dashboard.workstation.co.uk"
+nginx_default_server_frontend: "lon1.pop0.uk www.lon1.pop0.uk"
+nginx_default_server_backend: "lon1.pop0.uk"
+nginx_default_server_backend_port: 7691
+letsencrypt_email: "balinder.walia@gmail.com"
+openresty_admin_secondary_color: "#D91656"

--- a/devops/ansible/hosts
+++ b/devops/ansible/hosts
@@ -11,12 +11,14 @@ ubworker04 ansible_user=bwalia
 whisky08 ansible_user=bwalia
 192.168.10.1 ansible_user=bwalia
 187.124.112.155 ansible_user=root
+lon1.pop0.uk ansible_user=root
 187.77.179.206 ansible_user=root
 187.124.112.156 ansible_user=root
 
 # Environment-based server groups for config deployment
 [openresty_prod]
 187.124.112.155 ansible_user=root
+lon1.pop0.uk ansible_user=root
 
 [openresty_int]
 slworker00 ansible_user=bwalia

--- a/devops/ansible/roles/wslproxy/tasks/deploy_app.yml
+++ b/devops/ansible/roles/wslproxy/tasks/deploy_app.yml
@@ -29,7 +29,7 @@
     src: cdn-dependencies.sh.j2
     dest: /tmp/cdn-dependencies.sh
     mode: 0777
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 - name: Ensure nginx data directory exists
   ansible.builtin.file:
@@ -104,23 +104,23 @@
     exit $FAILED
   register: luarocks_install_result
   ignore_errors: true
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 - name: Show luarocks install output
   debug:
     msg: "{{ luarocks_install_result.stdout_lines }}"
   when: luarocks_install_result is defined
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 - name: Execute the cdn-dependencies.sh script
   shell: /tmp/cdn-dependencies.sh 2>&1
   register: cdn_deps_result
   async: 300
   poll: 15
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 - name: Show cdn-dependencies output (last 40 lines)
   debug:
     msg: "{{ cdn_deps_result.stdout_lines[-40:] }}"
   when: cdn_deps_result is defined
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]

--- a/devops/ansible/roles/wslproxy/tasks/main.yml
+++ b/devops/ansible/roles/wslproxy/tasks/main.yml
@@ -11,10 +11,10 @@
     - "Debian.yml"
   tags: [always]
 
-# Step 1: OS-specific package refresh
+# Step 1: OS-specific package refresh (heavy — skip with --skip-tags build)
 - name: Run OS-specific setup
   include_tasks: "os_setup_{{ ansible_os_family | lower }}.yml"
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 # Step 2: Load host variables
 - name: Load host variables
@@ -25,10 +25,10 @@
   include_tasks: user_setup.yml
   tags: [openresty, lapis, dashboard, nginx]
 
-# Step 4: Bootstrap and compile OpenResty from source
+# Step 4: Bootstrap and compile OpenResty from source (heavy — skip with --skip-tags build)
 - name: Bootstrap and build OpenResty
   include_tasks: openresty_build.yml
-  tags: [openresty, lapis]
+  tags: [openresty, lapis, build]
 
 # Step 5: Nginx configuration directories and base configs
 - name: Configure nginx

--- a/openresty-admin/src/ChangeRequests/ChangeRequestList.jsx
+++ b/openresty-admin/src/ChangeRequests/ChangeRequestList.jsx
@@ -30,6 +30,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import SettingsIcon from "@mui/icons-material/Settings";
 import { useNotify } from "react-admin";
 import StatusBadge from "../component/StatusBadge";
 
@@ -65,7 +66,12 @@ const ChangeRequestList = () => {
   const [actionCR, setActionCR] = useState(null);
   const [approverUser, setApproverUser] = useState("");
   const [approveComment, setApproveComment] = useState("");
+  const [approvePassphrase, setApprovePassphrase] = useState("");
   const [rejectReason, setRejectReason] = useState("");
+  const [crConfig, setCrConfig] = useState({});
+  const [passphraseDialogOpen, setPassphraseDialogOpen] = useState(false);
+  const [newPassphrase, setNewPassphrase] = useState("");
+  const [passphraseUser, setPassphraseUser] = useState("");
 
   const fetchCRs = useCallback(async () => {
     setLoading(true);
@@ -95,10 +101,22 @@ const ChangeRequestList = () => {
     }
   }, []);
 
+  const fetchCRConfig = useCallback(async () => {
+    try {
+      const url = `${API_URL}/change-requests/config?timestamp=${Date.now()}`;
+      const response = await fetch(url, { method: "GET", headers: getHeaders() });
+      const result = await response.json();
+      setCrConfig(result.data || {});
+    } catch (error) {
+      console.error("Failed to fetch CR config:", error);
+    }
+  }, []);
+
   useEffect(() => {
     fetchCRs();
     fetchPendingCount();
-  }, [fetchCRs, fetchPendingCount]);
+    fetchCRConfig();
+  }, [fetchCRs, fetchPendingCount, fetchCRConfig]);
 
   const handleViewCR = (cr) => {
     setSelectedCR(cr);
@@ -112,7 +130,7 @@ const ChangeRequestList = () => {
       const response = await fetch(url, {
         method: "PUT",
         headers: getHeaders(),
-        body: JSON.stringify({ user: approverUser, comment: approveComment }),
+        body: JSON.stringify({ user: approverUser, comment: approveComment, passphrase: approvePassphrase }),
       });
       const result = await response.json();
       if (response.ok) {
@@ -120,6 +138,7 @@ const ChangeRequestList = () => {
         setApproveDialogOpen(false);
         setApproverUser("");
         setApproveComment("");
+        setApprovePassphrase("");
         fetchCRs();
         fetchPendingCount();
       } else {
@@ -127,6 +146,30 @@ const ChangeRequestList = () => {
       }
     } catch (error) {
       notify("Failed to approve CR", { type: "error" });
+    }
+  };
+
+  const handleSetPassphrase = async () => {
+    if (!newPassphrase || !passphraseUser) return;
+    try {
+      const url = `${API_URL}/change-requests/config/passphrase`;
+      const response = await fetch(url, {
+        method: "PUT",
+        headers: getHeaders(),
+        body: JSON.stringify({ passphrase: newPassphrase, user: passphraseUser }),
+      });
+      if (response.ok) {
+        notify("CR approval passphrase updated", { type: "success" });
+        setPassphraseDialogOpen(false);
+        setNewPassphrase("");
+        setPassphraseUser("");
+        fetchCRConfig();
+      } else {
+        const result = await response.json();
+        notify(result?.data?.message || "Failed to set passphrase", { type: "error" });
+      }
+    } catch (error) {
+      notify("Failed to set passphrase", { type: "error" });
     }
   };
 
@@ -199,6 +242,15 @@ const ChangeRequestList = () => {
         </TextField>
         <Button variant="outlined" size="small" startIcon={<RefreshIcon />} onClick={fetchCRs}>
           Refresh
+        </Button>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<SettingsIcon />}
+          onClick={() => setPassphraseDialogOpen(true)}
+          color={crConfig.has_passphrase ? "success" : "warning"}
+        >
+          {crConfig.has_passphrase ? "Passphrase Set" : "Set Approval Passphrase"}
         </Button>
       </Stack>
 
@@ -444,6 +496,9 @@ const ChangeRequestList = () => {
           <Alert severity="info" sx={{ mb: 2 }}>
             <strong>4-Eyes Principle:</strong> You cannot approve a CR you created.
             Two different users must approve before the change goes live.
+            {crConfig.has_passphrase && (
+              <><br /><strong>Approval passphrase required.</strong> Contact your admin if you don't have it.</>
+            )}
           </Alert>
           <Typography variant="body2" sx={{ mb: 2 }}>
             Resource: {actionCR?.resource_name} (v{actionCR?.version})
@@ -457,6 +512,19 @@ const ChangeRequestList = () => {
             required
             helperText="Must be different from the CR creator"
           />
+          {crConfig.has_passphrase && (
+            <TextField
+              label="Approval Passphrase"
+              fullWidth
+              type="password"
+              value={approvePassphrase}
+              onChange={(e) => setApprovePassphrase(e.target.value)}
+              sx={{ mb: 2 }}
+              required
+              helperText="Secret code required to approve changes"
+              inputProps={{ autoComplete: "new-password" }}
+            />
+          )}
           <TextField
             label="Comment (optional)"
             fullWidth
@@ -468,8 +536,54 @@ const ChangeRequestList = () => {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setApproveDialogOpen(false)}>Cancel</Button>
-          <Button variant="contained" color="success" onClick={handleApprove} disabled={!approverUser}>
+          <Button
+            variant="contained"
+            color="success"
+            onClick={handleApprove}
+            disabled={!approverUser || (crConfig.has_passphrase && !approvePassphrase)}
+          >
             Approve
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Set Passphrase Dialog */}
+      <Dialog open={passphraseDialogOpen} onClose={() => setPassphraseDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>CR Approval Passphrase</DialogTitle>
+        <DialogContent>
+          <Alert severity={crConfig.has_passphrase ? "success" : "warning"} sx={{ mb: 2 }}>
+            {crConfig.has_passphrase
+              ? `Passphrase is configured (set by ${crConfig.passphrase_set_by || "unknown"}).
+                 Anyone approving a CR must provide this passphrase.`
+              : "No passphrase is configured. Anyone can approve CRs without a secret code. Set one to secure the approval process."}
+          </Alert>
+          <TextField
+            label="Your Username"
+            fullWidth
+            value={passphraseUser}
+            onChange={(e) => setPassphraseUser(e.target.value)}
+            sx={{ mb: 2 }}
+            required
+          />
+          <TextField
+            label={crConfig.has_passphrase ? "New Passphrase (replaces existing)" : "Set Passphrase"}
+            fullWidth
+            type="password"
+            value={newPassphrase}
+            onChange={(e) => setNewPassphrase(e.target.value)}
+            required
+            helperText="This passphrase will be required for all future CR approvals"
+            inputProps={{ autoComplete: "new-password" }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPassphraseDialogOpen(false)}>Cancel</Button>
+          <Button
+            variant="contained"
+            onClick={handleSetPassphrase}
+            disabled={!newPassphrase || !passphraseUser}
+          >
+            {crConfig.has_passphrase ? "Update Passphrase" : "Set Passphrase"}
           </Button>
         </DialogActions>
       </Dialog>

--- a/openresty-admin/src/Rules/Form.jsx
+++ b/openresty-admin/src/Rules/Form.jsx
@@ -785,9 +785,29 @@ const Form = () => {
         </FormDataConsumer>
 
         {/* Version History */}
-        <SectionCard title="Version History" subtitle="Track configuration versions, create drafts, and manage change requests">
-          <VersionHistoryTab resourceType="rules" />
-        </SectionCard>
+        <Card
+          variant="outlined"
+          className="section-card"
+          sx={{
+            borderColor: "primary.main",
+            borderWidth: 2,
+          }}
+        >
+          <CardContent>
+            <Typography
+              variant="subtitle1"
+              className="section-card__title"
+              sx={{ color: "primary.main" }}
+            >
+              Version History & Change Control
+            </Typography>
+            <Typography variant="body2" color="text.secondary" className="section-card__subtitle">
+              All changes stay in draft until a Change Request is created and approved.
+              Two approvers are required (4-eyes principle).
+            </Typography>
+            <VersionHistoryTab resourceType="rules" />
+          </CardContent>
+        </Card>
 
       </div>
     </SimpleForm>

--- a/openresty-admin/src/Rules/List.jsx
+++ b/openresty-admin/src/Rules/List.jsx
@@ -8,8 +8,11 @@ import {
   ReferenceInput,
   SelectInput,
   SearchInput,
-  CloneButton
+  CloneButton,
+  FunctionField,
 } from 'react-admin'
+import { Chip, useTheme, alpha } from "@mui/material";
+import HistoryIcon from "@mui/icons-material/HistoryRounded";
 import ExportJsonButton from './toolbar/ExportJsonButton';
 import ImportJsonButton from '../component/ImportJsonButton';
 import Empty from '../component/Empty';
@@ -31,6 +34,8 @@ const rulesFilters = [
 ];
 
 const List = () => {
+  const theme = useTheme();
+
   return (
     <RaList
       title={"Server Rules"}
@@ -48,6 +53,42 @@ const List = () => {
         <TextField source='match.rules.path' />
         <NumberField source='match.rules.client_ip' />
         <BooleanField source='match.response.allow' />
+        <FunctionField
+          source="_version_control"
+          label="Version"
+          sortable={false}
+          render={record => {
+            const vc = record._version_control;
+            if (vc && vc.managed) {
+              return (
+                <Chip
+                  icon={<HistoryIcon />}
+                  label={`v${vc.live_version}`}
+                  size="small"
+                  sx={{
+                    backgroundColor: alpha(theme.palette.success.main, 0.12),
+                    color: theme.palette.success.main,
+                    fontWeight: 600,
+                    fontSize: '0.75rem',
+                    '& .MuiChip-icon': { fontSize: 14, color: 'inherit' },
+                  }}
+                />
+              );
+            }
+            return (
+              <Chip
+                label="No VC"
+                size="small"
+                variant="outlined"
+                sx={{
+                  color: theme.palette.text.disabled,
+                  borderColor: theme.palette.divider,
+                  fontSize: '0.75rem',
+                }}
+              />
+            );
+          }}
+        />
         <CloneButton />
       </Datagrid>
       {/* <ImportJsonButton resource={"rules"} /> */}

--- a/openresty-admin/src/Servers/List.jsx
+++ b/openresty-admin/src/Servers/List.jsx
@@ -17,6 +17,7 @@ import CancelIcon from "@mui/icons-material/CancelRounded";
 import LockIcon from "@mui/icons-material/LockRounded";
 import CachedIcon from "@mui/icons-material/CachedRounded";
 import ShieldIcon from "@mui/icons-material/ShieldRounded";
+import HistoryIcon from "@mui/icons-material/HistoryRounded";
 import ExportJsonButton from './toolbar/ExportJsonButton';
 import Empty from '../component/Empty';
 import ToolBar from "../component/ToolBar";
@@ -312,6 +313,45 @@ const List = () => {
                 }}
               />
             )}
+          />
+          <FunctionField
+            source="_version_control"
+            label="Version"
+            sortable={false}
+            render={record => {
+              const vc = record._version_control;
+              if (vc && vc.managed) {
+                return (
+                  <Chip
+                    icon={<HistoryIcon />}
+                    label={`v${vc.live_version}`}
+                    size="small"
+                    sx={{
+                      backgroundColor: alpha(theme.palette.success.main, 0.12),
+                      color: theme.palette.success.main,
+                      fontWeight: 600,
+                      fontSize: '0.75rem',
+                      '& .MuiChip-icon': {
+                        fontSize: 14,
+                        color: 'inherit',
+                      },
+                    }}
+                  />
+                );
+              }
+              return (
+                <Chip
+                  label="No VC"
+                  size="small"
+                  variant="outlined"
+                  sx={{
+                    color: theme.palette.text.disabled,
+                    borderColor: theme.palette.divider,
+                    fontSize: '0.75rem',
+                  }}
+                />
+              );
+            }}
           />
           <StatusChip source="config_status" label="Status" successLabel="Active" failLabel="Inactive" />
           <CloneButton />


### PR DESCRIPTION
## Summary
- **New host `lon1.pop0.uk`** (72.62.211.28) added to Ansible inventory as prod server
- **Stage 4b** in pipeline: deploys to LON1 automatically after prod (pop0) succeeds
- **Admin UI** available at http://lon1.pop0.uk:8080
- Uses same `prod` data configs (servers/rules) as pop0
- Also includes: fast deploy (skip build by default) + version control enhancements from earlier PRs

## Pipeline flow
```
Stage 1 → Stage 2 (int) → Stage 3 (test) → Stage 4 (prod/pop0) → Stage 4b (lon1) → Stage 5/6 (manual)
```

## Files changed
- `devops/ansible/hosts` — added lon1.pop0.uk to cluster and openresty_prod group
- `devops/ansible/host_vars/lon1.pop0.uk/vars.yaml` — host variables (modeled after pop0)
- `devops/ansible/deploy-configs.yml` — added lon1 to valid target_env list
- `.github/workflows/build-deploy-wslproxy.yml` — Stage 4b + lon1 in TARGET_HOST/TARGET_ENV options

## Prerequisites before first deploy
- [ ] SSH key for root@lon1.pop0.uk configured on slworker00 runner
- [ ] Create `/home/bwalia/.secrets/wslproxy/lon1/settings.json` on slworker00
- [ ] Create `/home/bwalia/.secrets/wslproxy/lon1/.env` on slworker00
- [ ] OpenResty installed on lon1 (run first deploy with FULL_BUILD=true)

## Test plan
- [ ] Merge and verify pipeline runs Stage 4b after Stage 4
- [ ] First deploy with FULL_BUILD=true to bootstrap OpenResty on lon1
- [ ] Verify admin UI at http://lon1.pop0.uk:8080
- [ ] Subsequent deploys should be code-only (fast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)