### PR TITLE
ci: gate Next.js dashboard health + fix bare-metal platform flag

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -65,6 +65,10 @@ on:
         description: "Deploy mode: code, nginx, servers, dashboard, dashboard-next, os_deps, build, full"
         type: string
         required: true
+      nextjs_dashboard_port:
+        description: "Port the nginx-fronted Next.js dashboard listens on (nginx_nextjs_dashboard_port). Used only by the post-deploy dashboard health gate."
+        type: string
+        default: "8099"
     secrets:
       SLACK_WEBHOOK:
         required: true
@@ -135,7 +139,7 @@ jobs:
           NEXT_PUBLIC_APP_VERSION=${APP_VERSION}
           NEXT_PUBLIC_APP_BUILD_NUMBER=${APP_BUILD}
           NEXT_PUBLIC_DEPLOYMENT_TIME=${DEPLOY_TIME}
-          NEXT_PUBLIC_TARGET_PLATFORM=DOCKER
+          NEXT_PUBLIC_TARGET_PLATFORM=BARE_METAL
           ENVEOF
           # Strip leading whitespace from env file
           sed -i 's/^[[:space:]]*//' .env.production
@@ -440,6 +444,70 @@ jobs:
             sleep $WAIT
           done
           echo "::error::Health check failed on ${{ inputs.env_label }} after $((RETRIES * WAIT))s"
+          exit 1
+
+      # ── Next.js dashboard health gate ──
+      # Only runs when this deploy actually touched the dashboard
+      # (dashboard-next / dashboard / full).  The main gate above only
+      # checks the Lua API on :8080 — without this, a Next.js service
+      # that failed to start would still let the pipeline pass green.
+      #
+      # Connection-mode based (not health_check_mode) because the
+      # dashboard port is bound to localhost on the target and isn't
+      # reachable externally on prod hosts — so we always check it
+      # locally or over SSH, mirroring the openresty -t check above.
+      - name: Post-deploy Next.js dashboard health gate
+        if: contains(inputs.deploy_mode, 'dashboard') || inputs.deploy_mode == 'full'
+        run: |
+          PORT="${{ inputs.nextjs_dashboard_port }}"
+          # /login always returns 200 (the root redirects to it when
+          # unauthenticated, which would muddy a status-code check).
+          URL="http://localhost:${PORT}/login"
+          SVC="wslproxy-nextjs-dashboard"
+          echo "Verifying Next.js dashboard on ${{ inputs.env_label }} (port ${PORT})..."
+
+          SSH_OPTS="-o BatchMode=yes -o ConnectTimeout=10"
+          [[ "${{ inputs.connection_mode }}" == "ssh_key" ]] && SSH_OPTS="$SSH_OPTS -i ~/.ssh/id_rsa"
+
+          # 1) systemd service must be active
+          if [[ "${{ inputs.connection_mode }}" == "local" ]]; then
+            sudo systemctl is-active "$SVC" >/dev/null 2>&1 || {
+              echo "::error::$SVC is not active on ${{ inputs.host_ip }}"
+              sudo systemctl status "$SVC" --no-pager -l 2>&1 | tail -30 || true
+              exit 1
+            }
+          else
+            SUDO_PREFIX=""
+            [[ "${{ inputs.ssh_user }}" != "root" ]] && SUDO_PREFIX="sudo"
+            ssh $SSH_OPTS ${{ inputs.ssh_user }}@${{ inputs.host_ip }} \
+              "$SUDO_PREFIX systemctl is-active $SVC" >/dev/null 2>&1 || {
+              echo "::error::$SVC is not active on ${{ inputs.host_ip }}"
+              ssh $SSH_OPTS ${{ inputs.ssh_user }}@${{ inputs.host_ip }} \
+                "$SUDO_PREFIX systemctl status $SVC --no-pager -l 2>&1 | tail -30" || true
+              exit 1
+            }
+          fi
+          echo "Service $SVC is active"
+
+          # 2) dashboard must serve /login with HTTP 200 (retry: the
+          #    Node server takes a few seconds to bind after restart)
+          RETRIES=12
+          WAIT=5
+          for i in $(seq 1 $RETRIES); do
+            if [[ "${{ inputs.connection_mode }}" == "local" ]]; then
+              STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null || echo "000")
+            else
+              STATUS=$(ssh $SSH_OPTS ${{ inputs.ssh_user }}@${{ inputs.host_ip }} \
+                "curl -sf -o /dev/null -w '%{http_code}' $URL 2>/dev/null" || echo "000")
+            fi
+            if [ "$STATUS" = "200" ]; then
+              echo "Next.js dashboard health check passed (HTTP $STATUS on $URL)"
+              exit 0
+            fi
+            echo "Attempt $i/$RETRIES: HTTP $STATUS on $URL — waiting ${WAIT}s..."
+            sleep $WAIT
+          done
+          echo "::error::Next.js dashboard did not return 200 on $URL after $((RETRIES * WAIT))s"
           exit 1
 
       # ── Slack notifications ──


### PR DESCRIPTION
## Summary

Closes two gaps in the delivery pipeline's Next.js dashboard deploy, found while tracing whether `deploy-wslproxy-delivery-pipeline.yml` actually ships the new dashboard via Ansible.

**① Next.js health gate** — the post-deploy gate previously only checked the Lua API on `:8080`, so a Next.js standalone server that failed to start would still let the pipeline pass green. Added a dashboard health step (gated on `dashboard-next` / `dashboard` / `full` deploy modes) that:
- asserts `systemctl is-active wslproxy-nextjs-dashboard` (dumps `systemctl status` tail on failure)
- curls `http://localhost:<port>/login` expecting HTTP 200, retrying 12×5s while the Node server binds
- checks locally or over SSH based on `connection_mode` (the dashboard port is localhost-bound, unreachable externally on prod), mirroring the existing `openresty -t` check
- new overridable `nextjs_dashboard_port` input (default `8099` = `nginx_nextjs_dashboard_port`)

**② Build-time platform flag** — the generated `.env.production` set `NEXT_PUBLIC_TARGET_PLATFORM=DOCKER` on bare-metal Ansible targets. Next inlines `NEXT_PUBLIC_*` into the browser bundle at build time, so that — not the systemd `Environment=` (already `BARE_METAL`) — is what the client sees. Set to `BARE_METAL` so platform-gated UI (e.g. the Sync button) behaves correctly.

## Context

- Dashboard runs on **port 8099** (nginx) → `127.0.0.1:3099` (Node standalone). All five pipeline hosts use these defaults; `nginx_web_ui_enabled: "yes"` everywhere, so `full` (push default) and `dashboard-next` both deploy it via `deploy_nextjs_admin_ui.yml`.

## Test plan

- [ ] Manual run with `DEPLOY_MODE=dashboard-next` to int → new gate passes when the service is up
- [ ] Stop `wslproxy-nextjs-dashboard` on a host, redeploy → gate fails loudly (regression check)
- [ ] Confirm the deployed dashboard bundle reports `BARE_METAL` (Sync button hidden state matches)

## Risk

Low — touches only `deploy-environment.yml`. The new gate is additive and scoped to dashboard deploy modes, so non-dashboard runs (`code`, `nginx`, `servers`) are unaffected. No conflicts with main (branch is strictly ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)