### PR TITLE
ci: promotion pipeline — full int canary, code-only test/acc

### DIFF
--- a/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
@@ -1,29 +1,41 @@
 name: CI/CD Promotion Pipeline (main → int → test → acc)
 # Deploys from main branch through non-production environments: int → smoke test → test → acc
-# For config/server updates only — no full builds or production deployments
-# Use deploy-wslproxy-delivery-pipeline.yml for production releases from the release branch
+#
+# Auto-trigger policy (push to `main`):
+#   - int  → `full`  (everything: api code, nginx, servers, both admin
+#                     UIs, os_deps, build).  This is the canary host
+#                     where every layer is verified before promotion.
+#   - test → `code`  (Lua api/* only — int already proved the rest).
+#   - acc  → `code`  (same).
+#
+# Manual `workflow_dispatch` lets ops pick any DEPLOY_MODE and stop
+# at any TARGET_ENV — useful for surgical redeploys (e.g. push only
+# `dashboard-next` to acc after an admin-UI hotfix).
+#
+# Production hosts are never touched here — use
+# deploy-wslproxy-delivery-pipeline.yml for production releases from
+# the release branch.
 
 on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - feature/*
-      - bugfix/*
-      - hotfix/*
-      - release/*
-      - main
   workflow_dispatch:
     inputs:
       DEPLOY_MODE:
         type: choice
-        description: "What to deploy"
-        default: "servers"
+        description: "What to deploy (full = everything; specific layers for surgical updates)"
+        default: "full"
         required: true
         options:
+          - full
+          - code
           - nginx
           - servers
+          - dashboard
+          - dashboard-next
+          - os_deps
+          - build
 
       TARGET_ENV:
         type: choice
@@ -110,7 +122,11 @@ jobs:
       docker_prune: false
       notify_success: false
       deploy_branch: main
-      deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'servers' }}
+      # int is the canary — push to main runs `full` so every layer
+      # is exercised here before promoting code-only to test/acc.
+      # Manual workflow_dispatch can override DEPLOY_MODE for a
+      # scoped redeploy.
+      deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
@@ -205,7 +221,10 @@ jobs:
       docker_prune: false
       notify_success: true
       deploy_branch: main
-      deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'servers' }}
+      # Push to main → `code` only (int already proved every other
+      # layer in the canary stage above).  Manual workflow_dispatch
+      # can override DEPLOY_MODE for a scoped or `full` redeploy.
+      deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'code' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
@@ -233,7 +252,10 @@ jobs:
       docker_prune: false
       notify_success: true
       deploy_branch: main
-      deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'servers' }}
+      # Push to main → `code` only (int already proved every other
+      # layer in the canary stage above).  Manual workflow_dispatch
+      # can override DEPLOY_MODE for a scoped or `full` redeploy.
+      deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'code' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 


### PR DESCRIPTION
## Summary

Reworks `.github/workflows/deploy-wslproxy-promotion-pipeline.yml` so a push to `main` automatically promotes through non-prod environments with the right scope per stage.

### Default mode per environment (push to `main`)

| Stage | Host | Mode |
|---|---|---|
| Int | 192.168.1.193 | **`full`** — every layer (api code, nginx, servers, both admin UIs, os_deps, build) |
| Test | 192.168.1.140 | **`code`** — api/*.lua only |
| Acc | 187.77.179.206 | **`code`** — api/*.lua only |

Int acts as the canary where every layer is exercised; test + acc piggyback on what int proved.

### Removed: `pull_request:` trigger

Previously every PR fanned out to int → test → acc with `servers`-tag deploys. With the heavier `full`-by-default policy that would be both wasteful and risky, so PR triggers are removed entirely. Promotion runs only on:

- `push: main`
- Manual `workflow_dispatch` (any `DEPLOY_MODE`, any `TARGET_ENV`)

### Manual dispatch choices

`DEPLOY_MODE` expanded to the full delivery-pipeline set: `full`, `code`, `nginx`, `servers`, `dashboard`, `dashboard-next`, `os_deps`, `build`. Useful for surgical redeploys (e.g. push only `dashboard-next` to acc after an admin-UI hotfix).

`TARGET_ENV` unchanged: `int` / `test` / `acc`. Prod hosts still require the separate `deploy-wslproxy-delivery-pipeline.yml` from a release branch.

## Test plan

- [ ] Trigger a manual `workflow_dispatch` with `DEPLOY_MODE=full`, `TARGET_ENV=int` — verify all ansible tags run on 193.
- [ ] Trigger a `push` to a small commit on `main` — verify int gets `full`, test + acc each get `code`.
- [ ] Trigger `workflow_dispatch` with `DEPLOY_MODE=dashboard-next`, `TARGET_ENV=acc` — verify only the Next.js admin redeploys to 206.
- [ ] Open a PR — verify the promotion pipeline does NOT fire (only the delivery pipeline / build-validate workflows should).

🤖 Generated with [Claude Code](https://claude.com/claude-code)