### PR TITLE
Fix footer build-info inlining + relax 305 rule validation

### DIFF
--- a/openresty-admin-next/src/lib/config/env.ts
+++ b/openresty-admin-next/src/lib/config/env.ts
@@ -75,12 +75,39 @@ function formatZodError(
   return `Invalid ${kind} environment variables:\n${issues}`;
 }
 
-const clientResult = clientEnvSchema.safeParse(process.env);
+// Critical: Next.js inlines `process.env.NEXT_PUBLIC_X` into the
+// client bundle ONLY when accessed by explicit property name — not
+// when `process.env` is passed around as a whole object.  Webpack's
+// DefinePlugin substitutes literal text matches like
+// `process.env.NEXT_PUBLIC_APP_VERSION`, but a call like
+// `safeParse(process.env)` reaches the browser with `process.env`
+// shimmed to `{ NODE_ENV: "production" }` — every NEXT_PUBLIC_* var
+// is undefined, every Zod `.default(...)` kicks in, and the footer
+// permanently shows `LOCAL · vdev · Build local` no matter what the
+// ansible build step set.  Build each field explicitly so the
+// inlining can fire.
+const clientEnv = {
+  NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
+  NEXT_PUBLIC_APP_DISPLAY_NAME: process.env.NEXT_PUBLIC_APP_DISPLAY_NAME,
+  NEXT_PUBLIC_APP_VERSION: process.env.NEXT_PUBLIC_APP_VERSION,
+  NEXT_PUBLIC_APP_BUILD_NUMBER: process.env.NEXT_PUBLIC_APP_BUILD_NUMBER,
+  NEXT_PUBLIC_DEPLOYMENT_TIME: process.env.NEXT_PUBLIC_DEPLOYMENT_TIME,
+  NEXT_PUBLIC_ENV_NAME: process.env.NEXT_PUBLIC_ENV_NAME,
+  NEXT_PUBLIC_GIT_SHA: process.env.NEXT_PUBLIC_GIT_SHA,
+  NEXT_PUBLIC_GIT_REPO: process.env.NEXT_PUBLIC_GIT_REPO,
+  NEXT_PUBLIC_TARGET_PLATFORM: process.env.NEXT_PUBLIC_TARGET_PLATFORM,
+  NEXT_PUBLIC_THEME_PRIMARY_COLOR: process.env.NEXT_PUBLIC_THEME_PRIMARY_COLOR,
+  NEXT_PUBLIC_THEME_SECONDARY_COLOR: process.env.NEXT_PUBLIC_THEME_SECONDARY_COLOR,
+};
+
+const clientResult = clientEnvSchema.safeParse(clientEnv);
 if (!clientResult.success) {
   throw new Error(formatZodError("client", clientResult.error));
 }
 
 // Only parse server schema in a Node runtime — skip on client bundles.
+// `process.env` IS the real env on the server (no Webpack rewriting),
+// so passing it as an object here is correct.
 const isServer = typeof window === "undefined";
 const serverResult = isServer
   ? serverEnvSchema.safeParse(process.env)

--- a/openresty-admin-next/src/lib/validation/input-schemas.ts
+++ b/openresty-admin-next/src/lib/validation/input-schemas.ts
@@ -333,12 +333,17 @@ export const ruleInputSchema = z
       message: "Redirect URI is required for 301 / 302 responses",
     },
   )
-  // ...and when it IS provided for 301/302/305, it must look like an
-  // http(s) URL.  The gateway proxies/redirects to it verbatim, so a
-  // malformed value silently 502s at request time.
+  // For 301 / 302 (real HTTP redirects) the destination MUST be a
+  // full `http(s)://` URL — the gateway puts it verbatim into the
+  // `Location:` response header, and browsers refuse anything without
+  // a scheme.  305 (proxy pass) does NOT carry that constraint: the
+  // Lua gateway strips/prefixes the scheme itself before opening
+  // the upstream connection, so the user can type any of
+  // `https://backend:8080`, `backend:8080`, or `1.2.3.4` and they all
+  // resolve to the same proxy target.  Don't force a scheme there.
   .refine(
     (v) =>
-      !(v.code === 301 || v.code === 302 || v.code === 305) ||
+      !(v.code === 301 || v.code === 302) ||
       v.redirect_uri.length === 0 ||
       httpUrlRegex.test(v.redirect_uri),
     {
@@ -346,12 +351,24 @@ export const ruleInputSchema = z
       message: "Must be a full http(s):// URL",
     },
   )
-  // 305 = proxy pass.  Lua gateway expects at least one backend; zero
-  // means the rule matches but can't route anywhere.
-  .refine((v) => v.code !== 305 || v.backends.length > 0, {
-    path: ["backends"],
-    message: "At least one backend is required for proxy-pass (305) rules",
-  })
+  // 305 = proxy pass.  The Lua gateway accepts EITHER a single
+  // `redirect_uri` (the legacy one-target shape) OR a `backends`
+  // array (weighted / canary routing) — having one is sufficient.
+  // Previously this required `backends.length > 0` unconditionally,
+  // which forced anyone routing to a single host to type the same
+  // address twice (once in Proxy URL, once as a backend) and made
+  // the form actively confusing.
+  .refine(
+    (v) =>
+      v.code !== 305 ||
+      v.redirect_uri.length > 0 ||
+      v.backends.length > 0,
+    {
+      path: ["backends"],
+      message:
+        "Proxy-pass (305) needs either a Proxy URL or at least one backend",
+    },
+  )
   // Each backend in a 305 rule needs an address — empty entries produce
   // broken upstream config.
   .refine(


### PR DESCRIPTION
Two production regressions found after #1044 went live.

## 1. Footer still shows `LOCAL · vdev · Build local` on prod

After the previous deploy, the prod footer permanently displayed dev defaults despite:
- The systemd service running with the right env vars (`NEXT_PUBLIC_APP_VERSION=1.0.10`, `NEXT_PUBLIC_APP_BUILD_NUMBER=26818128166`, `NEXT_PUBLIC_ENV_NAME=prod`, …) — verified via `systemctl show wslproxy-nextjs-dashboard.service`
- The ansible build step explicitly passing those vars to `npm run build`
- A fresh `.next/BUILD_ID` matching the deploy time
- Grep on the deployed JS chunks finding the `envName` field but no `"1.0.10"` value anywhere

**Root cause** — `env.ts` was doing `clientEnvSchema.safeParse(process.env)`, passing `process.env` as a whole object. Next.js's DefinePlugin **only inlines `NEXT_PUBLIC_*` vars when accessed by explicit property name** (literal `process.env.NEXT_PUBLIC_X`), not when `process.env` is referenced as an object. In the client bundle, `process.env` ships shimmed to `{ NODE_ENV: "production" }` — every `NEXT_PUBLIC_*` is undefined, every Zod `.default(...)` fires, footer permanently shows the dev defaults regardless of what the build set.

**Fix** — [env.ts:78-104](openresty-admin-next/src/lib/config/env.ts#L78-L104) builds an explicit `clientEnv` object first, one `process.env.NEXT_PUBLIC_X` access per field, then passes that to Zod. The server schema still uses `process.env` as an object — that IS the real env on the server, no Webpack rewriting in the picture.

No new env vars or backend changes required. After deploy, the prod footer will show `● PROD · v1.0.10 · Build 26818128166 ↗ · Deployed Xm ago · d605956 ↗`.

## 2. Creating a proxy-pass (305) rule required typing the same target twice

Two over-strict validations on 305 rules forced the user to:
- Add `http(s)://` to the Proxy URL even though the Lua gateway resolves the address and prefixes the scheme itself before opening the upstream
- Fill in BOTH the Proxy URL AND at least one backend row, even when routing to a single host

Both relaxed in [input-schemas.ts:336-371](openresty-admin-next/src/lib/validation/input-schemas.ts#L336-L371):

| Behaviour | Before | After |
|---|---|---|
| Proxy URL on 305 must be `http(s)://...` | yes (forced) | **no — accepts bare host/IP** (`backend:8080`, `1.2.3.4`, `https://x` all work) |
| 301 / 302 `Location:` redirect must be `http(s)://...` | yes | yes (kept — browsers refuse without scheme) |
| At least one backend on 305 | yes (unconditional) | **optional — either Proxy URL or one backend is enough** |
| Empty `backends[].address` rows | rejected | rejected (kept — they produce broken upstream config) |

If a user leaves both Proxy URL and backends blank on 305, they get: *"Proxy-pass (305) needs either a Proxy URL or at least one backend"*.

## Test plan
- [x] HMR compiles cleanly after both changes
- [x] Local rule form: 305 with bare `1.2.3.4` Proxy URL and zero backends → saves
- [x] Local rule form: 305 with `backend:8080` Proxy URL and zero backends → saves
- [x] Local rule form: 305 with empty Proxy URL but one valid backend → saves
- [x] Local rule form: 305 with empty Proxy URL and zero backends → fails with the new error message
- [x] 301 redirect_uri without scheme still rejected (browsers need the scheme in `Location:`)
- [ ] After deploy: verify prod footer shows real version / build / SHA / deployment-time
- [ ] After deploy: create a 305 rule with bare IP and confirm gateway routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)