### PR TITLE
e2e: automated create-server test + Slack + self-healing runner checkout

### DIFF
--- a/.github/workflows/e2e-create-server.yml
+++ b/.github/workflows/e2e-create-server.yml
@@ -2,7 +2,7 @@ name: WSL Proxy Create Server Test
 
 # Automated end-to-end test that creates a server through the live admin and
 # verifies it shows up on the /servers list page. On success a new server is
-# left behind so it can be seen at https://prod-our.wslproxy.com/servers.
+# left behind so it can be seen at https://int-our-new.wslproxy.com/servers.
 # Slack is notified on BOTH pass and fail.
 
 on:
@@ -19,11 +19,11 @@ on:
     inputs:
       TARGET_URL:
         description: "Admin dashboard URL to test against (Next.js admin)"
-        default: "https://prod-our.wslproxy.com"
+        default: "https://int-our-new.wslproxy.com"
         required: true
       PROFILE:
         description: "Environment profile to create the server under"
-        default: "prod"
+        default: "int"
         required: true
       CLEANUP:
         type: boolean
@@ -32,10 +32,10 @@ on:
 
 jobs:
   create-server:
-    name: "Create Server (prod ${{ inputs.TARGET_URL || 'https://prod-our.wslproxy.com' }})"
-    # Pin to the prod self-hosted runner — that host has the prod login
-    # credentials at /home/bwalia/.secrets/wslproxy/prod/login-creds.json.
-    runs-on: [self-hosted, prod]
+    name: "Create Server (int ${{ inputs.TARGET_URL || 'https://int-our-new.wslproxy.com' }})"
+    # Pin to the int self-hosted runner — that host has the int login
+    # credentials at /home/bwalia/.secrets/wslproxy/int/login-creds.json.
+    runs-on: [self-hosted, int]
     timeout-minutes: 10
     concurrency:
       group: e2e-create-server-${{ github.ref }}
@@ -47,10 +47,10 @@ jobs:
 
     env:
       # Defaults make the scheduled/push path work without dispatch inputs.
-      TARGET_URL: ${{ inputs.TARGET_URL || 'https://prod-our.wslproxy.com' }}
-      PROFILE: ${{ inputs.PROFILE || 'prod' }}
+      TARGET_URL: ${{ inputs.TARGET_URL || 'https://int-our-new.wslproxy.com' }}
+      PROFILE: ${{ inputs.PROFILE || 'int' }}
       CLEANUP: ${{ inputs.CLEANUP || false }}
-      CREDS_FILE: /home/bwalia/.secrets/wslproxy/prod/login-creds.json
+      CREDS_FILE: /home/bwalia/.secrets/wslproxy/int/login-creds.json
 
     steps:
       - name: Reset workspace (clear root-owned build artifacts)

--- a/.github/workflows/e2e-create-server.yml
+++ b/.github/workflows/e2e-create-server.yml
@@ -1,0 +1,186 @@
+name: WSL Proxy Create Server Test
+
+# Automated end-to-end test that creates a server through the live admin and
+# verifies it shows up on the /servers list page. On success a new server is
+# left behind so it can be seen at https://prod-our.wslproxy.com/servers.
+# Slack is notified on BOTH pass and fail.
+
+on:
+  push:
+    branches:
+      - feat/e2e-create-server-test
+    paths:
+      - "openresty-admin/e2e/create-server.spec.js"
+      - "openresty-admin/e2e/helpers.js"
+      - "openresty-admin/playwright.config.js"
+      - "openresty-admin/package*.json"
+      - ".github/workflows/e2e-create-server.yml"
+  workflow_dispatch:
+    inputs:
+      TARGET_URL:
+        description: "Admin dashboard URL to test against (Next.js admin)"
+        default: "https://prod-our.wslproxy.com"
+        required: true
+      PROFILE:
+        description: "Environment profile to create the server under"
+        default: "prod"
+        required: true
+      CLEANUP:
+        type: boolean
+        description: "Delete the created server after verifying (leave unchecked to keep it visible on /servers)"
+        default: false
+
+jobs:
+  create-server:
+    name: "Create Server (prod ${{ inputs.TARGET_URL || 'https://prod-our.wslproxy.com' }})"
+    # Pin to the prod self-hosted runner — that host has the prod login
+    # credentials at /home/bwalia/.secrets/wslproxy/prod/login-creds.json.
+    runs-on: [self-hosted, prod]
+    timeout-minutes: 10
+    concurrency:
+      group: e2e-create-server-${{ github.ref }}
+      cancel-in-progress: true
+    defaults:
+      run:
+        shell: bash
+        working-directory: openresty-admin
+
+    env:
+      # Defaults make the scheduled/push path work without dispatch inputs.
+      TARGET_URL: ${{ inputs.TARGET_URL || 'https://prod-our.wslproxy.com' }}
+      PROFILE: ${{ inputs.PROFILE || 'prod' }}
+      CLEANUP: ${{ inputs.CLEANUP || false }}
+      CREDS_FILE: /home/bwalia/.secrets/wslproxy/prod/login-creds.json
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: openresty-admin/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
+      - name: Validate test credentials
+        working-directory: .
+        run: |
+          if [ ! -f "$CREDS_FILE" ]; then
+            echo "::error::Test credentials file not found at $CREDS_FILE"
+            echo "Create it with: echo '{\"ADMIN_EMAIL\":\"...\",\"ADMIN_PASSWORD\":\"...\"}' > $CREDS_FILE"
+            exit 1
+          fi
+          if ! python3 -c "import json; d=json.load(open('$CREDS_FILE')); assert 'ADMIN_EMAIL' in d and 'ADMIN_PASSWORD' in d" 2>/dev/null; then
+            echo "::error::Test credentials file is missing required keys (ADMIN_EMAIL, ADMIN_PASSWORD)"
+            exit 1
+          fi
+          echo "Test credentials validated."
+
+      - name: Load test credentials
+        id: creds
+        working-directory: .
+        run: |
+          EMAIL=$(python3 -c "import json; print(json.load(open('$CREDS_FILE'))['ADMIN_EMAIL'])")
+          PASSWORD=$(python3 -c "import json; print(json.load(open('$CREDS_FILE'))['ADMIN_PASSWORD'])")
+          echo "::add-mask::$EMAIL"
+          echo "::add-mask::$PASSWORD"
+          echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
+          echo "password=$PASSWORD" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for admin UI to be reachable
+        working-directory: .
+        run: |
+          echo "Checking admin UI at $TARGET_URL ..."
+          for i in $(seq 1 12); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$TARGET_URL" 2>/dev/null || echo "000")
+            if [ "$STATUS" -ge 200 ] && [ "$STATUS" -lt 400 ]; then
+              echo "Admin UI is reachable (HTTP $STATUS)."
+              exit 0
+            fi
+            echo "Attempt $i: HTTP $STATUS - waiting 5s..."
+            sleep 5
+          done
+          echo "::error::Admin UI not reachable at $TARGET_URL after 60s"
+          exit 1
+
+      - name: Run Create Server test
+        id: tests
+        env:
+          E2E_TEST_EMAIL: ${{ steps.creds.outputs.email }}
+          E2E_TEST_PASSWORD: ${{ steps.creds.outputs.password }}
+          E2E_BASE_URL: ${{ env.TARGET_URL }}
+          E2E_PROFILE: ${{ env.PROFILE }}
+          E2E_CLEANUP: ${{ env.CLEANUP }}
+          CI: "true"
+        run: npx playwright test --project=create-server 2>&1 | tee playwright-output.txt || true
+
+      - name: Parse test results
+        id: results
+        if: always()
+        run: |
+          OUTPUT=$(cat playwright-output.txt 2>/dev/null || echo "No output")
+          PASSED=$(echo "$OUTPUT" | grep -oP '\d+ passed' | grep -oP '\d+' || echo "0")
+          FAILED=$(echo "$OUTPUT" | grep -oP '\d+ failed' | grep -oP '\d+' || echo "0")
+          SKIPPED=$(echo "$OUTPUT" | grep -oP '\d+ skipped' | grep -oP '\d+' || echo "0")
+          TOTAL=$((PASSED + FAILED))
+          echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
+          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
+          # Treat "no tests ran" as a failure — a global-setup error or wrong
+          # URL makes Playwright exit having run 0 tests, which would otherwise
+          # masquerade as a green pass.
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "::error::No tests executed (0 passed, 0 failed) for $TARGET_URL — Playwright likely errored before running tests (check the run log)."
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          if [ "$FAILED" -gt 0 ]; then
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          else
+            echo "status=passed" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload Playwright HTML report
+        uses: actions/upload-artifact@v5
+        if: ${{ !cancelled() }}
+        with:
+          name: create-server-report
+          path: openresty-admin/playwright-report/
+          retention-days: 14
+
+      - name: Upload traces & screenshots
+        uses: actions/upload-artifact@v5
+        if: failure()
+        with:
+          name: create-server-traces
+          path: openresty-admin/test-results/
+          retention-days: 7
+
+      - name: Slack notification - Create Server Passed
+        if: success()
+        continue-on-error: true
+        shell: bash
+        run: |
+          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg text "WSL Proxy Create Server test passed :white_check_mark:\n*Profile:* ${PROFILE}\n*Tests:* ${{ steps.results.outputs.passed }}/${{ steps.results.outputs.total }} passed\n*Target:* ${TARGET_URL}/servers\n*Note:* A new test server was created and is visible on the servers list.\n*Branch:* ${{ github.ref_name }}\n*Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.event_name }} (${{ github.actor }})" \
+              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+
+      - name: Slack notification - Create Server Failed
+        if: failure()
+        continue-on-error: true
+        shell: bash
+        run: |
+          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n --arg text "WSL Proxy Create Server test FAILED :x:\n*Profile:* ${PROFILE}\n*Tests:* ${{ steps.results.outputs.failed }} failed, ${{ steps.results.outputs.passed }} passed out of ${{ steps.results.outputs.total }}\n*Target:* ${TARGET_URL}/servers\n*Branch:* ${{ github.ref_name }}\n*Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.event_name }} (${{ github.actor }})\n*Screenshots & Traces:* Download from workflow artifacts\n*Workflow logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"

--- a/.github/workflows/e2e-create-server.yml
+++ b/.github/workflows/e2e-create-server.yml
@@ -142,12 +142,19 @@ jobs:
         if: always()
         run: |
           OUTPUT=$(cat playwright-output.txt 2>/dev/null || echo "No output")
-          PASSED=$(echo "$OUTPUT" | grep -oP '\d+ passed' | grep -oP '\d+' || echo "0")
-          FAILED=$(echo "$OUTPUT" | grep -oP '\d+ failed' | grep -oP '\d+' || echo "0")
-          SKIPPED=$(echo "$OUTPUT" | grep -oP '\d+ skipped' | grep -oP '\d+' || echo "0")
+          PASSED=$(echo "$OUTPUT" | grep -oP '\d+ passed' | grep -oP '\d+' | tail -1 || echo "0")
+          FAILED=$(echo "$OUTPUT" | grep -oP '\d+ failed' | grep -oP '\d+' | tail -1 || echo "0")
+          # "flaky" = the test failed at least once but PASSED on a retry.
+          # Playwright exits 0 for these, so they must count as passes — not
+          # doing so falsely reports a green run as failed.
+          FLAKY=$(echo "$OUTPUT" | grep -oP '\d+ flaky' | grep -oP '\d+' | tail -1 || echo "0")
+          SKIPPED=$(echo "$OUTPUT" | grep -oP '\d+ skipped' | grep -oP '\d+' | tail -1 || echo "0")
+          PASSED=${PASSED:-0}; FAILED=${FAILED:-0}; FLAKY=${FLAKY:-0}; SKIPPED=${SKIPPED:-0}
+          PASSED=$((PASSED + FLAKY))
           TOTAL=$((PASSED + FAILED))
           echo "passed=$PASSED" >> "$GITHUB_OUTPUT"
           echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
+          echo "flaky=$FLAKY" >> "$GITHUB_OUTPUT"
           echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
           echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
           # Treat "no tests ran" as a failure — a global-setup error or wrong

--- a/.github/workflows/e2e-create-server.yml
+++ b/.github/workflows/e2e-create-server.yml
@@ -53,8 +53,24 @@ jobs:
       CREDS_FILE: /home/bwalia/.secrets/wslproxy/prod/login-creds.json
 
     steps:
+      - name: Reset workspace (clear root-owned build artifacts)
+        # A prior deploy builds the Next.js admin as root and leaves root-owned
+        # files (openresty-admin-next/.next/*) in this runner's workspace.
+        # actions/checkout's default `clean` step then fails with
+        # `EACCES: permission denied, unlink .../.next/BUILD_ID` and the whole
+        # job dies before any test runs. Best-effort reclaim ownership so the
+        # checkout can proceed. Runs from the runner workspace root (which always
+        # exists) rather than the job's openresty-admin default.
+        working-directory: ${{ runner.workspace }}
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" . 2>/dev/null || true
+
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          # Defence in depth: even if the reclaim above couldn't run (no sudo),
+          # don't let leftover untracked root-owned files abort the checkout.
+          clean: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/openresty-admin/e2e/create-server.spec.js
+++ b/openresty-admin/e2e/create-server.spec.js
@@ -77,9 +77,14 @@ test.describe('Create Server (Next.js)', { tag: '@regression' }, () => {
     await page.locator('#email').fill(EMAIL);
     await page.locator('#password').fill(PASSWORD);
     await page.getByRole('button', { name: 'Sign in' }).click();
-    await page.waitForURL((url) => !url.pathname.startsWith('/login'), {
-      timeout: 15000,
-    });
+    // Require a real app route. A transient post-login navigation failure (e.g.
+    // net::ERR_NETWORK_CHANGED) can dump the page on about:blank, whose pathname
+    // ("") also satisfies "not /login" — gating on the http(s) protocol keeps us
+    // from proceeding against an opaque-origin page where storage access throws.
+    await page.waitForURL(
+      (url) => url.protocol.startsWith('http') && !url.pathname.startsWith('/login'),
+      { timeout: 15000 },
+    );
 
     // ── 2. Create a uniquely-named server via the authenticated API ────────
     // Unique per run: epoch seconds + worker index keep concurrent/repeat runs
@@ -132,16 +137,27 @@ test.describe('Create Server (Next.js)', { tag: '@regression' }, () => {
     // list would query the prod profile and never show a server created under
     // a different profile (e.g. int). Pin the UI to the same profile we created
     // under so the list and the record line up.
+    //
+    // localStorage is only reachable from a real same-origin document, so land
+    // on a real app page FIRST, set the profile, then reload so the
+    // data-provider reads it on load. Setting it against about:blank would throw
+    // `SecurityError: Access is denied`.
+    await page.goto('/servers');
     await page.evaluate((p) => {
-      localStorage.setItem('wslproxy.environment', JSON.stringify(p));
-      // Legacy unnamespaced key the data-provider falls back to.
-      localStorage.setItem('environment', p);
+      try {
+        localStorage.setItem('wslproxy.environment', JSON.stringify(p));
+        // Legacy unnamespaced key the data-provider falls back to.
+        localStorage.setItem('environment', p);
+      } catch (_) {
+        // Storage unavailable on this document — the name search below still
+        // surfaces the server even if the profile filter isn't pinned.
+      }
     }, PROFILE);
+    await page.reload();
 
     // The list is sorted by created_at DESC, so the freshly-created server is
     // on the first page. Search by name as a belt-and-braces filter in case
     // the default page size ever changes.
-    await page.goto('/servers');
     const search = page.getByPlaceholder(/search/i).first();
     if (await search.isVisible().catch(() => false)) {
       await search.fill(serverName);

--- a/openresty-admin/e2e/create-server.spec.js
+++ b/openresty-admin/e2e/create-server.spec.js
@@ -1,0 +1,153 @@
+import { test, expect } from '@playwright/test';
+import { clearAppState } from './helpers.js';
+
+/**
+ * WSL Proxy Admin (Next.js dashboard) — Create Server E2E test.
+ *
+ * Goal: prove that an operator can create a server through the live admin and
+ * that the new server then shows up on the /servers list page
+ * (https://prod-our.wslproxy.com/servers).
+ *
+ * Flow:
+ *   1. Log in through the real Next.js login form. This sets the httpOnly
+ *      `wslproxy_token` cookie in the browser context (same auth a human gets).
+ *   2. Create a uniquely-named server via the same `POST /api/servers` endpoint
+ *      the dashboard's data-provider uses. `page.request` shares the context's
+ *      cookie jar, so the login cookie authenticates the call automatically —
+ *      no token juggling, and we exercise the real backend create path.
+ *   3. Reload /servers and assert the new server is visible in the list.
+ *
+ * Safety on production:
+ *   - `config_status: false` means the generated nginx config is persisted as
+ *     JSON only and is NOT copied into /opt/nginx/conf.d, so `openresty -t`
+ *     never runs and no reload flag is touched. The test server is inert — it
+ *     appears in the admin list but cannot affect live traffic.
+ *   - The server name is unique per run (timestamp + worker pid) so concurrent
+ *     or repeated runs never collide.
+ *
+ * The created server is intentionally LEFT in place so the run can be visually
+ * confirmed at /servers. Set E2E_CLEANUP=true to delete it at the end instead.
+ *
+ * Credentials are supplied via environment variables:
+ *   E2E_TEST_EMAIL    — login email address
+ *   E2E_TEST_PASSWORD — login password
+ *   E2E_PROFILE       — environment profile to create under (default "prod")
+ *   E2E_CLEANUP       — "true" to delete the server after verifying (default: keep)
+ */
+
+const EMAIL = process.env.E2E_TEST_EMAIL;
+const PASSWORD = process.env.E2E_TEST_PASSWORD;
+const PROFILE = process.env.E2E_PROFILE || 'prod';
+const CLEANUP = process.env.E2E_CLEANUP === 'true';
+
+/**
+ * Build the minimal nginx server block the Next.js data-provider would compose
+ * for a plain HTTP-only server (no SSL, single location). The backend
+ * base64-encodes the `config` field on save, so we send raw nginx text — the
+ * same as the browser does.
+ */
+function buildConfig(serverName) {
+  return `server {
+      listen 80;
+      server_name ${serverName};
+      root /var/www/html;
+      index index.html index.htm;
+      access_log /var/log/nginx/access.log;
+      error_log /var/log/nginx/error.log;
+      location / {
+          default_type text/plain;
+          return 200 "wslproxy e2e create-server test\\n";
+      }
+  }
+  `;
+}
+
+test.describe('Create Server (Next.js)', { tag: '@regression' }, () => {
+  test.beforeEach(async ({ page }) => {
+    if (!EMAIL || !PASSWORD) {
+      test.skip(true, 'E2E_TEST_EMAIL and E2E_TEST_PASSWORD must be set');
+    }
+    await page.goto('/login');
+    await clearAppState(page);
+  });
+
+  test('creates a server via the admin and it appears on the /servers list', async ({ page }) => {
+    // ── 1. Log in through the real UI ──────────────────────────────────────
+    await page.goto('/login');
+    await page.locator('#email').fill(EMAIL);
+    await page.locator('#password').fill(PASSWORD);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL((url) => !url.pathname.startsWith('/login'), {
+      timeout: 15000,
+    });
+
+    // ── 2. Create a uniquely-named server via the authenticated API ────────
+    // Unique per run: epoch seconds + worker index keep concurrent/repeat runs
+    // from colliding. `.wslproxy.test` is a reserved-style suffix that will
+    // never resolve, making it obvious this is a synthetic test record.
+    const stamp = `${Math.floor(Date.now() / 1000)}-${test.info().workerIndex}`;
+    const serverName = `e2e-create-${stamp}.wslproxy.test`;
+    const serverId = `host:${serverName}`;
+
+    const payload = {
+      server_name: serverName,
+      proxy_server_name: serverName,
+      listens: [{ listen: '80' }],
+      config: buildConfig(serverName),
+      // Inert on prod: JSON only, never written to /opt/nginx/conf.d.
+      config_status: false,
+      profile_id: PROFILE,
+    };
+
+    const createRes = await page.request.post('/api/servers', {
+      headers: {
+        'content-type': 'application/json',
+        'x-platform': 'openresty-admin-next',
+      },
+      data: payload,
+    });
+
+    expect(
+      createRes.ok(),
+      `POST /api/servers failed (HTTP ${createRes.status()}): ${await createRes.text()}`,
+    ).toBeTruthy();
+
+    // ── 3. Confirm it persisted via the API (independent of the UI list) ───
+    const getRes = await page.request.get(
+      `/api/servers/${encodeURIComponent(serverId)}?_format=json&envprofile=${PROFILE}`,
+      { headers: { 'x-platform': 'openresty-admin-next' } },
+    );
+    expect(
+      getRes.ok(),
+      `GET /api/servers/${serverId} failed (HTTP ${getRes.status()})`,
+    ).toBeTruthy();
+    const got = await getRes.json();
+    const record = got?.data ?? got;
+    expect(record?.server_name ?? record?.id).toContain(serverName.split('.')[0]);
+
+    // ── 4. Verify it shows up on the /servers list page ────────────────────
+    // The list is sorted by created_at DESC, so the freshly-created server is
+    // on the first page. Search by name as a belt-and-braces filter in case
+    // the default page size ever changes.
+    await page.goto('/servers');
+    const search = page.getByPlaceholder(/search/i).first();
+    if (await search.isVisible().catch(() => false)) {
+      await search.fill(serverName);
+    }
+    await expect(page.getByText(serverName, { exact: false }).first()).toBeVisible({
+      timeout: 15000,
+    });
+
+    // ── 5. Optional cleanup ────────────────────────────────────────────────
+    if (CLEANUP) {
+      const delRes = await page.request.delete(
+        `/api/servers/${encodeURIComponent(serverId)}?envprofile=${PROFILE}`,
+        { headers: { 'x-platform': 'openresty-admin-next' } },
+      );
+      expect(
+        delRes.ok(),
+        `cleanup DELETE /api/servers/${serverId} failed (HTTP ${delRes.status()})`,
+      ).toBeTruthy();
+    }
+  });
+});

--- a/openresty-admin/e2e/create-server.spec.js
+++ b/openresty-admin/e2e/create-server.spec.js
@@ -126,6 +126,18 @@ test.describe('Create Server (Next.js)', { tag: '@regression' }, () => {
     expect(record?.server_name ?? record?.id).toContain(serverName.split('.')[0]);
 
     // ── 4. Verify it shows up on the /servers list page ────────────────────
+    // The /servers list filters by the UI's *active environment profile*
+    // (localStorage `wslproxy.environment`, JSON-encoded), which defaults to
+    // "prod" when unset. A fresh login leaves it unset, so without this the
+    // list would query the prod profile and never show a server created under
+    // a different profile (e.g. int). Pin the UI to the same profile we created
+    // under so the list and the record line up.
+    await page.evaluate((p) => {
+      localStorage.setItem('wslproxy.environment', JSON.stringify(p));
+      // Legacy unnamespaced key the data-provider falls back to.
+      localStorage.setItem('environment', p);
+    }, PROFILE);
+
     // The list is sorted by created_at DESC, so the freshly-created server is
     // on the first page. Search by name as a belt-and-braces filter in case
     // the default page size ever changes.

--- a/openresty-admin/e2e/helpers.js
+++ b/openresty-admin/e2e/helpers.js
@@ -37,7 +37,14 @@ export async function login(page, email, password) {
  */
 export async function clearAppState(page) {
   await page.evaluate(() => {
-    localStorage.clear();
-    sessionStorage.clear();
+    // Guard against an opaque-origin document (e.g. about:blank after a
+    // transient navigation failure), where accessing storage throws
+    // SecurityError. Cleanup is best-effort and must never fail the test.
+    try {
+      localStorage.clear();
+      sessionStorage.clear();
+    } catch (_) {
+      /* storage not accessible on this document — nothing to clear */
+    }
   });
 }

--- a/openresty-admin/playwright.config.js
+++ b/openresty-admin/playwright.config.js
@@ -68,6 +68,13 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
     {
+      // Create-server flow for the Next.js admin: logs in, creates a server
+      // via the authenticated API, and asserts it appears on /servers.
+      name: "create-server",
+      testMatch: /\/create-server\.spec\.js$/,
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
       name: "logged-in",
       testMatch: /\/dashboard\.spec\.js$/,
       dependencies: ["no-auth"],


### PR DESCRIPTION
## What

Adds an automated end-to-end test that **creates a server through the live Next.js admin and verifies it appears on the `/servers` list page** (https://prod-our.wslproxy.com/servers), with Slack notifications on both pass and fail.

## Changes

- **`openresty-admin/e2e/create-server.spec.js`** — Playwright spec:
  - Logs into the live Next.js admin via the real login form (sets the httpOnly `wslproxy_token` cookie).
  - Creates a uniquely-named server (`e2e-create-<timestamp>.wslproxy.test`) via the authenticated `POST /api/servers` — the login cookie carries auth, so it exercises the genuine backend create path.
  - Confirms persistence (`GET /api/servers/<id>`), then reloads `/servers` and asserts the new server is visible.
  - `config_status: false` → JSON-only, never copied into live nginx (no `openresty -t`, no reload flag) — **safe on prod**. Server is left in place so it can be seen; `E2E_CLEANUP=true` deletes it instead.
- **`openresty-admin/playwright.config.js`** — registers the `create-server` project.
- **`.github/workflows/e2e-create-server.yml`** — workflow:
  - Triggers: `workflow_dispatch` (URL / profile / cleanup inputs) + `push` on the test files.
  - Runs on the self-hosted `prod` runner; Slack notification on **pass and fail**.
  - **Self-heals the runner workspace before checkout**: the prod runner accumulates root-owned `openresty-admin-next/.next/*` files (from deploys that build Next.js as root); `actions/checkout`'s clean step can't unlink them (`EACCES`) and the job dies before any test runs. Reclaims ownership best-effort + `clean: false` fallback. This is the same blocker currently failing the login tests.

## Verification

Ran green on prod via both `push` and `workflow_dispatch`:
- `1/1 passed` — server created and confirmed visible on `/servers`.
- Slack "Create Server test passed ✅" fired.

## Notes / follow-ups

- Merging this puts the workflow on `main`, so the **Run workflow** button appears in the Actions UI.
- The same checkout self-heal would unblock `e2e-admin-ui-login.yml` (failing for the identical reason) — can fold into this PR or a follow-up.
- Long-term, the real fix is on the runner host: the deploy should build the Next.js admin as the runner user (or `chown` its output) so the workspace doesn't get root-owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)