### PR TITLE
Make Vault /sys/health probe informational, not fatal

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -194,9 +194,13 @@ jobs:
               exit 1 ;;
           esac
 
-          # Probe Vault. Capture both exit code and body-less status via -w.
-          # --max-time bounds DNS/connect. -L follows redirects (some Vault
-          # UIs are behind a path-prefix or a reverse proxy that 30x's).
+          # Probe Vault — INFORMATIONAL ONLY. Some Vault setups expose the
+          # secret paths but block /v1/sys/health at the reverse-proxy layer
+          # (observed on run 24294596315: same secrets / same runner as a
+          # previously-passing run, but the health endpoint returned 404).
+          # The authoritative test is ansible's own uri task fetching the
+          # actual secret in deploy_data.yml; if that fails it surfaces a
+          # real error. This probe just logs reachability for diagnostics.
           STATUS="$(curl -sSL --max-time 10 -o /dev/null -w '%{http_code}' \
             -H "X-Vault-Token: $VAULT_TOKEN_SECRET" \
             "$VAULT_ADDR_SECRET/v1/sys/health" 2>/tmp/curl_err)"
@@ -204,21 +208,15 @@ jobs:
 
           if [ "$CURL_RC" -ne 0 ]; then
             ERR="$(cat /tmp/curl_err 2>/dev/null | head -c 300)"
-            echo "::error::Vault probe failed: curl exit=$CURL_RC (${ERR:-no detail}). Check VAULT_ADDR reachability from the runner."
-            echo "::error::Probe URL path used: \$VAULT_ADDR/v1/sys/health (value redacted)"
-            exit 1
+            echo "::warning::Vault probe could not connect: curl exit=$CURL_RC (${ERR:-no detail}). Continuing — ansible's uri task will surface the real error if Vault is actually unreachable."
+          else
+            case "$STATUS" in
+              200|429|473|501|503)
+                echo "Vault reachable via /v1/sys/health (HTTP $STATUS)" ;;
+              *)
+                echo "::warning::Vault /v1/sys/health returned HTTP $STATUS (expected 200/429/473/501/503). This often just means the health endpoint is blocked at a reverse proxy; the actual secret fetch may still work. Continuing — ansible's uri task is authoritative." ;;
+            esac
           fi
-          # 200 = healthy, 429 = sealed, 473 = disaster-recovery standby,
-          # 501 = not-initialised, 503 = sealed or standby.
-          # All of these are "Vault is reachable, continue" — ansible will
-          # surface the real error if the token can't actually read secrets.
-          case "$STATUS" in
-            200|429|473|501|503)
-              echo "Vault reachable (HTTP $STATUS)" ;;
-            *)
-              echo "::error::Vault health check returned HTTP $STATUS (expected 200/429/473/501/503). Check VAULT_ADDR and VAULT_TOKEN."
-              exit 1 ;;
-          esac
 
           # Mask the token in any downstream logs that might happen to echo
           # env vars, then export to GITHUB_ENV for the ansible-playbook step.


### PR DESCRIPTION
## Summary

Run [24294596315](https://github.com/bwalia/wslproxy/actions/runs/24294596315) failed at the Vault probe with HTTP 404 on \`/v1/sys/health\` — same int runner (\`slworker00\`), same secrets, same code as the previously-passing run 24294059506. The only variable was wall-clock time.

The most likely explanation: the reverse proxy in front of this Vault instance blocks or intermittently rejects \`/v1/sys/health\` while the actual secret paths continue to work. Many hardened Vault setups disable the health endpoint at the proxy layer on purpose.

This PR downgrades the \`/sys/health\` probe to ::warning:: so it no longer kills the step on non-200. Empty/missing-scheme checks still \`exit 1\`. Ansible's \`uri\` task in \`deploy_data.yml\` fetching the actual secret path is the authoritative test — it fails with a clear HTTP status if the fetch doesn't work.

## Test plan

- [x] Promotion pipeline (run 24294059506) already proved Vault fetch works end-to-end on this int runner
- [ ] After merge, the delivery pipeline's deploy-int should pass the health probe as a warning and proceed to the actual ansible Vault fetch
- [ ] If Vault is genuinely broken, ansible will fail at the \`Vault: fetch settings.json\` task with a real error

🤖 Generated with [Claude Code](https://claude.com/claude-code)