### PR TITLE
ci: self-heal root-owned runner workspace in admin-ui-login tests

### DIFF
--- a/.github/workflows/e2e-admin-ui-login.yml
+++ b/.github/workflows/e2e-admin-ui-login.yml
@@ -86,8 +86,24 @@ jobs:
         working-directory: openresty-admin
 
     steps:
+      - name: Reset workspace (clear root-owned build artifacts)
+        # A prior deploy builds the Next.js admin as root and leaves root-owned
+        # files (openresty-admin-next/.next/*) in this runner's workspace.
+        # actions/checkout's default `clean` step then fails with
+        # `EACCES: permission denied, unlink .../.next/BUILD_ID` and the whole
+        # job dies before any test runs. Best-effort reclaim ownership so the
+        # checkout can proceed. Runs from the runner workspace root (which always
+        # exists) rather than the job's openresty-admin default.
+        working-directory: ${{ runner.workspace }}
+        run: |
+          sudo chown -R "$(id -u)":"$(id -g)" . 2>/dev/null || true
+
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          # Defence in depth: even if the reclaim above couldn't run (no sudo),
+          # don't let leftover untracked root-owned files abort the checkout.
+          clean: false
 
       - name: Set environment config
         id: env_config


### PR DESCRIPTION
## Problem

The hourly **WSL Proxy Admin UI Login Tests** workflow (`e2e-admin-ui-login.yml`) fails at the **Checkout** step on the prod self-hosted runner — before any test runs:

```
##[error]File was unable to be removed Error: EACCES: permission denied,
         rmdir '.../openresty-admin-next/.next/build'
##[error]An error occurred trying to start process '/usr/bin/bash' with
         working directory '.../openresty-admin'. No such file or directory
```

A prior deploy builds the Next.js admin **as root**, leaving root-owned `openresty-admin-next/.next/*` files in the runner workspace. The runner runs as `bwalia`, so `actions/checkout`'s clean step can't unlink them (`EACCES`) and the job dies. The result-parser then sees `0 passed / 0 failed` and correctly flags it as a failure.

Example failing run: https://github.com/bwalia/wslproxy/actions/runs/27521965253

## Fix

Apply the same pattern already in `e2e-create-server.yml` (commit `88feeeb7`):
- A pre-checkout step that best-effort `sudo chown`s the workspace back to the runner user.
- `clean: false` on `actions/checkout` as defence in depth.

## Note

This is a recurring root cause — deploys keep leaving root-owned artifacts in the runner workspace. The self-heal makes the test workflows resilient; a cleaner long-term fix would be to stop the deploy from writing root-owned files there in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)