### PR TITLE
admin-next: list pages default to newest-first + sidebar relabel

### DIFF
--- a/openresty-admin-next/src/app/(dashboard)/instances/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/instances/page.tsx
@@ -16,8 +16,8 @@ export default function InstancesListPage() {
   const [perPage, setPerPage] = useState(25);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
-    field: "id",
-    order: "ASC",
+    field: "created_at",
+    order: "DESC",
   });
 
   const params = useMemo(

--- a/openresty-admin-next/src/app/(dashboard)/profiles/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/profiles/page.tsx
@@ -14,8 +14,13 @@ export default function ProfilesListPage() {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(25);
   const [search, setSearch] = useState("");
+  // Profiles are filesystem directories (not JSON records), so the
+  // backend exposes them with `name` + `createdAt` (camelCase) — not
+  // the `created_at` snake_case that the other resources use.  Sort
+  // alphabetically by name; that's also the most useful order for a
+  // small set of named buckets.
   const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
-    field: "id",
+    field: "name",
     order: "ASC",
   });
 

--- a/openresty-admin-next/src/app/(dashboard)/rules/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/rules/page.tsx
@@ -17,8 +17,8 @@ export default function RulesListPage() {
   const [perPage, setPerPage] = useState(25);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
-    field: "id",
-    order: "ASC",
+    field: "created_at",
+    order: "DESC",
   });
 
   const params = useMemo(

--- a/openresty-admin-next/src/app/(dashboard)/secrets/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/secrets/page.tsx
@@ -16,8 +16,8 @@ export default function SecretsListPage() {
   const [perPage, setPerPage] = useState(25);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
-    field: "id",
-    order: "ASC",
+    field: "created_at",
+    order: "DESC",
   });
 
   const params = useMemo(

--- a/openresty-admin-next/src/app/(dashboard)/servers/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/servers/page.tsx
@@ -18,8 +18,8 @@ export default function ServersListPage() {
   const [perPage, setPerPage] = useState(25);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
-    field: "id",
-    order: "ASC",
+    field: "created_at",
+    order: "DESC",
   });
 
   const params = useMemo(

--- a/openresty-admin-next/src/app/(dashboard)/upstreams/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/upstreams/page.tsx
@@ -17,8 +17,8 @@ export default function UpstreamsListPage() {
   const [perPage, setPerPage] = useState(25);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
-    field: "id",
-    order: "ASC",
+    field: "created_at",
+    order: "DESC",
   });
 
   const params = useMemo(

--- a/openresty-admin-next/src/app/(dashboard)/users/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/users/page.tsx
@@ -16,8 +16,8 @@ export default function UsersListPage() {
   const [perPage, setPerPage] = useState(25);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
-    field: "id",
-    order: "ASC",
+    field: "created_at",
+    order: "DESC",
   });
 
   const params = useMemo(

--- a/openresty-admin-next/src/app/(dashboard)/waf-policies/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/waf-policies/page.tsx
@@ -17,8 +17,8 @@ export default function WafPoliciesListPage() {
   const [perPage, setPerPage] = useState(25);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
-    field: "id",
-    order: "ASC",
+    field: "created_at",
+    order: "DESC",
   });
 
   const params = useMemo(

--- a/openresty-admin-next/src/app/(dashboard)/waf-rules/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/waf-rules/page.tsx
@@ -40,8 +40,8 @@ export default function WafRulesListPage() {
   const [perPage, setPerPage] = useState(25);
   const [search, setSearch] = useState("");
   const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
-    field: "id",
-    order: "ASC",
+    field: "created_at",
+    order: "DESC",
   });
 
   const params = useMemo(

--- a/openresty-admin-next/src/components/layout/Sidebar.tsx
+++ b/openresty-admin-next/src/components/layout/Sidebar.tsx
@@ -73,7 +73,7 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
                 { label: "Sessions", href: "/sessions", icon: Activity },
               ] satisfies NavItem[])
             : []),
-          { label: "Logs & Troubleshoot", href: "/logs", icon: ScrollText },
+          { label: "Logs", href: "/logs", icon: ScrollText },
           // The admin health-dashboard page lives at `/system-status`,
           // not `/health`.  Reason: upstream nginx has
           // `location /health` as a PREFIX match → the Lua JSON probe


### PR DESCRIPTION
## Summary

Two small UX touches on the dashboard, both `openresty-admin-next/` only — no backend, no infra changes.

### 1. List pages default to newest-first, server-side (`088c6a7b`)

Previously every list defaulted to `field: "id", order: "ASC"`.  For records whose IDs aren't time-correlated (UUIDs, `host:`-prefixed strings), newly created servers/rules landed wherever their id sorted alphabetically — often deep in the list — and users reported "I lost the record I just created".

Switched the default to **`created_at DESC`** on the 8 list pages whose backend handlers set `payloads.created_at = os.time()` on POST/PUT:

| Resource | api.lua line that sets `created_at` |
|---|---|
| servers | 1343 |
| users | 1715 |
| rules | 2223 |
| secrets | 2249 |
| instances | 2266 |
| waf-rules | 2347 |
| waf-policies | 2460 |
| upstreams | 3034 |

So a freshly-saved record arrives at the top of page 1 on the next list refresh.  No backend changes — sort + filter were already flowing through `useList → dataProvider.getList → GET /api/{resource}?params={...}` and being processed server-side via `Helper.sortDesc(qParams.sort.field)` on the full collection before pagination.  This is purely the initial `useState` value on each page.

**Profiles is the exception** — it's exposed as filesystem directories (not JSON records), and the backend provides `createdAt` (camelCase) rather than `created_at`.  Defaulted to `name ASC` instead, which is the most useful order for a small set of named buckets anyway.  Inline comment explains the divergence.

### 2. Sidebar: shorten "Logs & Troubleshoot" → "Logs" (`d18d81dc`)

The longer label was the widest sidebar entry and broke the column rhythm at narrow widths.  Just the nav label — the page's own header (`logs/page.tsx:346` "Logs & Troubleshooting") is preserved.

## Test plan

- [x] `tsc --noEmit` + `next build` clean
- [ ] Create a new server / rule / upstream / etc. → it appears at the top of page 1, not buried at the bottom
- [ ] Click any column header to sort → state flips ASC/DESC as before
- [ ] Profiles page sorts alphabetically by name (no `created_at` regression)
- [ ] Sidebar "Logs" entry no longer pushes neighbouring items out of alignment

No conflicts with main (branch strictly ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)