### PR TITLE
fix(nginx): add prod-our.wslproxy.com server block so Let's Encrypt can renew

### DIFF
--- a/infra/ansible/host_vars/187.124.112.155/vars.yaml
+++ b/infra/ansible/host_vars/187.124.112.155/vars.yaml
@@ -12,5 +12,6 @@ nginx_k3s_dashboard_server_name: "k3s-dashboard.workstation.co.uk"
 nginx_default_server_frontend: "wslproxy.com www.wslproxy.com wslproxy.org www.wslproxy.org"
 nginx_default_server_backend: "prod-our-v1.wslproxy.com"
 nginx_default_server_backend_port: 7691
+nginx_default_server_backend_nextjs: "prod-our.wslproxy.com"
 letsencrypt_email: "balinder.walia@gmail.com"
 openresty_admin_secondary_color: "#D91656"

--- a/infra/ansible/roles/wslproxy/defaults/main.yml
+++ b/infra/ansible/roles/wslproxy/defaults/main.yml
@@ -4,9 +4,11 @@ nginx_port: 80
 # Override these in host_vars or group_vars for each environment
 # Frontend: public landing page (static HTML)
 # Backend: admin UI proxy to localhost:8080
+# Backend (Next.js): canonical domain proxied to the Next.js node (3099)
 nginx_default_server_frontend: ""
 nginx_default_server_backend: ""
 nginx_default_server_backend_port: 8080
+nginx_default_server_backend_nextjs: ""
 nginx_nextjs_dashboard_port: 8099
 nginx_nextjs_node_port: 3099
 

--- a/infra/ansible/roles/wslproxy/templates/default.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/default.conf.j2
@@ -126,3 +126,73 @@
         }
     }
 {% endif %}
+
+{% if nginx_default_server_backend_nextjs | default('') | length > 0 %}
+    # ──────────────────────────────────────────────────────
+    # BACKEND (Next.js) — proxy to 127.0.0.1:{{ nginx_nextjs_node_port }}
+    # Canonical production domain served by the Next.js standalone dashboard.
+    # Mirrors the cert handling above so auto-ssl can renew via HTTP-01.
+    # ──────────────────────────────────────────────────────
+
+    # HTTP (port 80) — redirect to HTTPS + ACME challenge
+    server {
+        listen       80;
+        server_name  {{ nginx_default_server_backend_nextjs }};
+
+        location /.well-known/acme-challenge/ {
+            content_by_lua_block {
+                auto_ssl:challenge_server()
+            }
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    # HTTPS (port 443) — Next.js dashboard with auto-ssl
+    server {
+        listen       443 ssl;
+        server_name  {{ nginx_default_server_backend_nextjs }};
+
+        http2 on;
+
+        ssl_session_timeout  5m;
+        ssl_session_cache shared:backend_ssl_nextjs:10m;
+        ssl_session_tickets off;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+        ssl_prefer_server_ciphers off;
+
+        ssl_certificate_by_lua_block {
+            auto_ssl:ssl_certificate()
+        }
+
+        ssl_certificate /etc/ssl/resty-auto-ssl-fallback.crt;
+        ssl_certificate_key /etc/ssl/resty-auto-ssl-fallback.key;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        location /.well-known/acme-challenge/ {
+            content_by_lua_block {
+                auto_ssl:challenge_server()
+            }
+        }
+
+        location / {
+            proxy_pass http://127.0.0.1:{{ nginx_nextjs_node_port }};
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+            proxy_connect_timeout 30s;
+            proxy_read_timeout 600s;
+            proxy_send_timeout 600s;
+        }
+    }
+{% endif %}


### PR DESCRIPTION
## Problem

`prod-our.wslproxy.com`'s Let's Encrypt cert **expired on Jun 11 2026** and could not auto-renew.

**Root cause:** the rename commit `4e88df5` ("rename prod-our → prod-our-v1 and route prod-our to Next.js :3099") repointed `prod-our.wslproxy.com` at the Next.js dashboard, but only templated a server block for **`prod-our-v1`** — the bare `prod-our.wslproxy.com` got no server block at all. So on the prod host:

- Port-80 requests for `prod-our.wslproxy.com` matched no `server_name`, fell through to the `default_server`, and returned the WSLProxy 404 page.
- The `/.well-known/acme-challenge/` path therefore never reached `auto_ssl:challenge_server()`.
- auto-ssl could not satisfy the HTTP-01 challenge → renewal failed silently → cert expired.

(The cert was still being *served* from the `0.0.0.0:443` auto-ssl catch-all and the in-memory `auto_ssl` shared dict, which masked the failure until expiry.)

## Fix

Adds an optional **Next.js backend** block to `default.conf.j2`, mirroring the existing frontend/backend blocks:
- Port 80: redirect to HTTPS **+ ACME challenge** → `auto_ssl:challenge_server()`
- Port 443: auto-ssl proxy to `nginx_nextjs_node_port` (3099) with WebSocket upgrade headers

Gated on a new `nginx_default_server_backend_nextjs` variable (defaults to `""` in the role; set to `prod-our.wslproxy.com` for the pop0 prod host).

## Files
- `templates/default.conf.j2` — new Next.js backend server blocks
- `defaults/main.yml` — new `nginx_default_server_backend_nextjs: ""` default
- `host_vars/187.124.112.155/vars.yaml` — set to `prod-our.wslproxy.com`

## Tested (on prod 187.124.112.155)
Deployed the equivalent block, reloaded OpenResty, and verified:
- `GET http://prod-our.wslproxy.com/.well-known/acme-challenge/<token>` now reaches auto-ssl's `challenge_server()` (plain openresty 404, not the WSLProxy 404 page)
- Port 80 root now `301 → https://prod-our.wslproxy.com/`
- auto-ssl issued a **fresh cert**: `auto-ssl: issuing new certificate for prod-our.wslproxy.com`
- Live cert (external, `ssl_verify=0`): `notBefore=Jun 12 2026`, **`notAfter=Sep 10 2026`**
- HTTPS serves the Next.js dashboard (307 → /login)

## Note
The prod host currently carries the equivalent block as a manual hotfix (to restore the expired cert immediately). The next Ansible deploy of this template regenerates `default.conf` from scratch, cleanly superseding the hotfix — no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)