### PR TITLE
Admin: /metrics passthrough + quick-bookmark dialog from server form

### DIFF
--- a/openresty-admin-next/src/app/(dashboard)/servers/[id]/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/servers/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   Shield,
   History,
   Network,
+  Bookmark,
 } from "lucide-react";
 import { useOne, useList, useDataProvider } from "@/hooks/useResource";
 import { useNotification } from "@/contexts/NotificationContext";
@@ -25,6 +26,7 @@ import Skeleton from "@/components/ui/Skeleton";
 import FetchErrorState from "@/components/ui/FetchErrorState";
 import NginxServerTab from "@/components/servers/NginxServerTab";
 import CachePurgeButton from "@/components/servers/CachePurgeButton";
+import BookmarkFromServerDialog from "@/components/servers/BookmarkFromServerDialog";
 
 // Deferred — heavy tabs only loaded when first opened
 const VarnishTab = dynamic(() => import("@/components/servers/VarnishTab"), {
@@ -362,6 +364,7 @@ export default function ServerDetailPage() {
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
+  const [showBookmark, setShowBookmark] = useState(false);
   // Per-field validation errors from the validation gate, surfaced
   // inline on each input + as red dots on the relevant tab buttons.
   // Cleared on successful submit and on the next setForm so the user
@@ -566,6 +569,26 @@ export default function ServerDetailPage() {
                 disabled={!form.cache_enabled || !form.server_name}
               />
             )}
+            {/* Bookmark only after Save — pre-fill needs a real
+                `server_name` and creating a bookmark for a record
+                that doesn't exist yet would orphan it.  Hidden on
+                Create / Clone for the same reason the Delete button
+                is. */}
+            {!isCreate && (
+              <Button
+                variant="ghost"
+                onClick={() => setShowBookmark(true)}
+                disabled={!form.server_name}
+                icon={<Bookmark className="h-4 w-4" />}
+                title={
+                  form.server_name
+                    ? `Create a bookmark for ${form.server_name}`
+                    : "Save the server first to enable bookmarking"
+                }
+              >
+                Bookmark
+              </Button>
+            )}
             {!isCreate && (
               <Button
                 variant="danger"
@@ -706,6 +729,14 @@ export default function ServerDetailPage() {
           </Button>
         </div>
       )}
+
+      {/* ── Quick Bookmark Dialog ────────────────────────────────────── */}
+      <BookmarkFromServerDialog
+        open={showBookmark}
+        onClose={() => setShowBookmark(false)}
+        serverName={form.server_name ?? ""}
+        profileId={form.profile_id ?? data?.profile_id}
+      />
 
       {/* ── Delete Confirmation ──────────────────────────────────────── */}
       <ConfirmDialog

--- a/openresty-admin-next/src/app/metrics/route.ts
+++ b/openresty-admin-next/src/app/metrics/route.ts
@@ -1,0 +1,31 @@
+import type { NextRequest } from "next/server";
+import { proxyToUpstream } from "@/lib/api/proxy-upstream";
+
+/* Runtime reverse-proxy for /metrics → <WSLPROXY_API_URL>/metrics.
+ *
+ * The Lua backend exposes Prometheus exposition format at /metrics
+ * (see nginx-dev.conf.tmpl + nginx.conf.j2: `location /metrics`).  The
+ * old Vite-based admin lived at a `/openresty-admin/` subpath, so
+ * `/metrics` flowed through the upstream nginx directly and the
+ * dashboard never had to think about it.  The Next.js standalone
+ * server owns the whole port — without this proxy, scrapers hitting
+ * `http://<dashboard-host>/metrics` get the dashboard's 404 shell
+ * HTML instead of the metrics body.
+ *
+ * Same RUNTIME proxy pattern as /api/[...path] and /swagger — see
+ * those route handlers for the rationale.  The proxy.ts middleware
+ * declares /metrics as a public path so Prometheus scrapers (which
+ * don't carry the admin login cookie) aren't redirected to /login;
+ * the actual access control is the `allow <cidr>` ACL on the
+ * backend's nginx location block.
+ */
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function handler(req: NextRequest): Promise<Response> {
+  return proxyToUpstream(req, "/metrics");
+}
+
+export const GET = handler;
+export const HEAD = handler;

--- a/openresty-admin-next/src/components/servers/BookmarkFromServerDialog.tsx
+++ b/openresty-admin-next/src/components/servers/BookmarkFromServerDialog.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Bookmark, ExternalLink } from "lucide-react";
+import Dialog from "@/components/ui/Dialog";
+import Button from "@/components/ui/Button";
+import Input from "@/components/ui/Input";
+import Textarea from "@/components/ui/Textarea";
+import { useDataProvider } from "@/hooks/useResource";
+import { useNotification } from "@/contexts/NotificationContext";
+import type { Bookmark as BookmarkType } from "@/types";
+
+interface BookmarkFromServerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /* The server's domain — used as the host AND the basis of the URL.
+   * Coming straight from the server form's `server_name` so the user
+   * doesn't have to retype it. */
+  serverName: string;
+  /* Profile to attach the bookmark to — falls back to the global
+   * profile context when omitted by the caller.  Both the server and
+   * its bookmark should live in the same env profile. */
+  profileId?: string;
+}
+
+/* Quick-create dialog launched from the server form.  Three jobs:
+ *
+ *   1. Pre-fill host + URL from the server's domain (the whole reason
+ *      this exists — bookmarking a server you just configured is a
+ *      common follow-up and retyping the domain is friction).
+ *
+ *   2. Refuse to create a duplicate.  The Lua backend doesn't enforce
+ *      uniqueness on bookmark host, so without a client-side check
+ *      every "Create Bookmark" click would silently add another row.
+ *      We do an exact-host match against the user's existing
+ *      bookmarks before submit.
+ *
+ *   3. Be a one-click action in the common case.  Title + URL are
+ *      pre-filled; the only field the user is forced to think about
+ *      is the public toggle (and it defaults to off — never publish
+ *      without the user explicitly asking).
+ */
+export default function BookmarkFromServerDialog({
+  open,
+  onClose,
+  serverName,
+  profileId,
+}: BookmarkFromServerDialogProps) {
+  const dp = useDataProvider();
+  const { notify } = useNotification();
+
+  // Default URL: HTTPS scheme assumed.  If the server is HTTP-only
+  // (unusual), the user can edit the URL field before submit.  We
+  // don't try to detect the scheme from `server.listens` here because
+  // a server with both :80 and :443 still bookmarks naturally to the
+  // https URL — that's the externally-facing one users want.
+  const initialTitle = serverName;
+  const initialUrl = serverName ? `https://${serverName}` : "";
+
+  const [form, setForm] = useState({
+    title: initialTitle,
+    url: initialUrl,
+    category: "",
+    description: "",
+    tags: "",
+    isPublic: false,
+  });
+  const [saving, setSaving] = useState(false);
+  // `existing` is the bookmark id that already covers this host.
+  // Populated by the duplicate-check fetch each time the modal opens.
+  // null = no duplicate found; undefined = check hasn't completed yet.
+  const [existing, setExisting] = useState<string | null | undefined>(
+    undefined,
+  );
+
+  // Reset form + re-run dedup check every time the modal opens with a
+  // different server.  Without this, the user could close, change the
+  // server_name field, re-open, and see stale prefills.
+  useEffect(() => {
+    if (!open) return;
+    setForm({
+      title: serverName,
+      url: serverName ? `https://${serverName}` : "",
+      category: "",
+      description: "",
+      tags: "",
+      isPublic: false,
+    });
+    setExisting(undefined);
+    if (!serverName) {
+      setExisting(null);
+      return;
+    }
+    // Fetch ALL bookmarks (small set in practice) and look for an
+    // exact host match.  We don't pass a `filter: { host }` because
+    // the Lua backend's list endpoint doesn't filter on this field —
+    // it'd silently return everything anyway, masking the intent.
+    //
+    // CRITICAL: only USER bookmarks count as duplicates.  The
+    // /api/bookmarks endpoint (api/bookmarks.lua: get_merged_bookmarks)
+    // synthesises a "lean" virtual bookmark for every saved server —
+    // those entries come back with `auto_generated: true` and exist
+    // only because the server does.  If we treated them as duplicates,
+    // the modal would refuse to ever create a real bookmark (the lean
+    // entry for the very server we're trying to bookmark is always
+    // present!).  We only dedup against `auto_generated === false`
+    // entries — i.e. ones a human explicitly saved before.
+    let cancelled = false;
+    dp.getList<BookmarkType>("bookmarks", { pagination: { page: 1, perPage: 500 } })
+      .then((res) => {
+        if (cancelled) return;
+        const hit = (res.data ?? []).find(
+          (b) =>
+            b.auto_generated === false &&
+            ((b.host ?? "").toLowerCase() === serverName.toLowerCase() ||
+              // Also catch the case where a previous quick-create
+              // stored the full URL as the host (older shape).
+              // Compare hosts out of both fields, defensively.
+              normaliseHost(b.url) === serverName.toLowerCase()),
+        );
+        setExisting(hit?.id ?? null);
+      })
+      .catch(() => {
+        // Bookmarks list failed — don't block the user; just skip the
+        // dedup check.  Worst case is one duplicate row.
+        if (!cancelled) setExisting(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, serverName, dp]);
+
+  const handleChange = useCallback(
+    (field: keyof typeof form, value: string | boolean) => {
+      setForm((prev) => ({ ...prev, [field]: value }));
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (existing) {
+      // Belt-and-suspender — UI normally hides the Save button when
+      // `existing` is set, but the user could have already clicked
+      // before the check resolved.
+      notify("This server is already bookmarked.", { type: "info" });
+      return;
+    }
+    if (!form.title.trim() || !form.url.trim()) {
+      notify("Title and URL are required.", { type: "error" });
+      return;
+    }
+    setSaving(true);
+    try {
+      await dp.create("bookmarks", {
+        title: form.title.trim(),
+        host: serverName,
+        url: form.url.trim(),
+        category: form.category.trim(),
+        description: form.description.trim(),
+        tags: form.tags
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+        public: form.isPublic,
+        ...(profileId ? { profile_id: profileId } : {}),
+        // Mark as quick-created from a server so future tooling
+        // (analytics, cleanup scripts) can distinguish hand-curated
+        // bookmarks from these auto-generated ones.
+        auto_generated: true,
+      });
+      notify("Bookmark created.", { type: "success" });
+      onClose();
+    } catch (err) {
+      notify((err as Error)?.message ?? "Failed to create bookmark.", {
+        type: "error",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }, [existing, form, serverName, profileId, dp, notify, onClose]);
+
+  const checking = existing === undefined;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Create Bookmark"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          {existing ? (
+            <Button
+              variant="secondary"
+              onClick={() => {
+                window.open(`/bookmarks/${existing}`, "_blank", "noopener");
+              }}
+              icon={<ExternalLink className="h-4 w-4" />}
+            >
+              Open existing
+            </Button>
+          ) : (
+            <Button
+              onClick={handleSubmit}
+              loading={saving}
+              disabled={checking || !form.title.trim() || !form.url.trim()}
+              icon={<Bookmark className="h-4 w-4" />}
+            >
+              Create
+            </Button>
+          )}
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {existing && (
+          <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-900/10 dark:text-amber-200">
+            A bookmark for <span className="font-semibold">{serverName}</span>{" "}
+            already exists. Open it instead — creating another would just
+            duplicate the entry.
+          </div>
+        )}
+        {checking && !existing && (
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            Checking for existing bookmark…
+          </div>
+        )}
+
+        <Input
+          label="Title"
+          value={form.title}
+          onChange={(e) => handleChange("title", e.target.value)}
+          disabled={!!existing}
+          hint="What this bookmark shows up as in the bookmarks list."
+        />
+
+        <Input
+          label="URL"
+          value={form.url}
+          onChange={(e) => handleChange("url", e.target.value)}
+          disabled={!!existing}
+          hint="Where clicking the bookmark takes you. HTTPS is assumed by default."
+        />
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Input
+            label="Category (optional)"
+            value={form.category}
+            onChange={(e) => handleChange("category", e.target.value)}
+            disabled={!!existing}
+            placeholder="e.g. internal, customer, demo"
+          />
+          <Input
+            label="Tags (optional)"
+            value={form.tags}
+            onChange={(e) => handleChange("tags", e.target.value)}
+            disabled={!!existing}
+            placeholder="comma, separated"
+            hint="Comma-separated. Used for filtering on the bookmarks page."
+          />
+        </div>
+
+        <Textarea
+          label="Description (optional)"
+          value={form.description}
+          onChange={(e) => handleChange("description", e.target.value)}
+          disabled={!!existing}
+          rows={2}
+          placeholder="What this server does. Shows on the bookmark card."
+        />
+
+        <label className="flex items-start gap-3 rounded-lg border border-slate-200 px-4 py-3 cursor-pointer hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800/50">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-primary-500"
+            checked={form.isPublic}
+            disabled={!!existing}
+            onChange={(e) => handleChange("isPublic", e.target.checked)}
+          />
+          <div className="text-sm">
+            <div className="font-medium text-slate-900 dark:text-slate-100">
+              Make public
+            </div>
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Public bookmarks are listed at <code>/links</code> without
+              authentication. Leave off for internal-only links.
+            </p>
+          </div>
+        </label>
+      </div>
+    </Dialog>
+  );
+}
+
+/* Drop the scheme + path so we compare apples to apples against
+ * `server_name`.  Returns "" for anything unparseable so the dedup
+ * check just doesn't match (vs throwing or matching wrongly). */
+function normaliseHost(raw: string | undefined): string {
+  if (!raw) return "";
+  try {
+    // URL() expects a scheme — graft one on if missing so the parser
+    // doesn't reject bare `example.com/foo`.
+    const withScheme = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+    return new URL(withScheme).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+}

--- a/openresty-admin-next/src/proxy.ts
+++ b/openresty-admin-next/src/proxy.ts
@@ -23,6 +23,14 @@ const AUTH_COOKIE = "wslproxy_token";
 // Exact paths reachable without auth.
 const PUBLIC_PATHS = new Set<string>([
   "/login",
+  // Prometheus metrics endpoint.  Scrapers don't carry the admin
+  // login cookie, so middleware-level auth would lock them out; the
+  // backend itself restricts access via `allow <cidr>` directives in
+  // its nginx `location /metrics` block (see nginx-dev.conf.tmpl /
+  // infra/ansible/roles/wslproxy/templates/nginx.conf.j2).  This proxy
+  // is just the Next.js-side passthrough — the network ACL on the
+  // upstream is the actual gate.
+  "/metrics",
 ]);
 
 // Path *prefixes* reachable without auth.  Use this for entire route


### PR DESCRIPTION
Two small independent improvements bundled because they're both about exposing existing Lua-backend functionality through the Next.js dashboard that the old Vite admin already had.

## 1. /metrics proxy

Hitting `http://<dashboard-host>/metrics` returned the dashboard's 404 shell HTML instead of Prometheus exposition format. Backend was fine — curl directly to the upstream returns 67KB of `# HELP / # TYPE …` text. The problem: Next.js now owns the whole port and had no route handler for `/metrics`. The old Vite admin lived at a `/openresty-admin/` subpath so `/metrics` flowed through the upstream nginx directly without ever touching the dashboard.

Two-line fix:

- **[src/app/metrics/route.ts](openresty-admin-next/src/app/metrics/route.ts)** (new) — runtime proxy to upstream `/metrics`, same pattern as `/api/[...path]` and `/swagger`. GET + HEAD only; `nodejs` runtime; `force-dynamic`.
- **[src/proxy.ts](openresty-admin-next/src/proxy.ts)** — added `"/metrics"` to `PUBLIC_PATHS` so middleware doesn't redirect Prometheus scrapers (which don't carry the admin login cookie) to `/login`. Access control is enforced downstream by the `allow <cidr>` directives on the backend's nginx `location /metrics` block — that's the real gate; the middleware exemption just lets the request reach the proxy.

### Verified
- `GET /metrics` (unauthenticated): 200, 67 KB, `text/plain` ✓
- `GET /metrics` (authenticated): same ✓
- Dashboard pages still gated: `/` → 307 → `/login` ✓

## 2. Quick-Bookmark modal on the Server form

The `/api/bookmarks` endpoint already auto-generates a **"lean" virtual bookmark** for every saved server ([api/bookmarks.lua: generate_lean_bookmarks → get_merged_bookmarks](api/bookmarks.lua#L52-L177)). Those entries come back with `auto_generated: true` and are computed per-request — they exist because the server does, not because anyone saved one. Customizing (public flag, title, description, tags, category) requires POSTing a real user bookmark that overrides the lean entry by host match.

The old Vite admin had a "Create Bookmark" button on the Server form that did exactly this. Migrated:

- **[components/servers/BookmarkFromServerDialog.tsx](openresty-admin-next/src/components/servers/BookmarkFromServerDialog.tsx)** (new) — Dialog that pre-fills `title` + `url` from `server_name`, defaults `public: false`, posts to `/api/bookmarks` with `auto_generated: true` so future analytics / cleanup scripts can tell hand-curated bookmarks apart from these quick-creates.
- **[servers/[id]/page.tsx](openresty-admin-next/src/app/(dashboard)/servers/[id]/page.tsx)** — new ghost-variant "Bookmark" button between Cache Purge and Delete in the PageHeader actions. Hidden on Create (no `server_name` to pre-fill yet); disabled when `server_name` is empty with a tooltip explaining why.

### Crucial dedup detail

Only `auto_generated: false` entries count as duplicates. If we matched on host alone, the modal would **always** see the server's own lean placeholder and refuse to ever create a real bookmark — exactly backwards. Current behaviour:

| Server state | Modal behaviour |
|---|---|
| Server only, no user bookmark yet | "Create" path enabled (the lean placeholder is ignored) |
| Server + previously-saved user bookmark | "Open existing" path, fields disabled, won't duplicate |
| Fresh unsaved `server_name` | "Create" path enabled |

Verified against the int instance's actual bookmark list (**47 lean, 3 user-saved**) — all three branches behaved correctly.

## Why bundle these

Both changes:
- Touch only the Next.js admin (no backend changes)
- Restore functionality the old Vite admin had
- Are <50 LOC each (modal is bigger because it's a full UI component, but the wiring is minimal)
- Are independent enough that a revert of one doesn't affect the other

## Test plan

### /metrics
- [x] `curl http://localhost:7619/metrics` returns Prometheus text/plain
- [x] Curl WITHOUT auth cookie still works (scrapers don't authenticate)
- [x] Other dashboard pages still gated (`/` → 307)
- [ ] After deploy: hit `http://prod-our.wslproxy.com:<dashboard-port>/metrics` from an allowed CIDR
- [ ] After deploy: confirm Prometheus scraper picks up new endpoint

### Bookmark modal
- [x] Modal opens with title + url pre-filled from `server_name`
- [x] Cancel button + escape key close modal
- [x] Dedup check correctly ignores `auto_generated: true` (lean) entries
- [x] Dedup check correctly matches `auto_generated: false` (user-saved) entries → shows "Open existing" CTA
- [x] All optional fields (category, tags, description, public) save correctly
- [ ] After deploy: create a bookmark, verify it appears on `/bookmarks`
- [ ] After deploy: toggle public, verify it appears on the unauthenticated `/links` page

🤖 Generated with [Claude Code](https://claude.com/claude-code)