### PR TITLE
fix(admin-next): accept BARE_METAL platform — fixes 500 on int

### DIFF
--- a/openresty-admin-next/src/lib/config/env.ts
+++ b/openresty-admin-next/src/lib/config/env.ts
@@ -20,8 +20,14 @@ const clientEnvSchema = z.object({
   NEXT_PUBLIC_APP_VERSION: z.string().default("dev"),
   NEXT_PUBLIC_APP_BUILD_NUMBER: z.string().default("local"),
   NEXT_PUBLIC_DEPLOYMENT_TIME: z.string().default(""),
+  // Accept the four deploy targets we actually ship to.  `BARE_METAL`
+  // is the value the Ansible systemd template sets on int / test /
+  // acc / prod (see infra/ansible/roles/wslproxy/templates/
+  // wslproxy-nextjs-dashboard.service.j2:28); without it here, env
+  // validation throws on import and every page that pulls in this
+  // module 500s.  `NATIVE` is kept as an alias for older deployments.
   NEXT_PUBLIC_TARGET_PLATFORM: z
-    .enum(["DOCKER", "KUBERNETES", "NATIVE"])
+    .enum(["DOCKER", "KUBERNETES", "NATIVE", "BARE_METAL"])
     .default("DOCKER"),
   NEXT_PUBLIC_THEME_PRIMARY_COLOR: z
     .string()


### PR DESCRIPTION
## Summary

Adds `BARE_METAL` to the `NEXT_PUBLIC_TARGET_PLATFORM` enum in [`lib/config/env.ts`](openresty-admin-next/src/lib/config/env.ts) so the value the Ansible systemd template ships matches what the Zod validator accepts.

## Symptom

Every authenticated page on `https://int-our-new.wslproxy.com/` returned a generic Next.js 500 "Internal Server Error". `/login` worked because it doesn't import `lib/config/env.ts`.

## Root cause

[`infra/ansible/roles/wslproxy/templates/wslproxy-nextjs-dashboard.service.j2:28`](infra/ansible/roles/wslproxy/templates/wslproxy-nextjs-dashboard.service.j2#L28) sets:

```
Environment=NEXT_PUBLIC_TARGET_PLATFORM=BARE_METAL
```

…but the Zod schema only allowed `DOCKER | KUBERNETES | NATIVE`, so the env validator threw at module-import time:

```
⨯ Error: Invalid client environment variables:
  - NEXT_PUBLIC_TARGET_PLATFORM:
    Invalid option: expected one of "DOCKER"|"KUBERNETES"|"NATIVE"
```

Every page that imports `env` — WelcomeBanner, AppBar, BuildVersionPanel, etc. — 500'd as a result. Confirmed live via journalctl on `slworker00` (192.168.1.193).

## Fix

```diff
   NEXT_PUBLIC_TARGET_PLATFORM: z
-    .enum(["DOCKER", "KUBERNETES", "NATIVE"])
+    .enum(["DOCKER", "KUBERNETES", "NATIVE", "BARE_METAL"])
     .default("DOCKER"),
```

`NATIVE` is kept as an alias so older deployments / hot-patches still validate.

## Verification

Hot-patched int's systemd unit `BARE_METAL` → `NATIVE` to prove the hypothesis end-to-end before merging. After patch + service restart:

```
/                    200    (was 500)
/login               200
/servers             200    (was 500)
/system-status       200    (was 500)
```

No more `Invalid client environment variables` in `journalctl -u wslproxy-nextjs-dashboard`.

## After merge

The next promotion-pipeline run will re-render the systemd unit with `BARE_METAL` (the canonical template value) — the new bundle will accept it directly and the hot-patch becomes redundant.

## Test plan

- [ ] Merge → trigger `gh workflow run deploy-wslproxy-promotion-pipeline.yml -f DEPLOY_MODE=dashboard-next -f TARGET_ENV=int`
- [ ] After rsync + systemd restart, confirm `journalctl -u wslproxy-nextjs-dashboard` no longer reports `Invalid client environment variables`
- [ ] Confirm `https://int-our-new.wslproxy.com/` renders the dashboard (not a 500)
- [ ] Confirm the hot-patched `NATIVE` reverts to `BARE_METAL` in the unit file

## Known unrelated issue (not in this PR)

journalctl also reports a benign warning:

```
Invalid environment assignment, ignoring: Proxy
```

Caused by line 24 of the j2 template (`Environment=NEXT_PUBLIC_APP_DISPLAY_NAME=WSL Proxy` — unquoted space). Truncates the AppBar title to "WSL". Trivial j2 quoting fix; happy to ship as a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)