### PR TITLE
Fix S3 sync: pin to self-hosted prod runner for SSH access

### DIFF
--- a/.github/workflows/sync-prod-data-to-s3.yml
+++ b/.github/workflows/sync-prod-data-to-s3.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   sync-prod-data-to-s3:
     name: "Sync prod data to S3"
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, prod]
 
     steps:
       - name: Setup SSH


### PR DESCRIPTION
The sync-prod-data-to-s3 workflow ran on ubuntu-latest (GitHub-hosted runner) which gets a random cloud IP on every run. pop0 (187.124.112.155) is firewalled to known IPs, so SSH always times out from a GH runner.

Pin to [self-hosted, Linux, prod] — the same runner (srv1467484) that the delivery pipeline uses to successfully deploy to pop0. It has SSH access and the network route.