### PR TITLE
fix(ssl): call auto_ssl:init_worker() so certs actually auto-renew

### DIFF
--- a/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
@@ -140,6 +140,18 @@ http {
     init_by_lua_file /usr/local/openresty/nginx/html/api/init.lua;
 
     init_worker_by_lua_block {
+        -- Start the lua-resty-auto-ssl background renewal timer.
+        -- auto_ssl:init() (in init.lua) only enables on-demand issuance; the
+        -- per-worker init_worker() call is what schedules the renewal timer
+        -- (ngx.timer.every(renew_check_interval)). Without it, certificates are
+        -- issued on first request but NEVER auto-renew — they silently expire
+        -- ~90 days after issuance. auto_ssl is a global set in init_by_lua_file.
+        if auto_ssl and auto_ssl.init_worker then
+            auto_ssl:init_worker()
+        else
+            ngx.log(ngx.ERR, "auto_ssl global missing in init_worker - cert renewal disabled")
+        end
+
         -- Initialize Prometheus metrics (requires lua_code_cache to be ON)
         local ok, metrics = pcall(require, "prometheus_metrics")
         if ok then

--- a/nginx-dev.conf.tmpl
+++ b/nginx-dev.conf.tmpl
@@ -99,6 +99,17 @@ http {
     init_by_lua_file /usr/local/openresty/nginx/html/api/init.lua;
 
     init_worker_by_lua_block {
+        -- Start the lua-resty-auto-ssl background renewal timer.
+        -- auto_ssl:init() (in init.lua) only enables on-demand issuance; the
+        -- per-worker init_worker() call is what schedules the renewal timer.
+        -- Without it, certificates are issued on first request but NEVER
+        -- auto-renew — they silently expire ~90 days after issuance.
+        if auto_ssl and auto_ssl.init_worker then
+            auto_ssl:init_worker()
+        else
+            ngx.log(ngx.ERR, "auto_ssl global missing in init_worker - cert renewal disabled")
+        end
+
         -- Initialize Prometheus metrics (requires lua_code_cache to be ON)
         local ok, metrics = pcall(require, "prometheus_metrics")
         if ok then


### PR DESCRIPTION
## Problem

Let's Encrypt certs across the prod host (`187.124.112.155`) are **silently expiring and never auto-renewing**. `acc-vault.diytaxreturn.co.uk` was the reported symptom (expired Jun 11), but it's host-wide: `diytaxreturn.co.uk`, `www.*`, `int-*`, `cognoai.uk`, `prod-our.wslproxy.com`, etc.

## Root cause

`lua-resty-auto-ssl` requires **two** calls:
- `auto_ssl:init()` in `init_by_lua` — present in `api/init.lua` → enables **on-demand issuance**.
- `auto_ssl:init_worker()` in `init_worker_by_lua` — **was missing everywhere** → this is what schedules the background **renewal timer** (`ngx.timer.every(renew_check_interval)`).

With `init()` but no `init_worker()`, a domain gets a cert on first request and then **never renews** — it just expires ~90 days later. New-domain issuance kept working, which masked the problem until the first batch aged out.

**Evidence:** every cert in the auto-ssl file store (`data/ssl-certs/storage/file/*`) was dated **Mar 13–18 2026** (initial bulk issuance) and *none* had renewed since → the whole batch hit 90-day expiry in June.

## Fix

Add `auto_ssl:init_worker()` (guarded on the `auto_ssl` global, which is defined in `init_by_lua_file`) to both nginx templates that use auto-ssl:
- `infra/ansible/roles/wslproxy/templates/nginx.conf.j2` (production)
- `nginx-dev.conf.tmpl` (Docker dev)

The k3s ingress `nginx.conf` files don't use auto-ssl (TLS via secrets) — unaffected.

## Tested (prod 187.124.112.155)

Applied the equivalent change to the live `nginx.conf`, `openresty -t` OK, restarted. Confirmed:
- `init_worker` now fires: log shows `auto-ssl: starting sockproc` in `init_worker_by_lua*` context (it didn't before).
- Forced re-issue of the expired `acc-vault` cert succeeded: `auto-ssl: issuing new certificate for acc-vault.diytaxreturn.co.uk`.
- New live cert (external, `ssl_verify=0`): `notBefore=Jun 13 2026`, **`notAfter=Sep 11 2026`**.

Going forward the renewal timer renews every cert before expiry — true zero-maintenance.

## Related
Complements #1063 (prod-our server block). That fixed prod-our's missing ACME challenge path; this fixes the host-wide renewal automation. Both were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)