### PR TITLE
ci(admin-ui-login): rename React-Admin login job to "Legacy Admin UI Login"

### DIFF
--- a/.github/workflows/e2e-admin-ui-login.yml
+++ b/.github/workflows/e2e-admin-ui-login.yml
@@ -66,7 +66,7 @@ jobs:
           echo "$MATRIX" | python3 -m json.tool
 
   login:
-    name: "Admin UI Login (${{ matrix.environment }} ${{ matrix.url }})"
+    name: "${{ matrix.suite == 'login' && 'Legacy Admin UI Login' || 'Admin UI Login' }} (${{ matrix.environment }} ${{ matrix.url }})"
     needs: setup
     # Pin to the runner whose label matches the env under test, so the
     # job lands on the host that actually has that env's login-creds.json


### PR DESCRIPTION
## What

In the **WSL Proxy Admin UI Login Tests** workflow (`.github/workflows/e2e-admin-ui-login.yml`), rename the matrix login job so the React-Admin run (e.g. `prod https://prod-our-v1.wslproxy.com`) displays as:

- **Legacy Admin UI Login (prod https://prod-our-v1.wslproxy.com)**

instead of "Admin UI Login (prod https://prod-our-v1.wslproxy.com)".

## How

The job name is templated over the matrix. The name is now conditional on `matrix.suite`:

- `login` suite (React-Admin / legacy, e.g. `prod-our-v1`) → **Legacy Admin UI Login**
- `login-next` suite (Next.js dashboard, e.g. `prod-our`) → **Admin UI Login** (unchanged)

This keeps the rename scoped to the legacy React-Admin run without touching the Next.js dashboard job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)