### PR TITLE
fix(admin-next): runtime /api + /swagger proxy — host-agnostic bundle

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -489,26 +489,51 @@ jobs:
           fi
           echo "Service $SVC is active"
 
+          # helper: run a curl either locally or over SSH
+          probe() {
+            local u="$1"
+            if [[ "${{ inputs.connection_mode }}" == "local" ]]; then
+              curl -s -o /dev/null -w "%{http_code}" "$u" 2>/dev/null || echo "000"
+            else
+              ssh $SSH_OPTS ${{ inputs.ssh_user }}@${{ inputs.host_ip }} \
+                "curl -s -o /dev/null -w '%{http_code}' '$u' 2>/dev/null" || echo "000"
+            fi
+          }
+
           # 2) dashboard must serve /login with HTTP 200 (retry: the
           #    Node server takes a few seconds to bind after restart)
           RETRIES=12
           WAIT=5
+          OK=""
           for i in $(seq 1 $RETRIES); do
-            if [[ "${{ inputs.connection_mode }}" == "local" ]]; then
-              STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null || echo "000")
-            else
-              STATUS=$(ssh $SSH_OPTS ${{ inputs.ssh_user }}@${{ inputs.host_ip }} \
-                "curl -sf -o /dev/null -w '%{http_code}' $URL 2>/dev/null" || echo "000")
-            fi
+            STATUS=$(probe "$URL")
             if [ "$STATUS" = "200" ]; then
-              echo "Next.js dashboard health check passed (HTTP $STATUS on $URL)"
-              exit 0
+              echo "Next.js /login OK (HTTP $STATUS)"
+              OK=1; break
             fi
             echo "Attempt $i/$RETRIES: HTTP $STATUS on $URL — waiting ${WAIT}s..."
             sleep $WAIT
           done
-          echo "::error::Next.js dashboard did not return 200 on $URL after $((RETRIES * WAIT))s"
-          exit 1
+          if [ -z "$OK" ]; then
+            echo "::error::Next.js dashboard did not return 200 on $URL after $((RETRIES * WAIT))s"
+            exit 1
+          fi
+
+          # 3) the /api/* proxy must REACH the backend.  Unauthenticated
+          #    we expect 401 (or any non-5xx); a 5xx means the dashboard's
+          #    API proxy is misrouted to a dead port — exactly the
+          #    baked-wrong-port bug this guards against.  Without this
+          #    check the dashboard can pass /login yet show empty
+          #    server/rule lists in the browser.
+          API_URL="http://localhost:${PORT}/api/servers?_format=json"
+          API_STATUS=$(probe "$API_URL")
+          if [ "$API_STATUS" -ge 500 ] 2>/dev/null || [ "$API_STATUS" = "000" ]; then
+            echo "::error::Next.js /api proxy is broken (HTTP $API_STATUS on /api/servers). Likely WSLPROXY_API_URL points at the wrong/dead backend port."
+            exit 1
+          fi
+          echo "Next.js /api proxy reaches backend (HTTP $API_STATUS — non-5xx, auth gate working)"
+          echo "Next.js dashboard health check passed"
+          exit 0
 
       # ── Slack notifications ──
       - name: Slack notify - deployed

--- a/openresty-admin-next/next.config.ts
+++ b/openresty-admin-next/next.config.ts
@@ -107,31 +107,19 @@ const nextConfig: NextConfig = {
     ];
   },
 
-  async rewrites() {
-    const apiBase =
-      process.env.WSLPROXY_API_URL ?? "http://wslproxy-local:8080";
-    return [
-      // NB: there is NO `/health` rewrite here intentionally.  The
-      // upstream nginx has `location /health` as a PREFIX match
-      // that hands anything starting with "/health" (including
-      // "/health-status", "/healthcheck", etc.) to the Lua JSON
-      // probe — so the admin dashboard lives at `/system-status`
-      // to sidestep the collision without touching nginx.
-      { source: "/api/:path*", destination: `${apiBase}/api/:path*` },
-      // Swagger UI is static HTML served by OpenResty at /swagger/.
-      // Forward the SAME path (`/swagger/`) so:
-      //   - The URL in the operator's address bar is the real one,
-      //     matching what nginx serves at the openresty front directly.
-      //   - Swagger's absolute asset paths (`/swagger/openapi.json` etc.)
-      //     resolve to the upstream too, instead of 404ing because they
-      //     don't match a different alias prefix.
-      // The bare `/swagger` source covers Next.js's trailing-slash
-      // redirect dance; `/swagger/:path*` covers nested assets and the
-      // openapi.json fetch.
-      { source: "/swagger", destination: `${apiBase}/swagger/` },
-      { source: "/swagger/:path*", destination: `${apiBase}/swagger/:path*` },
-    ];
-  },
+  // NB: `/api/*` and `/swagger/*` are intentionally NOT build-time
+  // rewrites.  Build-time rewrites freeze the upstream port
+  // (WSLPROXY_API_URL) into the standalone artifact — which breaks on
+  // hosts whose admin API isn't on the default port (e.g. prod pop0 on
+  // :7691).  Both are now handled by RUNTIME proxy route handlers:
+  //   src/app/api/[...path]/route.ts
+  //   src/app/swagger/[[...path]]/route.ts
+  // which read WSLPROXY_API_URL per request, so one bundle works on
+  // every host and a deploy can never re-bake a wrong port.
+  //
+  // There is deliberately no `/health` route either — upstream nginx
+  // owns `location /health` as a prefix match, so the dashboard lives
+  // at `/system-status` to avoid the collision.
 };
 
 export default withBundleAnalyzer(nextConfig);

--- a/openresty-admin-next/src/app/api/[...path]/route.ts
+++ b/openresty-admin-next/src/app/api/[...path]/route.ts
@@ -1,0 +1,33 @@
+import type { NextRequest } from "next/server";
+import { proxyToUpstream } from "@/lib/api/proxy-upstream";
+
+/* Runtime reverse-proxy for /api/*  →  <WSLPROXY_API_URL>/api/*
+ *
+ * Replaces the old build-time next.config rewrite, which baked the
+ * upstream port into the standalone artifact and broke on hosts whose
+ * admin API isn't on the default port (see proxy-upstream.ts for the
+ * full story).  `/api/*` is excluded from the auth middleware matcher,
+ * so requests reach here directly and the Lua backend does its own JWT
+ * check. */
+
+// Must run on Node (needs process.env + fetch to an internal host) and
+// must never be cached/prerendered — every call is a live proxy.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function handler(
+  req: NextRequest,
+  ctx: { params: Promise<{ path?: string[] }> },
+): Promise<Response> {
+  const { path } = await ctx.params;
+  const suffix = path && path.length ? `/${path.join("/")}` : "";
+  return proxyToUpstream(req, `/api${suffix}`);
+}
+
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;
+export const PATCH = handler;
+export const DELETE = handler;
+export const HEAD = handler;
+export const OPTIONS = handler;

--- a/openresty-admin-next/src/app/swagger/[[...path]]/route.ts
+++ b/openresty-admin-next/src/app/swagger/[[...path]]/route.ts
@@ -1,0 +1,28 @@
+import type { NextRequest } from "next/server";
+import { proxyToUpstream } from "@/lib/api/proxy-upstream";
+
+/* Runtime reverse-proxy for /swagger and /swagger/*  →
+ *   <WSLPROXY_API_URL>/swagger/...
+ *
+ * Same rationale as the /api proxy: the old build-time rewrite baked the
+ * upstream port, so swagger broke on hosts using a non-default API port.
+ * The optional catch-all `[[...path]]` covers both the bare `/swagger`
+ * entry and nested assets / the openapi.json fetch.  Auth middleware
+ * still runs for /swagger (it's not in the matcher's exclude list), so
+ * the docs stay behind the admin login exactly as before. */
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function handler(
+  req: NextRequest,
+  ctx: { params: Promise<{ path?: string[] }> },
+): Promise<Response> {
+  const { path } = await ctx.params;
+  // Backend serves the UI at "/swagger/"; map bare "/swagger" there too.
+  const suffix = path && path.length ? `/${path.join("/")}` : "/";
+  return proxyToUpstream(req, `/swagger${suffix}`);
+}
+
+export const GET = handler;
+export const HEAD = handler;

--- a/openresty-admin-next/src/lib/api/proxy-upstream.ts
+++ b/openresty-admin-next/src/lib/api/proxy-upstream.ts
@@ -1,0 +1,123 @@
+import type { NextRequest } from "next/server";
+import { env } from "@/lib/config/env";
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Runtime reverse-proxy to the Lua admin API / swagger.
+
+   WHY THIS EXISTS (the bug it fixes):
+     Next.js `rewrites()` in next.config are evaluated at BUILD time and
+     frozen into the standalone routes-manifest.  That meant the upstream
+     port (`WSLPROXY_API_URL`) got *baked into the artifact*.  Our hosts
+     run the admin API on different ports (8080 default, 7691 on prod
+     pop0), so a single baked bundle could only be correct on one host —
+     and the delivery pipeline kept shipping a bundle baked with `:8080`
+     to a host whose API is on `:7691`, giving ECONNREFUSED → 500 → empty
+     server/rule lists.
+
+     Server Components already dodged this because `server-client.ts`
+     reads `env.apiUrl` (i.e. `WSLPROXY_API_URL`) at RUNTIME.  This route
+     handler brings the browser-side `/api/*` path onto the same runtime
+     resolution, so the bundle is host-agnostic: the systemd service's
+     `Environment=WSLPROXY_API_URL=…` (set per host from
+     nginx_default_server_backend_port) is the single source of truth and
+     a deploy can never re-bake a wrong port again.
+
+   Behaviour:
+     - Streams the request through with method, query string, headers and
+       body intact.
+     - Forwards cookies both ways — critical for the httpOnly
+       `wslproxy_token` set by POST /api/user/login.
+     - Strips hop-by-hop headers (RFC 7230 §6.1) so we don't corrupt the
+       connection / framing.
+     - `redirect: "manual"` so 30x from the backend pass through verbatim
+       (e.g. login redirects) instead of being silently followed here.
+   ────────────────────────────────────────────────────────────────────────── */
+
+// RFC 7230 hop-by-hop headers — must not be forwarded across a proxy.
+// `host` and `content-length` are dropped so fetch sets them correctly
+// for the upstream connection.
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+]);
+
+function upstreamBase(): string {
+  // Read at runtime — NOT inlined at build.  Trailing slash trimmed so
+  // we can append the path cleanly.
+  return (env.apiUrl ?? "http://wslproxy-local:8080").replace(/\/+$/, "");
+}
+
+/**
+ * Proxy `req` to `<WSLPROXY_API_URL><upstreamPath><original query>`.
+ * `upstreamPath` must start with "/".
+ */
+export async function proxyToUpstream(
+  req: NextRequest,
+  upstreamPath: string,
+): Promise<Response> {
+  const target = `${upstreamBase()}${upstreamPath}${req.nextUrl.search}`;
+
+  // Copy request headers minus hop-by-hop.
+  const fwdHeaders = new Headers();
+  req.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) fwdHeaders.set(key, value);
+  });
+
+  const method = req.method.toUpperCase();
+  const hasBody = method !== "GET" && method !== "HEAD";
+  const body = hasBody ? await req.arrayBuffer() : undefined;
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(target, {
+      method,
+      headers: fwdHeaders,
+      body: body && body.byteLength > 0 ? body : undefined,
+      redirect: "manual",
+      cache: "no-store",
+    });
+  } catch (err) {
+    // Upstream unreachable (e.g. wrong port / service down).  Surface a
+    // clear 502 instead of a generic Next.js 500 so it's obvious in logs
+    // that the *backend* connection failed, not the dashboard.
+    return new Response(
+      JSON.stringify({
+        error: {
+          message: "Upstream API unreachable",
+          target: target.replace(/\?.*$/, ""),
+          detail: err instanceof Error ? err.message : String(err),
+        },
+      }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  // Copy response headers minus hop-by-hop; Set-Cookie handled separately
+  // so multiple cookies aren't folded into one header.
+  const respHeaders = new Headers();
+  upstream.headers.forEach((value, key) => {
+    const lower = key.toLowerCase();
+    if (lower === "set-cookie") return;
+    if (!HOP_BY_HOP.has(lower)) respHeaders.set(key, value);
+  });
+  const setCookies =
+    typeof upstream.headers.getSetCookie === "function"
+      ? upstream.headers.getSetCookie()
+      : [];
+  for (const cookie of setCookies) respHeaders.append("set-cookie", cookie);
+
+  const respBody = await upstream.arrayBuffer();
+  return new Response(respBody, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: respHeaders,
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the new Next.js dashboard showing **empty server/rule lists** on hosts whose admin API isn't on the default port (prod pop0 runs it on `:7691`).

**Root cause:** Next.js `rewrites()` are evaluated at **build time** and frozen into the standalone routes-manifest, so the upstream port (`WSLPROXY_API_URL`) was baked into the artifact. The delivery pipeline kept shipping a bundle baked with `:8080` to pop0 (`:7691`) → `ECONNREFUSED` → 500 on every `/api/*` call → empty lists. Server Components already worked (they read `WSLPROXY_API_URL` at runtime); only the browser `/api/*` path (the build-time rewrite) was broken.

## Change

Move `/api` and `/swagger` off build-time rewrites onto **runtime App Router proxy route handlers**:
- `src/lib/api/proxy-upstream.ts` — shared proxy that reads `WSLPROXY_API_URL` per request; forwards method/query/headers/body, preserves `Set-Cookie` both ways (login cookie), strips hop-by-hop headers, returns a clear **502** (not generic 500) when the backend is unreachable.
- `src/app/api/[...path]/route.ts` → `/api/*`
- `src/app/swagger/[[...path]]/route.ts` → `/swagger*` (same latent bug)
- `next.config.ts` — drop the `/api` + `/swagger` rewrites.

**Result:** one bundle works on every host. The per-host systemd `Environment=WSLPROXY_API_URL` (already derived from `nginx_default_server_backend_port`) is the single source of truth, so a deploy can never re-bake a wrong port again. Build confirms no upstream port remains in the manifests.

## Pipeline safety net

The post-deploy Next.js health gate (`deploy-environment.yml`, from #1032) now also probes `/api/servers` through the dashboard and **fails the deploy on a 5xx** — previously the dashboard could pass `/login` yet serve empty lists in the browser.

## Test plan

- [x] `tsc --noEmit` + `next build` clean; routes register as `ƒ /api/[...path]` and `ƒ /swagger/[[...path]]`; no baked port in `routes-manifest.json` / `required-server-files.json`
- [ ] Deploy `dashboard-next` to pop0 → `prod-our.wslproxy.com/servers` lists the 98 servers (replaces the manual hotfix currently in place)
- [ ] Gate fails if `WSLPROXY_API_URL` points at a dead port (5xx on `/api/servers`)
- [ ] Local Docker dev (`WSLPROXY_API_URL=http://wslproxy-local:8080`) still proxies correctly

## Notes

- A manual hotfix is live on pop0 (patched the baked `:8080`→`:7691`); it keeps working until this lands via a `dashboard-next` deploy, after which the bundle is self-correcting and the hotfix is moot.
- Deploying this is currently gated on the GitHub account suspension being lifted (pipeline checkout 403); can also be rolled out via manual Ansible in the meantime.

No conflicts with main (branch strictly ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)