### PR TITLE
feat(pops/dns): POPs + Cloudflare DNS (A/AAAA/CNAME) + MCP tools + Ansible seed

### DIFF
--- a/POPS_AND_DNS_GUIDE.md
+++ b/POPS_AND_DNS_GUIDE.md
@@ -6,6 +6,31 @@ This guide walks you through the **POPs** (Points of Presence) feature and the *
 
 ---
 
+## The mental model in 60 seconds
+
+The whole system is **two separate actions**, never tangled together:
+
+| Action | What it does | Touches Cloudflare? |
+|---|---|---|
+| **SAVE** (server form → Save Changes) | Writes the server JSON on disk (pop_ids, record type, etc.) | **No.** |
+| **PROVISION** (click Preview & Provision → Apply) | Reads what's currently in Cloudflare, computes the diff, writes the changes | **Yes.** |
+
+This means you can edit a server twenty times a day — flip pop_ids, switch record type, change CNAME targets — and Cloudflare sees nothing.  Cloudflare is only touched when you explicitly click **Preview & Provision** and approve the plan.
+
+### When *exactly* does Cloudflare get called?
+
+| Moment | What wslproxy does | Calls |
+|---|---|---|
+| You open a server edit page | Loads the current DNS records to show in the State panel | 1 read |
+| You click **Preview & Provision** | Builds a fresh action plan | 1 read |
+| You click **Apply N changes** in the dialog | Writes each action | N writes |
+
+That's it.  There's no cron job hitting Cloudflare.  There's no background sync.  Cloudflare is touched **only when an operator (or an AI agent) explicitly asks for it.**
+
+> **The single rule to remember:** "Save = wslproxy state only.  Provision = Cloudflare state."
+
+---
+
 ## Table of Contents
 
 1. [What is a POP?](#1-what-is-a-pop)
@@ -20,14 +45,15 @@ This guide walks you through the **POPs** (Points of Presence) feature and the *
    - [4.2  Via the REST API (curl)](#42-via-the-rest-api-curl)
    - [4.3  Via Ansible (production deploy)](#43-via-ansible-production-deploy)
    - [4.4  Via Claude / MCP (natural language)](#44-via-claude--mcp-natural-language)
-5. [Assigning POPs to a server](#5-assigning-pops-to-a-server)
+5. [Assigning POPs and choosing the record type](#5-assigning-pops-and-choosing-the-record-type)
 6. [Provisioning DNS](#6-provisioning-dns)
    - [6.1  Via the dashboard (Preview & Provision)](#61-via-the-dashboard-preview--provision)
    - [6.2  Via the REST API](#62-via-the-rest-api)
    - [6.3  Via Claude / MCP](#63-via-claude--mcp)
-7. [Safety guarantees](#7-safety-guarantees)
-8. [Troubleshooting](#8-troubleshooting)
-9. [FAQ](#9-faq)
+7. [Day-to-day operations](#7-day-to-day-operations)
+8. [Safety guarantees](#8-safety-guarantees)
+9. [Troubleshooting](#9-troubleshooting)
+10. [FAQ](#10-faq)
 
 ---
 
@@ -288,36 +314,67 @@ Other natural-language commands that work:
 
 ---
 
-## 5. Assigning POPs to a server
+## 5. Assigning POPs and choosing the record type
 
-Once your POPs exist, you tell each server (Virtual Server / hostname) which POPs serve it.
+Once your POPs exist, you tell each server (Virtual Server / hostname) two things:
+1. **Which POPs serve it** — the `pop_ids` list
+2. **What shape of DNS record to publish** — A / AAAA / BOTH / CNAME
 
 **Dashboard:**
 
 1. Open the server you want to edit at `/servers/host:your-domain.com`
 2. Scroll to the **POPs (Points of Presence)** section (right after **Basic Settings**).
 3. Tick the checkbox next to each POP that should serve this server.
-4. Click **Save Changes** at the bottom.
+4. Scroll one more card down to **DNS Record Type** and pick:
+   - **A** (default) — one IPv4 record per POP.  The right choice for most setups.
+   - **AAAA** — one IPv6 record per POP.  Each POP must have `public_ipv6` set.
+   - **BOTH** — dual-stack: A *and* AAAA per POP.  POPs without v6 still get their A record; the AAAA pass just skips them.
+   - **CNAME** — one CNAME pointing at a hostname.  When you pick this, a **CNAME target** input appears — fill in the hostname (e.g. `edge.wslproxy.com`).  POPs are ignored in CNAME mode.
+5. Click **Save Changes** at the bottom.
+
+> 💡 The picker above shows `· v6 <addr>` next to each POP's IPv4 address when that POP has `public_ipv6` set.  Use that to spot v6-ready POPs before flipping a server to AAAA or BOTH mode.
 
 **REST API:**
 
-Update the server with a `pop_ids` array:
+Update the server with `pop_ids`, `dns_record_type`, and (for CNAME mode) `dns_cname_target`:
 
 ```bash
+# Standard dual-stack server
 curl -X PUT "http://localhost:18280/api/servers/host:api.example.com" \
   -H "Authorization: Bearer $TOKEN" \
   -H 'x-platform: openresty-admin-next' \
   -H 'Content-Type: application/json' \
-  -d '{"pop_ids": ["pop0", "lon1"]}'
+  -d '{
+    "pop_ids": ["pop0", "lon1"],
+    "dns_record_type": "BOTH"
+  }'
+
+# CNAME server (pop_ids ignored)
+curl -X PUT "http://localhost:18280/api/servers/host:cdn.example.com" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'x-platform: openresty-admin-next' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "dns_record_type": "CNAME",
+    "dns_cname_target": "edge.wslproxy.com"
+  }'
 ```
 
 **Claude / MCP:**
 
 ```
-You: For server host:api.example.com, set the POPs to pop0 and lon1.
+You: For server host:api.example.com, set the POPs to pop0 and lon1
+     and publish both A and AAAA records.
 
-Claude: [calls update_server with pop_ids=["pop0","lon1"]]
-        Done.  api.example.com is now served by pop0 + lon1.
+Claude: [calls update_server with pop_ids=["pop0","lon1"],
+         dns_record_type="BOTH"]
+        Done.  api.example.com is now served by pop0 + lon1, dual-stack.
+
+You: For host:cdn.example.com, point it at edge.wslproxy.com via CNAME.
+
+Claude: [calls update_server with dns_record_type="CNAME",
+         dns_cname_target="edge.wslproxy.com"]
+        Done.  cdn.example.com is now a CNAME alias for edge.wslproxy.com.
 ```
 
 ---
@@ -419,7 +476,36 @@ For a full tour of the MCP setup (Claude Desktop, Claude Code, Cursor, Continue.
 
 ---
 
-## 7. Safety guarantees
+## 7. Day-to-day operations
+
+Once everything's set up, here's the rhythm operators repeat.  Every action follows the same shape: **edit → save → provision → apply.**  The "save" is local; the "apply" is the Cloudflare write.
+
+| You want to… | What you click | What Cloudflare sees |
+|---|---|---|
+| **Add a new POP to a domain** | Tick another POP on the server form → Save → Preview & Provision → Apply | One new A (or AAAA) record |
+| **Remove a POP from a domain** | Untick it on the server form → Save → Preview & Provision → Apply | One DELETE on the orphaned record |
+| **Replace a POP's IP** | Edit the POP record's `public_ipv4` → Save → re-Provision on every domain that uses it | One UPDATE per affected domain |
+| **Drain a POP for maintenance** | `/pops/<id>` → set status to "maintenance" → Save → re-Provision on each domain | One DELETE per affected domain (records come back when you flip status to active and re-provision) |
+| **Switch a domain from A to BOTH** | Server form → DNS Record Type → BOTH → Save → Preview & Provision → Apply | New AAAA records created alongside the existing A records |
+| **Switch a domain from A to CNAME** | Server form → DNS Record Type → CNAME + set target → Save → Preview & Provision → Apply | All A records deleted (orphaned), one CNAME created.  Because CNAME can't coexist with A at the same name, the orchestrator cleans up its old A records automatically. |
+| **Add a new POP to your fleet** | `/pops` → + Create POP → Save | Nothing.  The new POP is just sitting in the inventory until a server adds it to its `pop_ids`. |
+| **Audit "what records does wslproxy own?"** | Open server → DNS State panel.  Each row says "managed by wslproxy" or "external". | Nothing.  Read-only. |
+
+### A few useful Claude prompts
+
+Once Claude is connected via MCP ([api/mcp/README.md](api/mcp/README.md)):
+
+> *"Show me which POPs are currently active."*
+> *"Drain `lon1` for maintenance."*
+> *"What does Cloudflare currently have for `api.example.com`?"*
+> *"Add `pop2` in Frankfurt with IP 1.2.3.4 then provision DNS for `api.example.com` using all three POPs."*
+> *"Switch `cdn.example.com` to CNAME mode pointing at `edge.wslproxy.com`."*
+
+Claude will always **show you the action plan and wait for your "yes"** before writing to Cloudflare.  The `provision_dns` tool defaults to dry-run; the apply pass needs an explicit confirmation.
+
+---
+
+## 8. Safety guarantees
 
 The DNS provisioner has five hard guardrails:
 
@@ -431,7 +517,7 @@ The DNS provisioner has five hard guardrails:
 
 ---
 
-## 8. Troubleshooting
+## 9. Troubleshooting
 
 ### "DNS provisioning is not configured" in the panel
 You haven't added the `dns` block to `settings.json` yet.  Go back to [step 3.3](#33-add-the-dns-block-to-settingsjson).
@@ -443,6 +529,9 @@ Your `managed_zones[0].zone_id` is `00000000000000000000000000000000` (a placeho
 The domain you're trying to provision is not under any of the zones in your `managed_zones` allowlist.  Either:
 - Add the parent zone to `managed_zones` (with its zone_id), or
 - Pick a different domain that IS under an allowed zone.
+
+### "CNAME target not set" in the DNS State panel
+You picked **CNAME** for `dns_record_type` but the **CNAME target** input is empty.  Scroll up to the DNS Record Type card on the server form and fill in the target hostname (e.g. `edge.wslproxy.com`).
 
 ### "Cloudflare rejected the request (HTTP 403)" with code 10000 "Authentication error"
 The token doesn't have permission to read/write DNS on the zone you're targeting.  Either:
@@ -464,7 +553,7 @@ Check the comment on the existing Cloudflare records.  wslproxy can only update 
 
 ---
 
-## 9. FAQ
+## 10. FAQ
 
 **Q: Can I have multiple Cloudflare accounts / multiple providers?**
 Yes.  `providers[]` is an array — add a second entry with a different token + different `managed_zones`.  Each provider has its own allowlist.

--- a/POPS_AND_DNS_GUIDE.md
+++ b/POPS_AND_DNS_GUIDE.md
@@ -18,7 +18,8 @@ This guide walks you through the **POPs** (Points of Presence) feature and the *
 4. [Adding your POPs](#4-adding-your-pops)
    - [4.1  Via the dashboard](#41-via-the-dashboard)
    - [4.2  Via the REST API (curl)](#42-via-the-rest-api-curl)
-   - [4.3  Via Claude / MCP (natural language)](#43-via-claude--mcp-natural-language)
+   - [4.3  Via Ansible (production deploy)](#43-via-ansible-production-deploy)
+   - [4.4  Via Claude / MCP (natural language)](#44-via-claude--mcp-natural-language)
 5. [Assigning POPs to a server](#5-assigning-pops-to-a-server)
 6. [Provisioning DNS](#6-provisioning-dns)
    - [6.1  Via the dashboard (Preview & Provision)](#61-via-the-dashboard-preview--provision)
@@ -210,7 +211,42 @@ curl -X POST http://localhost:18280/api/pops \
   }'
 ```
 
-### 4.3  Via Claude / MCP (natural language)
+### 4.3  Via Ansible (production deploy)
+
+If you deploy wslproxy via the Ansible role, the two production POPs (`pop0` + `lon1`) are seeded automatically on the first deploy.  The seed is defined in `infra/ansible/roles/wslproxy/defaults/main.yml` under the `wslproxy_pops` variable, and the task lives at `tasks/seed_pops.yml`.
+
+**Two important properties:**
+
+1. **Idempotent.**  The seed uses `force: no` — if `/opt/nginx/data/pops/<id>.json` already exists on the target host (because an operator edited via the dashboard, or a previous deploy seeded it), the file is left untouched.  Re-running the role is safe.
+2. **Customisable per-environment.**  Override `wslproxy_pops` in your inventory / group_vars to add environment-specific POPs:
+
+```yaml
+# inventory/group_vars/staging.yml
+wslproxy_pops:
+  - id: pop0
+    display_name: "London POP 0"
+    public_ipv4: "187.124.112.155"
+    region: eu-west
+    city: London
+    country_code: GB
+    status: active
+    capacity_weight: 1.0
+    tags: [production, primary]
+    metadata: {}
+  # ... add per-environment POPs here ...
+  - id: staging-1
+    display_name: "Staging EU"
+    public_ipv4: "10.42.0.1"
+    region: eu-staging
+    status: maintenance
+    capacity_weight: 0
+    tags: [staging]
+    metadata: {}
+```
+
+Run `ansible-playbook ... --tags pops` to re-run just the seed task on its own.
+
+### 4.4  Via Claude / MCP (natural language)
 
 Once you've integrated wslproxy with Claude Desktop, Claude Code, or any other MCP client (see [api/mcp/README.md](api/mcp/README.md)), you can just ask:
 

--- a/POPS_AND_DNS_GUIDE.md
+++ b/POPS_AND_DNS_GUIDE.md
@@ -1,0 +1,456 @@
+# POPs & Cloudflare DNS — End-to-End Guide
+
+This guide walks you through the **POPs** (Points of Presence) feature and the **automatic Cloudflare DNS provisioning** that uses it.  It is written so a non-technical operator can follow it end-to-end with no prior Lua / OpenResty / Cloudflare knowledge — just copy the snippets and follow the screenshots-described steps.
+
+> **TL;DR.** A POP is a server location (a real machine with a public IP that runs wslproxy).  Once you tell wslproxy which POPs serve a given domain, the dashboard's **Preview & Provision** button (or the equivalent Claude / MCP command) will create the right Cloudflare A records for you — without ever touching DNS records you curated by hand.
+
+---
+
+## Table of Contents
+
+1. [What is a POP?](#1-what-is-a-pop)
+2. [How DNS provisioning works](#2-how-dns-provisioning-works)
+3. [One-time Cloudflare setup](#3-one-time-cloudflare-setup)
+   - [3.1  Generate a Cloudflare API token](#31-generate-a-cloudflare-api-token)
+   - [3.2  Find your zone ID](#32-find-your-zone-id)
+   - [3.3  Add the dns block to settings.json](#33-add-the-dns-block-to-settingsjson)
+   - [3.4  Reload OpenResty](#34-reload-openresty)
+4. [Adding your POPs](#4-adding-your-pops)
+   - [4.1  Via the dashboard](#41-via-the-dashboard)
+   - [4.2  Via the REST API (curl)](#42-via-the-rest-api-curl)
+   - [4.3  Via Claude / MCP (natural language)](#43-via-claude--mcp-natural-language)
+5. [Assigning POPs to a server](#5-assigning-pops-to-a-server)
+6. [Provisioning DNS](#6-provisioning-dns)
+   - [6.1  Via the dashboard (Preview & Provision)](#61-via-the-dashboard-preview--provision)
+   - [6.2  Via the REST API](#62-via-the-rest-api)
+   - [6.3  Via Claude / MCP](#63-via-claude--mcp)
+7. [Safety guarantees](#7-safety-guarantees)
+8. [Troubleshooting](#8-troubleshooting)
+9. [FAQ](#9-faq)
+
+---
+
+## 1. What is a POP?
+
+A **POP** (Point of Presence) is a physical or virtual server somewhere in the world that runs wslproxy and serves real traffic.  Each POP has:
+
+| Field | Example | What it's for |
+|---|---|---|
+| **id** | `pop0`, `lon1`, `us-east-1` | Short slug used everywhere wslproxy references this POP |
+| **display_name** | `London POP 0` | Human-friendly label shown in the dashboard |
+| **public_ipv4** | `187.124.112.155` | The public IP that DNS will point to |
+| **region** | `eu-west-1` | Logical grouping (used to sort the picker) |
+| **city** | `London` | For dashboards / context only |
+| **country_code** | `GB` | ISO code, for context |
+| **status** | `active` / `draining` / `maintenance` / `down` | Operational state — `draining` and `maintenance` are excluded from DNS by default |
+| **capacity_weight** | `1.0` (default) / `0.5` / `0` | Routing weight; `0` = drained (no traffic) |
+
+POPs are **global** — they're not per-environment.  The same `pop0` is referenced by your prod and int servers.
+
+A **server** (Virtual Server / hostname) declares which POPs serve it via its `pop_ids` field.  When you provision DNS, wslproxy creates one A record per active POP, pointing the domain at each POP's `public_ipv4`.
+
+```
+Server: api.example.com
+pop_ids: [pop0, lon1]
+
+      ↓ Preview & Provision
+
+Cloudflare A records:
+  api.example.com → 187.124.112.155  (pop=pop0)
+  api.example.com → 72.62.211.28     (pop=lon1)
+```
+
+---
+
+## 2. How DNS provisioning works
+
+When you click **Preview & Provision** (or call the equivalent MCP / REST endpoint), wslproxy does this in order:
+
+1. **Loads your server's `pop_ids`** from disk.
+2. **Resolves each pop_id** to a public IP by reading the POP's JSON.  POPs with status `down` / `maintenance` are skipped (unless you pass `include_inactive: true`).
+3. **Resolves the Cloudflare zone** for the domain from your `managed_zones` allowlist.  **Domains outside the allowlist are refused before any HTTP call to Cloudflare.**
+4. **Inventories existing records** for that domain from Cloudflare.  Each record carries a comment marker — `wslproxy-managed | server=… | profile=… | pop=…` — that tells wslproxy which records it owns.
+5. **Builds a plan**: for each desired POP it decides `create` / `update` / `unchanged`.  Records that exist for POPs no longer in `pop_ids` get marked `delete`.
+6. **In dry-run mode** (the default for Claude / MCP), the plan is returned without writing.  In apply mode, each action is executed against Cloudflare and reported back individually.
+
+**Records wslproxy didn't create are never modified or deleted.**  This is the hard guarantee — your hand-curated records and other tools' records are safe.
+
+---
+
+## 3. One-time Cloudflare setup
+
+### 3.1  Generate a Cloudflare API token
+
+This token is what wslproxy uses to authenticate with Cloudflare.  It only needs DNS edit permission on the zones you want to manage.
+
+1. Open https://dash.cloudflare.com/profile/api-tokens
+2. Click **Create Token** (top right)
+3. Find the template **"Edit zone DNS"** and click **Use template**
+4. Under **Zone Resources**, you have two choices:
+   - **Include → Specific zone → pick the zone you want to manage.**  This is the safer choice — the token can ONLY edit that one zone.
+   - **Include → All zones.**  Use this if you have many zones and don't want to manage tokens per zone.  ⚠ This token can edit DNS on every zone in your account.
+5. (Optional) **Client IP Address Filtering** — restrict to your wslproxy server's IP for extra safety.
+6. (Optional) **TTL** — set an expiry if you want forced rotation (e.g. 1 year).
+7. Click **Continue to summary** → **Create Token**.
+8. **Copy the token now** — Cloudflare will not show it again.  It looks like `cfut_abc123…` or `xRandomString…`.
+
+> **Important:** Treat this token like a password.  Don't paste it into chat logs, Slack, screenshots, or commit it to git.  `data/settings.json` is git-ignored so storing it there is safe.
+
+### 3.2  Find your zone ID
+
+Each Cloudflare zone has a 32-character hex ID.  To find it:
+
+1. In the Cloudflare dashboard, click on your zone (the domain name).
+2. Land on the **Overview** page.
+3. Scroll down the right sidebar — the **Zone ID** is shown there (e.g. `023e105f4ecef8ad9ca31a8372d0c353`).  Click the copy icon next to it.
+
+You'll need this ID for `settings.json`.
+
+### 3.3  Add the dns block to settings.json
+
+Open `data/settings.json` and add a top-level `dns` block.  Paste in your token (from 3.1) and zone (name + id from 3.2).  Example:
+
+```jsonc
+{
+  // ... existing keys ...
+  "dns": {
+    "enabled": true,
+    "default_ttl": 300,
+    "default_proxied": false,
+    "providers": [
+      {
+        "name": "cloudflare-primary",
+        "type": "cloudflare",
+        "api_token": "PASTE_YOUR_REAL_TOKEN_HERE",
+        "managed_zones": [
+          {
+            "name": "example.com",
+            "zone_id": "023e105f4ecef8ad9ca31a8372d0c353"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Field reference:**
+
+| Field | Required? | What it does |
+|---|---|---|
+| `enabled` | yes | Set `true` to allow provisioning at all.  `false` to switch off without removing the block. |
+| `default_ttl` | no | TTL (seconds) for created records.  300 = 5 minutes (a sensible default; tighter = faster fail-over, looser = less load on CF) |
+| `default_proxied` | no | `false` = DNS-only ("grey cloud").  `true` = proxy through Cloudflare ("orange cloud", with CDN/WAF). |
+| `providers[]` | yes | One entry per provider; today only `type: "cloudflare"` is supported. |
+| `providers[].api_token` | yes | The token you generated. |
+| `providers[].managed_zones[]` | yes | The **allowlist** — wslproxy refuses to write to any zone NOT in this list, even if the token has permission. |
+
+> ✅ The `managed_zones` allowlist is your safety net.  Even if the token has "All zones" access, only the zones listed here can be touched.  Adding a new zone is a deliberate edit to `settings.json`.
+
+### 3.4  Reload OpenResty
+
+So OpenResty picks up the new settings:
+
+```bash
+# Inside the Docker container:
+docker exec wslproxy-local /usr/local/openresty/bin/openresty -s reload
+
+# On a bare-metal install:
+sudo systemctl reload openresty
+```
+
+You're done with one-time setup.  Verify with a quick test:
+
+```bash
+curl -H "Authorization: Bearer YOUR_JWT" \
+  "http://localhost:18280/api/dns/lookup?domain=anything-not-in-your-zone.test"
+```
+
+You should get a `zone_not_allowed` 403 — that proves the dns block is loaded and the allowlist works.
+
+---
+
+## 4. Adding your POPs
+
+You can add POPs in three equivalent ways.  Use whichever fits your workflow.
+
+### 4.1  Via the dashboard
+
+1. Open `http://localhost:7619/pops` (dev) or your deployed dashboard URL.
+2. Click **+ Create POP** (top right).
+3. Fill in at minimum: `id`, `display_name`, `public_ipv4`.  The form will guide you through optional fields (region, city, country_code, status, capacity_weight, tags).
+4. Click **Save**.
+5. Verify the new POP shows up in the list with status badge `Active`.
+
+### 4.2  Via the REST API (curl)
+
+You need a JWT.  Get one by logging in:
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:18280/api/user/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"YOUR_ADMIN_PASSWORD"}' | jq -r .accessToken)
+```
+
+Then create the POP:
+
+```bash
+curl -X POST http://localhost:18280/api/pops \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'x-platform: openresty-admin-next' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "id": "lon2",
+    "display_name": "London POP 2",
+    "public_ipv4": "192.0.2.42",
+    "region": "eu-west-1",
+    "city": "London",
+    "country_code": "GB",
+    "status": "active"
+  }'
+```
+
+### 4.3  Via Claude / MCP (natural language)
+
+Once you've integrated wslproxy with Claude Desktop, Claude Code, or any other MCP client (see [api/mcp/README.md](api/mcp/README.md)), you can just ask:
+
+```
+You: Add a new POP called "lon2" in London, IP 192.0.2.42, eu-west-1 region.
+
+Claude: [calls create_pop with dry_run=true]
+        Here's what I'm about to create:
+          - id: lon2
+          - public_ipv4: 192.0.2.42
+          - region: eu-west-1
+          - city: London
+        Should I proceed?
+
+You: yes
+
+Claude: [calls create_pop with dry_run=false]
+        Done.  POP lon2 is now in the list.
+```
+
+Other natural-language commands that work:
+- *"List all POPs"*
+- *"What's the status of pop0?"*
+- *"Drain lon1 — set its status to maintenance"*
+- *"Delete the unused us-east-1 POP"*
+
+---
+
+## 5. Assigning POPs to a server
+
+Once your POPs exist, you tell each server (Virtual Server / hostname) which POPs serve it.
+
+**Dashboard:**
+
+1. Open the server you want to edit at `/servers/host:your-domain.com`
+2. Scroll to the **POPs (Points of Presence)** section (right after **Basic Settings**).
+3. Tick the checkbox next to each POP that should serve this server.
+4. Click **Save Changes** at the bottom.
+
+**REST API:**
+
+Update the server with a `pop_ids` array:
+
+```bash
+curl -X PUT "http://localhost:18280/api/servers/host:api.example.com" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'x-platform: openresty-admin-next' \
+  -H 'Content-Type: application/json' \
+  -d '{"pop_ids": ["pop0", "lon1"]}'
+```
+
+**Claude / MCP:**
+
+```
+You: For server host:api.example.com, set the POPs to pop0 and lon1.
+
+Claude: [calls update_server with pop_ids=["pop0","lon1"]]
+        Done.  api.example.com is now served by pop0 + lon1.
+```
+
+---
+
+## 6. Provisioning DNS
+
+This is the step that actually writes records to Cloudflare.
+
+### 6.1  Via the dashboard (Preview & Provision)
+
+After assigning POPs to a server (step 5), the **DNS State (Cloudflare)** card appears right below the POPs section.
+
+1. The card auto-loads the current Cloudflare records for that domain.
+2. Click **Preview & Provision**.
+3. A modal opens showing **the plan**: what will be created, updated, or deleted, per POP, with the IP and Cloudflare record ID.  Records the orchestrator can't act on are listed under "Skipped POPs" with a reason.
+4. Review the plan.  If it looks right, click **Apply N changes**.
+5. The modal shows the executed result — successes and any per-action errors (Cloudflare may succeed on some records and fail on others; each is reported independently).
+6. Close.  The DNS State panel refreshes to show the new live records.
+
+**What the state panel shows you:**
+
+| State | What it means | What to do |
+|---|---|---|
+| Records listed under "Managed by wslproxy" | These have the wslproxy comment marker and are subject to convergence | Normal state |
+| Records listed under "External records" | wslproxy did NOT create these — they'll never be modified or deleted | Normal state for hand-curated records |
+| `Replace the placeholder zone in settings.json` | You're still on a placeholder zone_id (`000…0`) | Edit `settings.json` to use a real zone_id (see step 3.3) |
+| `No managed zone covers <domain>` | The domain's parent zone isn't in your allowlist | Add the parent zone to `managed_zones` |
+| `DNS provisioning is not configured` | No `dns` block in `settings.json` | Complete step 3.3 |
+| `Cloudflare rejected the request` with code 10000 | Token lacks permission for this zone | Generate a new token scoped to this zone, or add the zone to the existing token's scope |
+
+### 6.2  Via the REST API
+
+**Preview (dry-run):**
+
+```bash
+curl -X POST http://localhost:18280/api/dns/provision \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'x-platform: openresty-admin-next' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "server_id": "host:api.example.com",
+    "profile_id": "prod",
+    "dry_run": true
+  }'
+```
+
+**Apply (real):**
+
+```bash
+curl -X POST http://localhost:18280/api/dns/provision \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'x-platform: openresty-admin-next' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "server_id": "host:api.example.com",
+    "profile_id": "prod",
+    "dry_run": false
+  }'
+```
+
+**Look up current state:**
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:18280/api/dns/lookup?domain=api.example.com"
+```
+
+### 6.3  Via Claude / MCP
+
+The MCP `provision_dns` tool **defaults to dry-run** — so Claude will always show you the plan before applying.
+
+```
+You: Provision DNS for host:api.example.com in prod.
+
+Claude: [calls provision_dns (dry_run defaults to true)]
+        Here's what would change in Cloudflare:
+          - CREATE A api.example.com → 187.124.112.155  (pop=pop0)
+          - CREATE A api.example.com → 72.62.211.28    (pop=lon1)
+        Should I apply these?
+
+You: yes
+
+Claude: [calls provision_dns with dry_run=false]
+        Applied:
+          - Created A record api.example.com → 187.124.112.155
+          - Created A record api.example.com → 72.62.211.28
+        Both records are now live in Cloudflare.
+
+You: What DNS records exist for api.example.com right now?
+
+Claude: [calls lookup_dns]
+        Cloudflare has 2 A records:
+          - 187.124.112.155  (managed by wslproxy, pop=pop0)
+          - 72.62.211.28    (managed by wslproxy, pop=lon1)
+        No hand-curated records.
+```
+
+For a full tour of the MCP setup (Claude Desktop, Claude Code, Cursor, Continue.dev, custom clients), see **[api/mcp/README.md](api/mcp/README.md)**.
+
+---
+
+## 7. Safety guarantees
+
+The DNS provisioner has five hard guardrails:
+
+1. **`managed_zones` allowlist.**  Domains outside the allowlist are refused before any HTTP call to Cloudflare.  Even if the token has "All zones" access, only the zones you list can be touched.
+2. **`wslproxy-managed` comment marker.**  wslproxy only modifies or deletes records carrying this comment.  Hand-curated records with no marker are **never touched** — even if their names collide with a desired record.
+3. **Down / maintenance POPs are skipped by default.**  Their A records are NOT created, even if they're in the server's `pop_ids`.  Pass `include_inactive: true` to override.
+4. **`dry_run: true` is the default for MCP `provision_dns`.**  An AI agent always sees the plan first; applying requires an explicit `dry_run: false` follow-up.
+5. **POP deletion refuses while in use.**  Deleting a POP that's referenced by any server returns `409` with the list of referencing servers.  Pass `force: true` to cascade-detach — and even then, if **any** server can't be safely rewritten, the whole delete aborts (no dangling pop_ids left behind).
+
+---
+
+## 8. Troubleshooting
+
+### "DNS provisioning is not configured" in the panel
+You haven't added the `dns` block to `settings.json` yet.  Go back to [step 3.3](#33-add-the-dns-block-to-settingsjson).
+
+### "Replace the placeholder zone in settings.json"
+Your `managed_zones[0].zone_id` is `00000000000000000000000000000000` (a placeholder we use during testing).  Replace it with the real zone_id from [step 3.2](#32-find-your-zone-id).
+
+### "No managed zone covers \<domain\>"
+The domain you're trying to provision is not under any of the zones in your `managed_zones` allowlist.  Either:
+- Add the parent zone to `managed_zones` (with its zone_id), or
+- Pick a different domain that IS under an allowed zone.
+
+### "Cloudflare rejected the request (HTTP 403)" with code 10000 "Authentication error"
+The token doesn't have permission to read/write DNS on the zone you're targeting.  Either:
+- Regenerate the token with the correct zone scope, or
+- Add this zone to the existing token's scope in Cloudflare dashboard → API tokens → edit token → Zone Resources.
+
+### "Could not reach Cloudflare" / network errors
+- Verify `api.cloudflare.com` is reachable from your wslproxy host: `curl https://api.cloudflare.com/client/v4`
+- Check the trust store directive in nginx: `lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;` should be in the `http` block.  Debian ships the bundle via the `ca-certificates` package.
+- On Docker for Mac: the bridge sometimes returns IPv6 with no v6 route — `ipv6=off` on the `resolver` directive avoids this.
+
+### "Pre-existing CRUD on POPs returns 500 HTML page"
+You hit a malformed JSON path.  This was fixed in commit `cd90ac8b` — make sure your `feature/pops-and-cloudflare-dns` branch is up to date.
+
+### Records keep getting created instead of updated
+Check the comment on the existing Cloudflare records.  wslproxy can only update records it created (those carrying the `wslproxy-managed | …` comment).  If someone (or another tool) created the record without the marker, wslproxy treats it as "external" and refuses to touch it.  Either:
+- Delete the unmarked record in Cloudflare manually and re-run Preview & Provision, or
+- Edit the Cloudflare record's comment to include `wslproxy-managed | server=… | profile=… | pop=…` and wslproxy will pick it up.
+
+---
+
+## 9. FAQ
+
+**Q: Can I have multiple Cloudflare accounts / multiple providers?**
+Yes.  `providers[]` is an array — add a second entry with a different token + different `managed_zones`.  Each provider has its own allowlist.
+
+**Q: What about AAAA (IPv6) records?**
+Today the provisioner manages A records only.  POPs have a `public_ipv6` field and the code is structured to support AAAA in a future change — but it's not exposed yet.  If you need it, file an issue or open a PR.
+
+**Q: What about CNAME records?**
+Not supported yet — same reason as AAAA.  Today wslproxy creates one A record per POP.  CNAME-via-single-hostname (e.g. all servers point to `wslproxy.example.com` which has A records for each POP) would be cleaner for fleets with rotating IPs, but isn't implemented.
+
+**Q: Does the dashboard's "Refresh" button rate-limit Cloudflare?**
+Each Refresh hits Cloudflare's `GET /zones/{id}/dns_records` once per domain.  Cloudflare's limit is ~1200 req/5min per token — you'd have to spam Refresh hundreds of times per minute to hit it.
+
+**Q: What happens if I rename a domain (change `server_name`)?**
+Today: nothing automatic.  The records for the old domain remain in Cloudflare (orphaned-but-marked).  You'd manually delete them in CF dashboard.  A future enhancement could detect rename and clean up.
+
+**Q: Is the Cloudflare API token rotated automatically?**
+No.  Tokens are static in `settings.json`.  We recommend setting a TTL in Cloudflare when you create the token (e.g. 1 year) and rotating manually.
+
+**Q: Can I roll back a DNS change?**
+Not directly — once applied, the change is in Cloudflare.  However, the audit log (`data/audit/YYYY-MM/DD.json`) records every action with timestamps and the previous state, so you can manually revert by replaying the inverse plan.  A "rollback last provision" feature is on the roadmap.
+
+**Q: What's the difference between `dry_run` (DNS) and `confirm` (POP delete)?**
+- `dry_run: true` returns a **plan preview** without writing — used for non-destructive changes you want to inspect first.
+- `confirm: true` is a **destructive-action gate** — required for irreversible operations (delete) so an AI agent can't accidentally trigger them.
+
+**Q: Can I use this without Cloudflare?**
+Today no.  The provider abstraction is in place (`api/dns_manager.lua` is structured around a `provider` type), so adding Route 53, Google Cloud DNS, or Azure DNS is a discrete chunk of work.  The dashboard and MCP tools are provider-agnostic — they only care about the `dns_manager` interface, not Cloudflare specifically.
+
+---
+
+## See also
+
+- **[api/mcp/README.md](api/mcp/README.md)** — full MCP server documentation: Claude Desktop / Code / Cursor / Continue.dev integration, all tool reference, troubleshooting
+- **[CLAUDE.md](CLAUDE.md)** — repo-level architecture + conventions
+- **`data/audit/YYYY-MM/DD.json`** — NDJSON audit trail of every POP and DNS action
+- **`data/pops/*.json`** — POP records on disk (one file per POP)
+- **`data/settings.json`** — global config including the `dns` block

--- a/POPS_AND_DNS_GUIDE.md
+++ b/POPS_AND_DNS_GUIDE.md
@@ -76,6 +76,19 @@ When you click **Preview & Provision** (or call the equivalent MCP / REST endpoi
 
 **Records wslproxy didn't create are never modified or deleted.**  This is the hard guarantee — your hand-curated records and other tools' records are safe.
 
+### Choosing the record type
+
+Each server has a `dns_record_type` field — set via the **DNS Record Type** card on the server form — that controls what shape of record the provisioner publishes:
+
+| Mode | What's published | Uses pop_ids? | Reads which POP field |
+|---|---|---|---|
+| **A** (default) | One A record per active POP | yes | `public_ipv4` |
+| **AAAA** | One AAAA record per active POP | yes | `public_ipv6` |
+| **BOTH** | Both A and AAAA per active POP (dual-stack) | yes | `public_ipv4` + `public_ipv6` |
+| **CNAME** | ONE CNAME pointing at a hostname | no | uses `dns_cname_target` instead |
+
+In **BOTH** mode, POPs that have `public_ipv4` but no `public_ipv6` still get an A record — the AAAA pass just skips them with reason `no_public_ipv6`.  In **CNAME** mode, POPs are not used at all; the server points at a single hostname.
+
 ---
 
 ## 3. One-time Cloudflare setup
@@ -457,10 +470,16 @@ Check the comment on the existing Cloudflare records.  wslproxy can only update 
 Yes.  `providers[]` is an array — add a second entry with a different token + different `managed_zones`.  Each provider has its own allowlist.
 
 **Q: What about AAAA (IPv6) records?**
-Today the provisioner manages A records only.  POPs have a `public_ipv6` field and the code is structured to support AAAA in a future change — but it's not exposed yet.  If you need it, file an issue or open a PR.
+Supported.  On the server form, pick the **DNS Record Type** card and choose **AAAA** (or **BOTH** for dual-stack).  AAAA mode publishes one record per active POP using its `public_ipv6` field; POPs without v6 set get skipped with reason `no_public_ipv6` so you can see at a glance which need configuring.  Set each POP's `public_ipv6` either via the `/pops` dashboard or by setting the field in `data/pops/<id>.json`.
 
 **Q: What about CNAME records?**
-Not supported yet — same reason as AAAA.  Today wslproxy creates one A record per POP.  CNAME-via-single-hostname (e.g. all servers point to `wslproxy.example.com` which has A records for each POP) would be cleaner for fleets with rotating IPs, but isn't implemented.
+Supported.  Pick **CNAME** on the DNS Record Type card and fill in the **CNAME target** field — the hostname your domain should point at (e.g. `edge.wslproxy.com`).  CNAME mode publishes ONE record (not per-POP) and ignores `pop_ids`.  Note that the DNS spec forbids CNAME from coexisting with A/AAAA at the same name; the provisioner will clean up any old A/AAAA records it owns when you switch to CNAME (records you curated by hand outside wslproxy are left alone, as always).
+
+**Q: When should I use BOTH vs A vs AAAA?**
+- **A** (default): every POP has IPv4, you don't need v6 yet, no client requests AAAA.
+- **AAAA**: pure v6 environment (rare for public-facing services, common for internal/eyeball clouds).
+- **BOTH**: dual-stack — you want v4 and v6 clients to both reach the POP closest to them.  POPs without v6 still get an A record; the AAAA pass just skips them.
+- **CNAME**: the domain is an alias for another hostname that already has the right records (e.g. a wholesale CDN endpoint, a managed-service hostname).  CNAME mode is incompatible with multi-POP routing on the same name.
 
 **Q: Does the dashboard's "Refresh" button rate-limit Cloudflare?**
 Each Refresh hits Cloudflare's `GET /zones/{id}/dns_records` once per domain.  Cloudflare's limit is ~1200 req/5min per token — you'd have to spam Refresh hundreds of times per minute to hit it.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ WSLProxy is a high-performance, cloud-native API gateway and reverse proxy built
 - **🏗️ Multi-Deployment Ready** - Docker, Kubernetes, Docker Swarm, and bare metal support
 - **🔌 Service Mesh Ready** - Consul integration for service discovery and health checks
 - **📦 Zero Dependencies** - Lightweight container (~150MB) with everything included
+- **🌍 POPs + Cloudflare DNS** - Declare your edge locations once, provision A records automatically — with safety guardrails so wslproxy never touches a record it didn't create. See **[POPS_AND_DNS_GUIDE.md](POPS_AND_DNS_GUIDE.md)**
+- **🤖 MCP / AI Agent Integration** - Manage servers, rules, POPs, and DNS via natural language from Claude Desktop / Claude Code / Cursor. See **[api/mcp/README.md](api/mcp/README.md)**
 
 ## Quick Start (Choose Your Deployment)
 

--- a/api/api.lua
+++ b/api/api.lua
@@ -13,6 +13,8 @@ local VarnishManager = require("varnish_manager")
 local VersionManager = require("version_manager")
 local CRManager = require("cr_manager")
 local AuditLogger = require("audit_logger")
+local Pops = require("pops")
+local DnsManager = require("dns_manager")
 
 local settings = Helper.settings()
 local storageTypeOverride = settings.settings or os.getenv("STORAGE_TYPE")
@@ -3484,6 +3486,248 @@ local function deleteProfile(body)
     end
 end
 
+-- ─────────────────────────────────────────────────────────────────────
+-- POPs (Points of Presence) — HTTP wrappers
+--
+-- Pure HTTP-translation layer.  All validation, persistence, audit
+-- and referential-integrity logic lives in api/pops.lua; these
+-- functions translate between HTTP request shape and the module's
+-- structured return contract.
+--
+-- Module returns `(value, err_table)` where `err_table.code` is one
+-- of: validation_failed | not_found | conflict | io_error.  The
+-- mapping below converts those to HTTP status codes once, in one
+-- place, so every endpoint surfaces identical error semantics.
+-- ─────────────────────────────────────────────────────────────────────
+
+local function popErrorResponse(err)
+    local status_for = {
+        validation_failed = ngx.HTTP_BAD_REQUEST,
+        not_found = ngx.HTTP_NOT_FOUND,
+        conflict = ngx.HTTP_CONFLICT,
+        io_error = ngx.HTTP_INTERNAL_SERVER_ERROR,
+    }
+    local status = status_for[err.code] or ngx.HTTP_INTERNAL_SERVER_ERROR
+    ngx.status = status
+    -- Envelope shape MUST match what the dashboard's parseBackendError
+    -- expects: `{ error: { message, status, code, details? } }`.  A
+    -- flat `{error: "code", message: ...}` body is parsed as raw text
+    -- and rendered verbatim in the UI's error banners.
+    ngx.say(cjson.encode({
+        error = {
+            message = err.message or "Unknown error",
+            status = status,
+            code = err.code or "internal_error",
+            details = err.details,
+        },
+    }))
+    return ngx.exit(status)
+end
+
+local function listPops(args)
+    local params = {}
+    -- Two query-arg conventions are in use across this API: a single
+    -- `params=<json>` blob (used by the react-admin dataProvider) or
+    -- individual `pagination[page]` style flat keys (used by curl /
+    -- the Next.js admin's dataProvider).  Accept both so callers
+    -- don't have to know which dialect this endpoint expects.
+    if args.params and args.params ~= "" then
+        local ok, decoded = pcall(cjson.decode, args.params)
+        if ok and type(decoded) == "table" then params = decoded end
+    else
+        params = {
+            pagination = {
+                page = tonumber(args['pagination[page]']) or 1,
+                perPage = tonumber(args['pagination[perPage]']) or 25,
+            },
+            sort = {
+                field = args['sort[field]'] or 'id',
+                order = args['sort[order]'] or 'ASC',
+            },
+            filter = {
+                q = args['filter[q]'],
+                status = args['filter[status]'],
+                region = args['filter[region]'],
+            },
+        }
+    end
+    local records, total_or_err = Pops.list(params)
+    if not records then
+        return popErrorResponse(total_or_err)
+    end
+    ngx.say(cjson.encode({ data = records, total = total_or_err }))
+end
+
+local function listPop(args, uuid)
+    local record, err = Pops.get(uuid)
+    if not record then
+        return popErrorResponse(err)
+    end
+    ngx.say(cjson.encode({ data = record }))
+end
+
+-- Shared create/update handler — matches the convention used by
+-- every other resource in this file (createUpdateServer,
+-- createUpdateUpstreams, etc.).  `uuid` nil = POST = create;
+-- `uuid` set = PUT = update.
+local function createUpdatePop(body, uuid)
+    local payload = Helper.GetPayloads(body)
+    if not payload then
+        ngx.status = ngx.HTTP_BAD_REQUEST
+        ngx.say(cjson.encode({
+            error = "validation_failed",
+            message = "Failed to parse request payload",
+        }))
+        return ngx.exit(ngx.HTTP_BAD_REQUEST)
+    end
+    local user = ngx.req.get_headers()["x-user"] or "system"
+    local record, err
+    if uuid and uuid ~= "" and uuid ~= "pops" then
+        record, err = Pops.update(uuid, payload, user)
+    else
+        record, err = Pops.create(payload, user)
+    end
+    if not record then
+        return popErrorResponse(err)
+    end
+    ngx.say(cjson.encode({ data = record }))
+end
+
+-- DELETE supports an optional `?force=true` query param for
+-- cascade-detach (strip the pop_id from every server that
+-- references it before removing).  Default behaviour is to refuse
+-- with 409 + a list of referencing servers so the operator can
+-- review them first.
+local function deletePop(args, uuid)
+    if not uuid or uuid == "" or uuid == "pops" then
+        ngx.status = ngx.HTTP_BAD_REQUEST
+        ngx.say(cjson.encode({
+            error = "validation_failed",
+            message = "pop id is required in the URL",
+        }))
+        return ngx.exit(ngx.HTTP_BAD_REQUEST)
+    end
+    -- Force flag can arrive in three places:
+    --   1. URL query string `?force=true`  (curl, direct API users)
+    --   2. POST body field `force=true`    (form-encoded)
+    --   3. Nested in `params` JSON blob   (react-admin dataProvider)
+    -- handle_delete_request passes the POST args to us; the URI
+    -- query args have to be read explicitly here.  Accept all three
+    -- forms so the API behaves identically regardless of caller.
+    local force = false
+    local query_args = ngx.req.get_uri_args()
+    if query_args.force == "true" or args.force == "true" or args.force == true then
+        force = true
+    elseif args.params then
+        local ok, decoded = pcall(cjson.decode, args.params)
+        if ok and type(decoded) == "table" and decoded.force then
+            force = true
+        end
+    end
+    local user = ngx.req.get_headers()["x-user"] or "system"
+    local ok, err = Pops.delete(uuid, {force = force}, user)
+    if not ok then
+        return popErrorResponse(err)
+    end
+    ngx.say(cjson.encode({ data = {message = "POP deleted", id = uuid, forced = force} }))
+end
+
+-- ─────────────────────────────────────────────────────────────────────
+-- DNS Manager — HTTP wrappers
+--
+-- Pure HTTP-translation layer for the Cloudflare provisioning module.
+-- Domain logic lives in api/dns_manager.lua; these handlers translate
+-- between request shape and the module's structured-error contract.
+--
+-- Status-code mapping covers a superset of the pops mapping: DNS adds
+-- `zone_not_allowed` (403 — the managed_zones safety guard fired),
+-- `not_configured` (503 — settings.json has no usable dns block),
+-- `disabled` (503 — explicitly off), `network_error` (502 — couldn't
+-- reach Cloudflare), `provider_error` (502 — Cloudflare returned
+-- success:false), `rate_limited` (429 — retries exhausted).
+-- ─────────────────────────────────────────────────────────────────────
+
+local function dnsErrorResponse(err)
+    local status_for = {
+        validation_failed = ngx.HTTP_BAD_REQUEST,
+        not_found = ngx.HTTP_NOT_FOUND,
+        no_pops_assigned = ngx.HTTP_BAD_REQUEST,
+        no_targets = ngx.HTTP_BAD_REQUEST,
+        zone_not_allowed = ngx.HTTP_FORBIDDEN,
+        conflict = ngx.HTTP_CONFLICT,
+        not_configured = ngx.HTTP_SERVICE_UNAVAILABLE,
+        disabled = ngx.HTTP_SERVICE_UNAVAILABLE,
+        network_error = ngx.HTTP_BAD_GATEWAY,
+        provider_error = ngx.HTTP_BAD_GATEWAY,
+        decode_error = ngx.HTTP_BAD_GATEWAY,
+        rate_limited = 429,
+        io_error = ngx.HTTP_INTERNAL_SERVER_ERROR,
+    }
+    local status = status_for[err.code] or ngx.HTTP_INTERNAL_SERVER_ERROR
+    ngx.status = status
+    -- Same envelope contract as popErrorResponse — the dashboard's
+    -- parseBackendError reads `error.message` / `error.code` /
+    -- `error.details` from this nested shape.  A flat top-level
+    -- envelope is treated as opaque text and rendered raw.
+    ngx.say(cjson.encode({
+        error = {
+            message = err.message or "Unknown error",
+            status = status,
+            code = err.code or "internal_error",
+            details = err.details,
+        },
+    }))
+    return ngx.exit(status)
+end
+
+-- GET /api/dns/lookup?domain=<fqdn>[&type=A]
+-- Read-only inspection — returns the current Cloudflare records for
+-- a domain, annotated with which ones wslproxy manages.  Used by the
+-- "DNS State" panel on the server form and for ops debugging.
+local function dnsLookup(args)
+    local domain = args.domain
+    if (not domain or domain == "") and args.params then
+        local ok, decoded = pcall(cjson.decode, args.params)
+        if ok and type(decoded) == "table" then
+            domain = decoded.domain
+        end
+    end
+    local result, err = DnsManager.lookup({
+        domain = domain,
+        type = args.type,
+    })
+    if not result then return dnsErrorResponse(err) end
+    ngx.say(cjson.encode({ data = result }))
+end
+
+-- POST /api/dns/provision
+-- Body: { server_id, profile_id, dry_run?, include_inactive?, record_type? }
+-- Reads the server's pop_ids, resolves each to a POP IP, and
+-- converges Cloudflare to match.  See dns_manager.provision_for_server
+-- for the exact action-planning semantics.
+local function dnsProvision(body)
+    local payload = Helper.GetPayloads(body)
+    if not payload then
+        ngx.status = ngx.HTTP_BAD_REQUEST
+        ngx.say(cjson.encode({
+            error = "validation_failed",
+            message = "Failed to parse request payload",
+        }))
+        return ngx.exit(ngx.HTTP_BAD_REQUEST)
+    end
+    local user = ngx.req.get_headers()["x-user"] or "system"
+    local result, err = DnsManager.provision_for_server({
+        server_id = payload.server_id,
+        profile_id = payload.profile_id,
+        dry_run = payload.dry_run == true,
+        include_inactive = payload.include_inactive == true,
+        record_type = payload.record_type,
+        user = user,
+    })
+    if not result then return dnsErrorResponse(err) end
+    ngx.say(cjson.encode({ data = result }))
+end
+
 local function readFile(filePath)
     local file, fileErr = io.open(filePath, "r")
     if not file then return fileErr, ngx.HTTP_INTERNAL_SERVER_ERROR end
@@ -4694,6 +4938,21 @@ local function handle_get_request(args, path)
         listProfile(args, uuid)
     end
 
+    -- POPs (Points of Presence)
+    if path == "pops" then
+        listPops(args)
+    elseif uuid and subPath[1] == "pops" then
+        listPop(args, uuid)
+    end
+
+    -- DNS Manager (Cloudflare).  Read-only inspection — returns the
+    -- current Cloudflare records for a domain.  Matches both
+    -- `/api/dns/lookup?domain=...` and the `params=` JSON envelope so
+    -- both curl and the dashboard's dataProvider can call it.
+    if path == "dns/lookup" then
+        dnsLookup(args)
+    end
+
     -- WAF endpoints
     if path == "waf_rules" then
         listWafRules(args)
@@ -4964,6 +5223,19 @@ local function handle_post_request(args, path)
         end
         if path == "profiles" then
             createUpdateProfiles(args, nil)
+        end
+        -- POPs POST: exact-match dispatch.  POST is create-only here;
+        -- updates go through PUT /api/pops/{id} via the PUT
+        -- dispatcher's "^pops" string.find clause.
+        if path == "pops" then
+            createUpdatePop(args, nil)
+        end
+        -- DNS provisioning.  The action endpoint (not a CRUD on a
+        -- resource) — body carries server_id + profile_id + flags.
+        -- Reads each pop's IP, converges Cloudflare to a 1-A-per-pop
+        -- record set.  See api/dns_manager.lua provision_for_server.
+        if path == "dns/provision" then
+            dnsProvision(args)
         end
         if path == "bookmarks" then
             local bm_ok, Bookmarks = pcall(require, "bookmarks")
@@ -5458,6 +5730,15 @@ local function handle_put_request(args, path)
             createUpdateProfiles(args, uuid)
         end
 
+        -- POPs PUT: forwards uuid (the URL segment) to the shared
+        -- create/update handler so it takes the update path.  We
+        -- anchor with "^pops" so unrelated paths like "shops/..."
+        -- can't trip on a `find` substring match.  POST routes to a
+        -- separate dispatch in handle_post_request (path == "pops").
+        if string.find(path, "^pops") then
+            createUpdatePop(args, uuid)
+        end
+
         -- Bookmarks share a single create/update handler (the function
         -- looks up by id/host and replaces or appends).  Without this
         -- the admin form's PUT request would silently no-op — POST
@@ -5728,6 +6009,13 @@ local function handle_delete_request(args, path)
         end
         if string.find(path, "profiles") then
             deleteProfile(args)
+        end
+        -- POPs DELETE: forwards uuid + the parsed query args (the
+        -- wrapper reads `force` from either a flat query param or a
+        -- nested params blob so the API behaves identically whether
+        -- called via curl or via the react-admin dataProvider).
+        if string.find(path, "^pops") and uuid then
+            deletePop(args, uuid)
         end
         if string.find(path, "bookmarks") and uuid then
             local bm_ok, Bookmarks = pcall(require, "bookmarks")

--- a/api/api.lua
+++ b/api/api.lua
@@ -3655,6 +3655,7 @@ local function dnsErrorResponse(err)
         not_found = ngx.HTTP_NOT_FOUND,
         no_pops_assigned = ngx.HTTP_BAD_REQUEST,
         no_targets = ngx.HTTP_BAD_REQUEST,
+        no_cname_target = ngx.HTTP_BAD_REQUEST,
         zone_not_allowed = ngx.HTTP_FORBIDDEN,
         conflict = ngx.HTTP_CONFLICT,
         not_configured = ngx.HTTP_SERVICE_UNAVAILABLE,

--- a/api/api.lua
+++ b/api/api.lua
@@ -3571,14 +3571,18 @@ end
 -- createUpdateUpstreams, etc.).  `uuid` nil = POST = create;
 -- `uuid` set = PUT = update.
 local function createUpdatePop(body, uuid)
-    local payload = Helper.GetPayloads(body)
-    if not payload then
-        ngx.status = ngx.HTTP_BAD_REQUEST
-        ngx.say(cjson.encode({
-            error = "validation_failed",
+    -- Helper.GetPayloads internally calls cjson.decode without a
+    -- pcall — malformed JSON throws a Lua runtime error which would
+    -- otherwise escape as a 500 with an HTML body, defeating our
+    -- structured error envelope.  Wrap defensively so any parse
+    -- failure surfaces as a 400 validation_failed instead.
+    local ok, payload = pcall(Helper.GetPayloads, body)
+    if not ok or not payload then
+        return popErrorResponse({
+            code = "validation_failed",
             message = "Failed to parse request payload",
-        }))
-        return ngx.exit(ngx.HTTP_BAD_REQUEST)
+            details = (not ok) and {parse_error = tostring(payload)} or nil,
+        })
     end
     local user = ngx.req.get_headers()["x-user"] or "system"
     local record, err
@@ -3600,12 +3604,10 @@ end
 -- review them first.
 local function deletePop(args, uuid)
     if not uuid or uuid == "" or uuid == "pops" then
-        ngx.status = ngx.HTTP_BAD_REQUEST
-        ngx.say(cjson.encode({
-            error = "validation_failed",
+        return popErrorResponse({
+            code = "validation_failed",
             message = "pop id is required in the URL",
-        }))
-        return ngx.exit(ngx.HTTP_BAD_REQUEST)
+        })
     end
     -- Force flag can arrive in three places:
     --   1. URL query string `?force=true`  (curl, direct API users)
@@ -3706,14 +3708,16 @@ end
 -- converges Cloudflare to match.  See dns_manager.provision_for_server
 -- for the exact action-planning semantics.
 local function dnsProvision(body)
-    local payload = Helper.GetPayloads(body)
-    if not payload then
-        ngx.status = ngx.HTTP_BAD_REQUEST
-        ngx.say(cjson.encode({
-            error = "validation_failed",
+    -- See note in createUpdatePop: Helper.GetPayloads will throw on
+    -- malformed JSON; pcall keeps the failure inside our structured
+    -- error envelope rather than bubbling up as a 500 HTML page.
+    local ok, payload = pcall(Helper.GetPayloads, body)
+    if not ok or not payload then
+        return dnsErrorResponse({
+            code = "validation_failed",
             message = "Failed to parse request payload",
-        }))
-        return ngx.exit(ngx.HTTP_BAD_REQUEST)
+            details = (not ok) and {parse_error = tostring(payload)} or nil,
+        })
     end
     local user = ngx.req.get_headers()["x-user"] or "system"
     local result, err = DnsManager.provision_for_server({

--- a/api/dns_manager.lua
+++ b/api/dns_manager.lua
@@ -505,11 +505,15 @@ function _M.provision_for_server(opts)
     local desired = {}      -- list of {pop_id, content (IP)}
     local skipped = {}
     for _, pid in ipairs(pop_ids) do
-        local pop = Pops.get(pid)
+        -- Capture both returns from Pops.get so we don't masquerade
+        -- io_error / decode_error as "not_found".  The operator sees
+        -- the real reason in the skipped list (e.g. "io_error" when a
+        -- pop file is unreadable — distinct from a genuinely missing
+        -- POP).
+        local pop, perr = Pops.get(pid)
         if type(pop) ~= "table" then
-            -- Pops.get returned an error; record the skip with the
-            -- error code so the dashboard can highlight it.
-            table.insert(skipped, {pop_id = pid, reason = "not_found"})
+            local reason = (perr and perr.code) or "not_found"
+            table.insert(skipped, {pop_id = pid, reason = reason})
         elseif not pop.public_ipv4 or pop.public_ipv4 == "" then
             table.insert(skipped, {pop_id = pid, reason = "no_public_ipv4"})
         elseif (pop.status == "down" or pop.status == "maintenance") and
@@ -643,7 +647,8 @@ function _M.provision_for_server(opts)
             else
                 table.insert(executed, {
                     action = "error", pop_id = a.pop_id,
-                    content = a.content, error = err.message,
+                    content = a.content,
+                    error = (err and err.message) or "unknown error",
                 })
             end
         elseif a.action == "update" then
@@ -664,7 +669,8 @@ function _M.provision_for_server(opts)
             else
                 table.insert(executed, {
                     action = "error", pop_id = a.pop_id,
-                    content = a.content, error = err.message,
+                    content = a.content,
+                    error = (err and err.message) or "unknown error",
                 })
             end
         elseif a.action == "delete" or a.action == "delete_legacy" then
@@ -678,7 +684,7 @@ function _M.provision_for_server(opts)
             else
                 table.insert(executed, {
                     action = "error", pop_id = a.pop_id,
-                    error = err.message,
+                    error = (err and err.message) or "unknown error",
                 })
             end
         else  -- unchanged

--- a/api/dns_manager.lua
+++ b/api/dns_manager.lua
@@ -1,0 +1,712 @@
+-- DNS Manager Module for WSLProxy
+--
+-- Provisions DNS records at external providers (Cloudflare today;
+-- Route53 / Google DNS later as additional `provider.type` entries).
+-- Reads each server's `pop_ids` field + the POP entities created by
+-- pops.lua to compute the desired set of A records, then converges
+-- Cloudflare to match.
+--
+-- Storage:  settings.json → `dns` block (token, managed_zones list,
+--           defaults).  No on-disk state of its own — Cloudflare is
+--           the source of truth.
+-- Public API:
+--   _M.is_enabled()                       → bool, missing-config string
+--   _M.find_zone(domain)                  → zone_record | (nil, err)
+--   _M.lookup(opts)                       → records[] | (nil, err)
+--   _M.ensure_record(opts)                → record_info | (nil, err)
+--   _M.provision_for_server(opts)         → summary | (nil, err)
+--
+-- Errors are structured tables of the form
+--   { code = "<symbolic>", message = "<human>", details = {...} }
+-- mirroring the convention from `pops.lua` so the HTTP layer can
+-- map them onto 400 / 404 / 409 / 502 cleanly.
+--
+-- Safety properties:
+--   1. The `managed_zones` allowlist in settings.json is the ONLY
+--      thing wslproxy will write to.  Unknown zones are refused
+--      before any HTTP call.  Hard guardrail against accidentally
+--      modifying a customer's domain.
+--   2. Every record wslproxy creates carries a `wslproxy-managed`
+--      marker in its `comment` field.  Records without that marker
+--      are NEVER touched, even by force-cleanup paths.  Hand-curated
+--      records by a human operator stay safe.
+--   3. Pops in `down` / `maintenance` status are skipped during
+--      provisioning by default (with a note in the response).  An
+--      explicit `include_inactive=true` is required to bring them
+--      back into a record set.
+
+local _M = {}
+
+local http = require("resty.http")
+local cjson = Cjson or require("cjson")
+local Helper = require("helpers")
+local AuditLogger = require("audit_logger")
+local Pops = require("pops")
+
+local configPath = os.getenv("NGINX_CONFIG_DIR") or "/opt/nginx/"
+
+-- ============================================================
+-- Constants
+-- ============================================================
+
+local CF_BASE = "https://api.cloudflare.com/client/v4"
+local DEFAULT_TIMEOUT_MS = 10000
+local DEFAULT_TTL = 300            -- 5 min, dashboard-changeable per request
+local DEFAULT_PROXIED = false      -- wslproxy terminates SSL; CF orange-cloud
+                                    -- would conflict by default
+local MARKER = "wslproxy-managed"
+local MAX_RETRIES_ON_429 = 3       -- Cloudflare rate-limit retries
+local RETRY_BASE_DELAY_MS = 250    -- exponential backoff base
+
+-- ============================================================
+-- Settings loading + zone discovery
+-- ============================================================
+
+--- Read the dns block from settings.json and return the primary
+--- Cloudflare provider.  Returns a normalised provider record or a
+--- structured error explaining what's missing.
+local function load_provider()
+    local settings = Helper.settings()
+    local dns_cfg = settings and settings.dns
+    if type(dns_cfg) ~= "table" then
+        return nil, {
+            code = "not_configured",
+            message = "settings.json has no `dns` block — DNS provisioning is disabled.  Add a dns.providers[] entry with a Cloudflare api_token + managed_zones list.",
+        }
+    end
+    if dns_cfg.enabled == false then
+        return nil, {
+            code = "disabled",
+            message = "DNS provisioning is explicitly disabled (settings.json: dns.enabled = false).",
+        }
+    end
+    local providers = dns_cfg.providers
+    if type(providers) ~= "table" or #providers == 0 then
+        return nil, {
+            code = "not_configured",
+            message = "settings.json: dns.providers is empty.  Add at least one provider entry.",
+        }
+    end
+    -- For now we only handle Cloudflare.  Pick the first provider
+    -- whose type matches; future work routes per-zone to different
+    -- providers, but a single-provider deploy is the 99% case.
+    for _, p in ipairs(providers) do
+        if p.type == "cloudflare" then
+            if not p.api_token or p.api_token == "" then
+                return nil, {
+                    code = "not_configured",
+                    message = "Cloudflare provider '" .. (p.name or "?") ..
+                        "' has no api_token.  Generate a token at https://dash.cloudflare.com/profile/api-tokens with 'Zone:Read' + 'DNS:Edit' scoped to your managed_zones.",
+                }
+            end
+            if type(p.managed_zones) ~= "table" or #p.managed_zones == 0 then
+                return nil, {
+                    code = "not_configured",
+                    message = "Cloudflare provider '" .. (p.name or "?") ..
+                        "' has no managed_zones.  Add each zone explicitly to prevent accidental writes to other domains.",
+                }
+            end
+            return {
+                name = p.name or "cloudflare",
+                type = "cloudflare",
+                api_token = p.api_token,
+                managed_zones = p.managed_zones,
+                default_ttl = tonumber(dns_cfg.default_ttl) or DEFAULT_TTL,
+                default_proxied = dns_cfg.default_proxied == true,
+            }
+        end
+    end
+    return nil, {
+        code = "not_configured",
+        message = "No Cloudflare provider found in dns.providers.  Only `type: cloudflare` is supported today.",
+    }
+end
+
+--- Find the zone whose name is the longest suffix of `domain`.
+--- Refuses domains not covered by any managed zone — that's the
+--- safety guarantee that prevents accidental writes outside the
+--- declared scope.
+function _M.find_zone(domain)
+    if type(domain) ~= "string" or domain == "" then
+        return nil, {code = "validation_failed", message = "domain is required"}
+    end
+    local provider, err = load_provider()
+    if not provider then return nil, err end
+    local lower_domain = domain:lower()
+    local best_match = nil
+    local best_len = 0
+    for _, z in ipairs(provider.managed_zones) do
+        if type(z.name) == "string" and type(z.zone_id) == "string" then
+            local zname = z.name:lower()
+            -- Match if domain == zone OR domain ends in ".<zone>"
+            if lower_domain == zname or
+                    lower_domain:sub(-(#zname + 1)) == ("." .. zname) then
+                if #zname > best_len then
+                    best_match = {
+                        zone_id = z.zone_id,
+                        zone_name = z.name,
+                        provider = provider,
+                    }
+                    best_len = #zname
+                end
+            end
+        end
+    end
+    if not best_match then
+        local zone_names = {}
+        for _, z in ipairs(provider.managed_zones) do
+            table.insert(zone_names, z.name)
+        end
+        return nil, {
+            code = "zone_not_allowed",
+            message = "Domain '" .. domain .. "' is not covered by any managed_zone.  Add the parent zone to settings.json (with its Cloudflare zone_id) before provisioning records under it.",
+            details = {managed_zones = zone_names},
+        }
+    end
+    return best_match
+end
+
+--- Cheap public-facing check.  Used by the HTTP layer to decide
+--- whether to render "DNS disabled" UX vs the normal flow.
+function _M.is_enabled()
+    local provider, err = load_provider()
+    if provider then return true end
+    return false, err and err.message or "DNS not configured"
+end
+
+-- ============================================================
+-- HTTP client wrapper
+-- ============================================================
+
+--- One-shot HTTP request to Cloudflare with structured error
+--- handling.  Decodes the standard `{success, errors, result}`
+--- envelope and surfaces Cloudflare error codes as our own structured
+--- errors.  Retries on 429 with exponential backoff up to
+--- MAX_RETRIES_ON_429 attempts; everything else fails fast.
+local function cf_request(provider, method, path, body)
+    local url = CF_BASE .. path
+    local attempt = 0
+    while true do
+        attempt = attempt + 1
+        local httpc = http.new()
+        httpc:set_timeout(DEFAULT_TIMEOUT_MS)
+        local opts = {
+            method = method,
+            headers = {
+                ["Authorization"] = "Bearer " .. provider.api_token,
+                ["Content-Type"] = "application/json",
+            },
+        }
+        if body then opts.body = cjson.encode(body) end
+
+        local res, err = httpc:request_uri(url, opts)
+        if not res then
+            return nil, {
+                code = "network_error",
+                message = "Cloudflare API call failed: " .. tostring(err),
+                details = {url = url, method = method},
+            }
+        end
+
+        -- 429: rate-limited.  Honour Retry-After if present, else
+        -- exponential backoff.  Don't loop forever — bail after
+        -- MAX_RETRIES_ON_429 so a misconfigured token can't pin a
+        -- request indefinitely.
+        if res.status == 429 then
+            if attempt > MAX_RETRIES_ON_429 then
+                return nil, {
+                    code = "rate_limited",
+                    message = "Cloudflare API rate limit; retries exhausted.",
+                    details = {attempts = attempt},
+                }
+            end
+            local retry_after = tonumber(res.headers["Retry-After"] or "")
+            local sleep_ms = retry_after and (retry_after * 1000) or
+                (RETRY_BASE_DELAY_MS * math.pow(2, attempt - 1))
+            ngx.sleep(sleep_ms / 1000)
+            -- loop continues to retry
+        else
+            -- Normal path — decode envelope and return
+            local body_ok, decoded = pcall(cjson.decode, res.body or "")
+            if not body_ok or type(decoded) ~= "table" then
+                return nil, {
+                    code = "decode_error",
+                    message = "Cloudflare returned non-JSON or malformed body",
+                    details = {status = res.status, body = (res.body or ""):sub(1, 200)},
+                }
+            end
+            if decoded.success == false then
+                -- Pull the first Cloudflare error for a concise summary;
+                -- keep the full list in details for the operator.
+                local first = decoded.errors and decoded.errors[1]
+                return nil, {
+                    code = "provider_error",
+                    message = first and (first.message or "Cloudflare error " .. tostring(first.code))
+                        or "Cloudflare reported failure with no error details",
+                    details = {
+                        http_status = res.status,
+                        cloudflare_errors = decoded.errors,
+                    },
+                }
+            end
+            return decoded.result
+        end
+    end
+end
+
+-- ============================================================
+-- Comment marker — provenance tracking
+-- ============================================================
+
+local function build_comment(server_id, profile_id, pop_id)
+    -- `MARKER` is intentionally first so a single substring grep
+    -- against Cloudflare's `comment` field reliably identifies
+    -- wslproxy-managed records.  Each subsequent piece is a key=value
+    -- pair so future parsers (cleanup tools, audit replay) can
+    -- structure-decode without ambiguity.
+    return string.format("%s | server=%s | profile=%s | pop=%s",
+        MARKER, server_id, profile_id, pop_id)
+end
+
+local function is_wslproxy_managed(record)
+    return type(record.comment) == "string" and
+        record.comment:find(MARKER, 1, true) ~= nil
+end
+
+--- Parse the pop_id out of a wslproxy-managed comment.  Returns nil
+--- for records that aren't ours or don't have a pop assigned (older
+--- formats).
+local function extract_pop_id(record)
+    if not is_wslproxy_managed(record) then return nil end
+    return record.comment:match("pop=([^ |]+)")
+end
+
+-- ============================================================
+-- Cloudflare CRUD primitives
+-- ============================================================
+
+local function list_records_for_name(provider, zone_id, name, record_type)
+    local q = "?name=" .. ngx.escape_uri(name)
+    if record_type then q = q .. "&type=" .. record_type end
+    return cf_request(provider, "GET", "/zones/" .. zone_id .. "/dns_records" .. q)
+end
+
+local function create_record(provider, zone_id, body)
+    return cf_request(provider, "POST", "/zones/" .. zone_id .. "/dns_records", body)
+end
+
+local function update_record(provider, zone_id, record_id, body)
+    return cf_request(provider, "PUT",
+        "/zones/" .. zone_id .. "/dns_records/" .. record_id, body)
+end
+
+local function delete_record(provider, zone_id, record_id)
+    return cf_request(provider, "DELETE",
+        "/zones/" .. zone_id .. "/dns_records/" .. record_id)
+end
+
+-- ============================================================
+-- Public: read-only lookup
+-- ============================================================
+
+--- Return the current set of Cloudflare records for `domain`,
+--- annotated with whether each one is wslproxy-managed.  Used by
+--- the dashboard's "DNS State" panel and by the provision logic
+--- internally.
+function _M.lookup(opts)
+    opts = opts or {}
+    local domain = opts.domain
+    if not domain or domain == "" then
+        return nil, {code = "validation_failed", message = "domain is required"}
+    end
+    local zone, err = _M.find_zone(domain)
+    if not zone then return nil, err end
+    local records, lerr = list_records_for_name(
+        zone.provider, zone.zone_id, domain, opts.type)
+    if not records then
+        -- Enrich provider/network errors with the zone we tried so the
+        -- operator can immediately see *which* zone_id Cloudflare
+        -- refused — without this context an "Authentication error" is
+        -- noise; with it, the operator can spot a wrong zone_id at a
+        -- glance.  Doesn't change the error code, just the details
+        -- payload.  Defensive against a `nil` lerr (cf_request always
+        -- returns one with the failure, but LSP can't prove that).
+        local enriched = lerr or {code = "io_error", message = "Cloudflare call returned nil"}
+        enriched.details = enriched.details or {}
+        enriched.details.zone = {name = zone.zone_name, id = zone.zone_id}
+        return nil, enriched
+    end
+    local annotated = {}
+    for _, r in ipairs(records) do
+        table.insert(annotated, {
+            id = r.id,
+            type = r.type,
+            name = r.name,
+            content = r.content,
+            ttl = r.ttl,
+            proxied = r.proxied,
+            comment = r.comment,
+            managed_by_wslproxy = is_wslproxy_managed(r),
+            pop_id = extract_pop_id(r),
+        })
+    end
+    return {
+        domain = domain,
+        zone_id = zone.zone_id,
+        zone_name = zone.zone_name,
+        records = annotated,
+    }
+end
+
+-- ============================================================
+-- Public: idempotent ensure_record (low-level)
+-- ============================================================
+
+--- Idempotent upsert for a single record.  Mostly used by
+--- provision_for_server; exposed publicly for ad-hoc ops.
+---
+--- opts: {
+---   domain (req), type (req, default "A"), content (req),
+---   ttl, proxied, comment, dry_run
+--- }
+function _M.ensure_record(opts)
+    if not opts.domain or opts.domain == "" then
+        return nil, {code = "validation_failed", message = "domain is required"}
+    end
+    if not opts.content or opts.content == "" then
+        return nil, {code = "validation_failed", message = "content is required"}
+    end
+    local zone, err = _M.find_zone(opts.domain)
+    if not zone then return nil, err end
+    local record_type = opts.type or "A"
+    local existing, lerr = list_records_for_name(
+        zone.provider, zone.zone_id, opts.domain, record_type)
+    if not existing then
+        local enriched = lerr or {code = "io_error", message = "Cloudflare call returned nil"}
+        enriched.details = enriched.details or {}
+        enriched.details.zone = {name = zone.zone_name, id = zone.zone_id}
+        return nil, enriched
+    end
+
+    -- Find a wslproxy-managed record we can update in place.  If a
+    -- record matches by content AND comment, it's already correct;
+    -- if it matches by comment but content differs, it's a stale
+    -- target we should update; if neither matches we create new.
+    local same = nil
+    local stale = nil
+    for _, r in ipairs(existing) do
+        if is_wslproxy_managed(r) and (not opts.comment or r.comment == opts.comment) then
+            if r.content == opts.content then
+                same = r
+            else
+                stale = r
+            end
+            break
+        end
+    end
+
+    local body = {
+        type = record_type,
+        name = opts.domain,
+        content = opts.content,
+        ttl = tonumber(opts.ttl) or zone.provider.default_ttl,
+        proxied = opts.proxied == true or
+            (opts.proxied == nil and zone.provider.default_proxied),
+        comment = opts.comment,
+    }
+
+    if opts.dry_run then
+        return {
+            dry_run = true,
+            action = same and "unchanged" or (stale and "would_update" or "would_create"),
+            would_write = body,
+            existing_record_id = (same or stale) and (same or stale).id or nil,
+            zone_id = zone.zone_id,
+        }
+    end
+
+    if same then
+        return {action = "unchanged", record_id = same.id, content = same.content}
+    elseif stale then
+        local updated, uerr = update_record(zone.provider, zone.zone_id, stale.id, body)
+        if not updated then return nil, uerr end
+        return {action = "updated", record_id = updated.id, content = updated.content}
+    else
+        local created, cerr = create_record(zone.provider, zone.zone_id, body)
+        if not created then return nil, cerr end
+        return {action = "created", record_id = created.id, content = created.content}
+    end
+end
+
+-- ============================================================
+-- Public: high-level orchestrator — provision DNS for a server
+-- ============================================================
+
+--- The main user-facing flow.  Reads server.pop_ids, looks up each
+--- POP's IP, and converges Cloudflare to publish exactly one A
+--- record per active POP.  Orphaned wslproxy-managed records (POPs
+--- that were removed from the server) are deleted.
+---
+--- opts: {
+---   server_id (req), profile_id (req),
+---   dry_run (bool), include_inactive (bool), record_type ("A")
+--- }
+---
+--- Returns a summary table:
+--- {
+---   domain, zone_id, zone_name,
+---   actions = [ {action, content, pop_id, record_id?, error?}, ... ],
+---   skipped = [ {pop_id, reason}, ... ],
+---   warnings = [ ... ],
+--- }
+function _M.provision_for_server(opts)
+    opts = opts or {}
+    local user = opts.user or "system"
+    if not opts.server_id or opts.server_id == "" then
+        return nil, {code = "validation_failed", message = "server_id is required"}
+    end
+    if not opts.profile_id or opts.profile_id == "" then
+        return nil, {code = "validation_failed", message = "profile_id is required"}
+    end
+
+    -- 1. Read server JSON
+    local server_path = configPath .. "data/servers/" .. opts.profile_id ..
+        "/" .. opts.server_id .. ".json"
+    local content = Helper.getDataFromFile(server_path)
+    if not content then
+        return nil, {
+            code = "not_found",
+            message = "Server '" .. opts.server_id .. "' not found in profile '" ..
+                opts.profile_id .. "'",
+            details = {expected_path = server_path},
+        }
+    end
+    local ok_dec, server = pcall(cjson.decode, content)
+    if not ok_dec or type(server) ~= "table" then
+        return nil, {code = "io_error", message = "Server JSON is malformed"}
+    end
+    local domain = server.server_name
+    if not domain or domain == "" then
+        return nil, {
+            code = "validation_failed",
+            message = "Server has no server_name — cannot resolve a Cloudflare zone for it",
+        }
+    end
+
+    -- 2. Resolve target IPs from pop_ids
+    local pop_ids = server.pop_ids
+    if type(pop_ids) ~= "table" or #pop_ids == 0 then
+        return nil, {
+            code = "no_pops_assigned",
+            message = "Server '" .. opts.server_id ..
+                "' has no pop_ids assigned.  Assign at least one POP on the server form before provisioning DNS.",
+        }
+    end
+    local desired = {}      -- list of {pop_id, content (IP)}
+    local skipped = {}
+    for _, pid in ipairs(pop_ids) do
+        local pop = Pops.get(pid)
+        if type(pop) ~= "table" then
+            -- Pops.get returned an error; record the skip with the
+            -- error code so the dashboard can highlight it.
+            table.insert(skipped, {pop_id = pid, reason = "not_found"})
+        elseif not pop.public_ipv4 or pop.public_ipv4 == "" then
+            table.insert(skipped, {pop_id = pid, reason = "no_public_ipv4"})
+        elseif (pop.status == "down" or pop.status == "maintenance") and
+                not opts.include_inactive then
+            table.insert(skipped, {pop_id = pid, reason = "status_" .. pop.status})
+        else
+            table.insert(desired, {pop_id = pid, content = pop.public_ipv4})
+        end
+    end
+    if #desired == 0 then
+        return nil, {
+            code = "no_targets",
+            message = "No active POPs to provision.  All assigned POPs were skipped — see the `skipped` list.",
+            details = {skipped = skipped},
+        }
+    end
+
+    -- 3. Resolve Cloudflare zone for the domain
+    local zone, zerr = _M.find_zone(domain)
+    if not zone then return nil, zerr end
+
+    -- 4. Inventory existing wslproxy-managed records for this name
+    local existing, lerr = list_records_for_name(
+        zone.provider, zone.zone_id, domain, opts.record_type or "A")
+    if not existing then
+        local enriched = lerr or {code = "io_error", message = "Cloudflare call returned nil"}
+        enriched.details = enriched.details or {}
+        enriched.details.zone = {name = zone.zone_name, id = zone.zone_id}
+        return nil, enriched
+    end
+    -- Index by pop_id (when extractable) for O(1) diff lookup.
+    -- Records that are NOT wslproxy-managed are left untouched
+    -- regardless of their content — the marker is what protects
+    -- hand-curated records from this orchestrator.
+    local by_pop = {}
+    local untracked_ours = {}  -- our records with no pop_id parseable
+    for _, r in ipairs(existing) do
+        if is_wslproxy_managed(r) then
+            local rpop = extract_pop_id(r)
+            if rpop then
+                by_pop[rpop] = r
+            else
+                table.insert(untracked_ours, r)
+            end
+        end
+    end
+
+    -- 5. Compute the action plan: for each desired POP, decide
+    -- create / update / unchanged.  Then collect orphans for delete.
+    local actions = {}
+    local seen_pops = {}
+    for _, d in ipairs(desired) do
+        seen_pops[d.pop_id] = true
+        local existing_rec = by_pop[d.pop_id]
+        local desired_comment = build_comment(opts.server_id, opts.profile_id, d.pop_id)
+        if not existing_rec then
+            table.insert(actions, {
+                pop_id = d.pop_id,
+                action = "create",
+                content = d.content,
+                comment = desired_comment,
+            })
+        elseif existing_rec.content == d.content then
+            table.insert(actions, {
+                pop_id = d.pop_id,
+                action = "unchanged",
+                content = d.content,
+                record_id = existing_rec.id,
+            })
+        else
+            table.insert(actions, {
+                pop_id = d.pop_id,
+                action = "update",
+                content = d.content,
+                comment = desired_comment,
+                record_id = existing_rec.id,
+                from_content = existing_rec.content,
+            })
+        end
+    end
+    for pop_id, rec in pairs(by_pop) do
+        if not seen_pops[pop_id] then
+            table.insert(actions, {
+                pop_id = pop_id,
+                action = "delete",
+                record_id = rec.id,
+                from_content = rec.content,
+            })
+        end
+    end
+    -- Also clean up any legacy our-records that have no pop_id —
+    -- these would be from earlier provisioning shapes and don't
+    -- belong in the new desired set.
+    for _, rec in ipairs(untracked_ours) do
+        table.insert(actions, {
+            pop_id = nil,
+            action = "delete_legacy",
+            record_id = rec.id,
+            from_content = rec.content,
+        })
+    end
+
+    -- 6. Execute (or just plan)
+    if opts.dry_run then
+        return {
+            dry_run = true,
+            domain = domain,
+            zone_id = zone.zone_id,
+            zone_name = zone.zone_name,
+            actions = actions,
+            skipped = skipped,
+        }
+    end
+
+    local executed = {}
+    for _, a in ipairs(actions) do
+        if a.action == "create" then
+            local rec, err = create_record(zone.provider, zone.zone_id, {
+                type = opts.record_type or "A",
+                name = domain,
+                content = a.content,
+                ttl = zone.provider.default_ttl,
+                proxied = zone.provider.default_proxied,
+                comment = a.comment,
+            })
+            if rec then
+                table.insert(executed, {
+                    action = "created", pop_id = a.pop_id,
+                    content = a.content, record_id = rec.id,
+                })
+            else
+                table.insert(executed, {
+                    action = "error", pop_id = a.pop_id,
+                    content = a.content, error = err.message,
+                })
+            end
+        elseif a.action == "update" then
+            local rec, err = update_record(zone.provider, zone.zone_id, a.record_id, {
+                type = opts.record_type or "A",
+                name = domain,
+                content = a.content,
+                ttl = zone.provider.default_ttl,
+                proxied = zone.provider.default_proxied,
+                comment = a.comment,
+            })
+            if rec then
+                table.insert(executed, {
+                    action = "updated", pop_id = a.pop_id,
+                    content = a.content, record_id = rec.id,
+                    from_content = a.from_content,
+                })
+            else
+                table.insert(executed, {
+                    action = "error", pop_id = a.pop_id,
+                    content = a.content, error = err.message,
+                })
+            end
+        elseif a.action == "delete" or a.action == "delete_legacy" then
+            local ok2, err = delete_record(zone.provider, zone.zone_id, a.record_id)
+            if ok2 then
+                table.insert(executed, {
+                    action = a.action == "delete_legacy" and "deleted_legacy" or "deleted",
+                    pop_id = a.pop_id, from_content = a.from_content,
+                    record_id = a.record_id,
+                })
+            else
+                table.insert(executed, {
+                    action = "error", pop_id = a.pop_id,
+                    error = err.message,
+                })
+            end
+        else  -- unchanged
+            table.insert(executed, {
+                action = "unchanged", pop_id = a.pop_id,
+                content = a.content, record_id = a.record_id,
+            })
+        end
+    end
+
+    -- 7. Audit log + return summary
+    pcall(function()
+        AuditLogger.log("dns_provision", user, "servers", opts.server_id, {
+            profile_id = opts.profile_id,
+            domain = domain,
+            zone_id = zone.zone_id,
+            actions_count = #executed,
+            skipped = skipped,
+        })
+    end)
+
+    return {
+        domain = domain,
+        zone_id = zone.zone_id,
+        zone_name = zone.zone_name,
+        actions = executed,
+        skipped = skipped,
+    }
+end
+
+return _M

--- a/api/dns_manager.lua
+++ b/api/dns_manager.lua
@@ -442,22 +442,227 @@ end
 -- Public: high-level orchestrator — provision DNS for a server
 -- ============================================================
 
---- The main user-facing flow.  Reads server.pop_ids, looks up each
---- POP's IP, and converges Cloudflare to publish exactly one A
---- record per active POP.  Orphaned wslproxy-managed records (POPs
---- that were removed from the server) are deleted.
+--- Plan the per-POP convergence for a single record type (A or
+--- AAAA).  Extracted from provision_for_server so the BOTH mode can
+--- run it twice without duplicating the loop.
+---
+--- `ip_field` is which POP field to read for the record content
+--- (`public_ipv4` for A; `public_ipv6` for AAAA).  POPs missing that
+--- specific field skip with a type-specific reason — the operator
+--- sees "no_public_ipv6" rather than a generic "no_public_ipv4" when
+--- they're running AAAA mode against POPs that only have v4.
+---
+--- Every action emitted carries a `record_type` field so the
+--- executor below can call create/update/delete with the right type
+--- when BOTH mode produces a mixed action list.
+local function plan_per_pop(opts, server, zone, pop_ids,
+                            record_type, ip_field, no_ip_reason)
+    local desired = {}
+    local skipped = {}
+    for _, pid in ipairs(pop_ids) do
+        -- Capture both returns from Pops.get so we don't masquerade
+        -- io_error / decode_error as "not_found".
+        local pop, perr = Pops.get(pid)
+        if type(pop) ~= "table" then
+            table.insert(skipped, {
+                pop_id = pid,
+                reason = (perr and perr.code) or "not_found",
+                record_type = record_type,
+            })
+        elseif not pop[ip_field] or pop[ip_field] == "" then
+            table.insert(skipped, {
+                pop_id = pid,
+                reason = no_ip_reason,
+                record_type = record_type,
+            })
+        elseif (pop.status == "down" or pop.status == "maintenance") and
+                not opts.include_inactive then
+            table.insert(skipped, {
+                pop_id = pid,
+                reason = "status_" .. pop.status,
+                record_type = record_type,
+            })
+        else
+            table.insert(desired, {pop_id = pid, content = pop[ip_field]})
+        end
+    end
+
+    -- Inventory CF records OF THIS TYPE for the domain.  Filtering
+    -- by type matters: BOTH mode plans A and AAAA independently and
+    -- must not see one type's records in the other's plan.
+    local existing, lerr = list_records_for_name(
+        zone.provider, zone.zone_id, server.server_name, record_type)
+    if not existing then
+        local enriched = lerr or {code = "io_error", message = "Cloudflare call returned nil"}
+        enriched.details = enriched.details or {}
+        enriched.details.zone = {name = zone.zone_name, id = zone.zone_id}
+        enriched.details.record_type = record_type
+        return nil, nil, enriched
+    end
+
+    local by_pop = {}
+    local untracked_ours = {}
+    for _, r in ipairs(existing) do
+        if is_wslproxy_managed(r) then
+            local rpop = extract_pop_id(r)
+            if rpop and rpop ~= "cname" then
+                by_pop[rpop] = r
+            else
+                table.insert(untracked_ours, r)
+            end
+        end
+    end
+
+    local actions = {}
+    local seen_pops = {}
+    for _, d in ipairs(desired) do
+        seen_pops[d.pop_id] = true
+        local existing_rec = by_pop[d.pop_id]
+        local desired_comment = build_comment(opts.server_id, opts.profile_id, d.pop_id)
+        if not existing_rec then
+            table.insert(actions, {
+                pop_id = d.pop_id, action = "create",
+                content = d.content, comment = desired_comment,
+                record_type = record_type,
+            })
+        elseif existing_rec.content == d.content then
+            table.insert(actions, {
+                pop_id = d.pop_id, action = "unchanged",
+                content = d.content, record_id = existing_rec.id,
+                record_type = record_type,
+            })
+        else
+            table.insert(actions, {
+                pop_id = d.pop_id, action = "update",
+                content = d.content, comment = desired_comment,
+                record_id = existing_rec.id,
+                from_content = existing_rec.content,
+                record_type = record_type,
+            })
+        end
+    end
+    for pop_id, rec in pairs(by_pop) do
+        if not seen_pops[pop_id] then
+            table.insert(actions, {
+                pop_id = pop_id, action = "delete",
+                record_id = rec.id, from_content = rec.content,
+                record_type = record_type,
+            })
+        end
+    end
+    for _, rec in ipairs(untracked_ours) do
+        table.insert(actions, {
+            pop_id = nil, action = "delete_legacy",
+            record_id = rec.id, from_content = rec.content,
+            record_type = record_type,
+        })
+    end
+
+    return actions, skipped
+end
+
+--- Plan the single-record convergence for CNAME mode.  CNAME is
+--- fundamentally different from A/AAAA: it's ONE record pointing at
+--- a hostname, not per-POP fan-out.  Reads `server.dns_cname_target`
+--- as the target hostname.  POPs are not involved.
+---
+--- Cloudflare and the DNS spec disallow CNAME records coexisting
+--- with other record types at the same name, so callers should not
+--- combine CNAME with A/AAAA on the same server.
+local function plan_cname(opts, server, zone)
+    local target = server.dns_cname_target
+    if not target or target == "" then
+        return nil, nil, {
+            code = "no_cname_target",
+            message = "Server '" .. opts.server_id ..
+                "' has dns_record_type='CNAME' but no dns_cname_target set.  " ..
+                "Set the hostname this server should point at (e.g. " ..
+                "'edge.wslproxy.com') in the server form's DNS section.",
+        }
+    end
+
+    local existing, lerr = list_records_for_name(
+        zone.provider, zone.zone_id, server.server_name, "CNAME")
+    if not existing then
+        local enriched = lerr or {code = "io_error", message = "Cloudflare call returned nil"}
+        enriched.details = enriched.details or {}
+        enriched.details.zone = {name = zone.zone_name, id = zone.zone_id}
+        enriched.details.record_type = "CNAME"
+        return nil, nil, enriched
+    end
+
+    -- There should be at most ONE wslproxy-managed CNAME per name.
+    -- If there are more (somehow corrupted state), the later one
+    -- "wins" and the earlier ones get cleaned up as legacy.
+    local our_existing
+    local untracked_ours = {}
+    for _, r in ipairs(existing) do
+        if is_wslproxy_managed(r) then
+            if our_existing then
+                table.insert(untracked_ours, our_existing)
+            end
+            our_existing = r
+        end
+    end
+
+    local actions = {}
+    local desired_comment = build_comment(opts.server_id, opts.profile_id, "cname")
+    if not our_existing then
+        table.insert(actions, {
+            pop_id = nil, action = "create",
+            content = target, comment = desired_comment,
+            record_type = "CNAME",
+        })
+    elseif our_existing.content == target then
+        table.insert(actions, {
+            pop_id = nil, action = "unchanged",
+            content = target, record_id = our_existing.id,
+            record_type = "CNAME",
+        })
+    else
+        table.insert(actions, {
+            pop_id = nil, action = "update",
+            content = target, comment = desired_comment,
+            record_id = our_existing.id,
+            from_content = our_existing.content,
+            record_type = "CNAME",
+        })
+    end
+    for _, rec in ipairs(untracked_ours) do
+        table.insert(actions, {
+            pop_id = nil, action = "delete_legacy",
+            record_id = rec.id, from_content = rec.content,
+            record_type = "CNAME",
+        })
+    end
+
+    return actions, {}
+end
+
+--- The main user-facing flow.  Dispatches on `record_type` (or
+--- `server.dns_record_type`, falling back to "A"):
+---
+---   - "A"    — one A record per active POP using public_ipv4
+---   - "AAAA" — one AAAA record per active POP using public_ipv6
+---   - "BOTH" — both of the above; produces a mixed action list
+---   - "CNAME" — one CNAME pointing at server.dns_cname_target;
+---               POPs are not used in this mode
+---
+--- Orphaned wslproxy-managed records (POPs removed from the server,
+--- or records of the wrong type for the current mode) are deleted.
 ---
 --- opts: {
 ---   server_id (req), profile_id (req),
----   dry_run (bool), include_inactive (bool), record_type ("A")
+---   dry_run (bool), include_inactive (bool),
+---   record_type ("A"|"AAAA"|"BOTH"|"CNAME") — overrides
+---              server.dns_record_type if set,
 --- }
 ---
 --- Returns a summary table:
 --- {
----   domain, zone_id, zone_name,
----   actions = [ {action, content, pop_id, record_id?, error?}, ... ],
----   skipped = [ {pop_id, reason}, ... ],
----   warnings = [ ... ],
+---   domain, zone_id, zone_name, record_type,
+---   actions = [ {action, content, pop_id, record_type, record_id?, error?}, ... ],
+---   skipped = [ {pop_id, record_type, reason}, ... ],
 --- }
 function _M.provision_for_server(opts)
     opts = opts or {}
@@ -493,127 +698,85 @@ function _M.provision_for_server(opts)
         }
     end
 
-    -- 2. Resolve target IPs from pop_ids
-    local pop_ids = server.pop_ids
-    if type(pop_ids) ~= "table" or #pop_ids == 0 then
+    -- 2. Decide which record type(s) to converge.  Explicit
+    -- opts.record_type beats server.dns_record_type beats "A".
+    -- Upper-casing is forgiving (operators write "a" or "cname"
+    -- interchangeably).  The validation rejects anything not in the
+    -- enum before we start touching Cloudflare.
+    local record_type = opts.record_type or server.dns_record_type or "A"
+    record_type = string.upper(tostring(record_type))
+    local VALID_TYPES = {A = true, AAAA = true, BOTH = true, CNAME = true}
+    if not VALID_TYPES[record_type] then
         return nil, {
-            code = "no_pops_assigned",
-            message = "Server '" .. opts.server_id ..
-                "' has no pop_ids assigned.  Assign at least one POP on the server form before provisioning DNS.",
-        }
-    end
-    local desired = {}      -- list of {pop_id, content (IP)}
-    local skipped = {}
-    for _, pid in ipairs(pop_ids) do
-        -- Capture both returns from Pops.get so we don't masquerade
-        -- io_error / decode_error as "not_found".  The operator sees
-        -- the real reason in the skipped list (e.g. "io_error" when a
-        -- pop file is unreadable — distinct from a genuinely missing
-        -- POP).
-        local pop, perr = Pops.get(pid)
-        if type(pop) ~= "table" then
-            local reason = (perr and perr.code) or "not_found"
-            table.insert(skipped, {pop_id = pid, reason = reason})
-        elseif not pop.public_ipv4 or pop.public_ipv4 == "" then
-            table.insert(skipped, {pop_id = pid, reason = "no_public_ipv4"})
-        elseif (pop.status == "down" or pop.status == "maintenance") and
-                not opts.include_inactive then
-            table.insert(skipped, {pop_id = pid, reason = "status_" .. pop.status})
-        else
-            table.insert(desired, {pop_id = pid, content = pop.public_ipv4})
-        end
-    end
-    if #desired == 0 then
-        return nil, {
-            code = "no_targets",
-            message = "No active POPs to provision.  All assigned POPs were skipped — see the `skipped` list.",
-            details = {skipped = skipped},
+            code = "validation_failed",
+            message = "Invalid record_type '" .. record_type ..
+                "'.  Must be one of: A, AAAA, BOTH, CNAME.",
         }
     end
 
-    -- 3. Resolve Cloudflare zone for the domain
+    -- 3. Resolve Cloudflare zone for the domain (one lookup, reused
+    -- by both planners — the zone allowlist check is the safety gate
+    -- that runs BEFORE any record-shape decision).
     local zone, zerr = _M.find_zone(domain)
     if not zone then return nil, zerr end
 
-    -- 4. Inventory existing wslproxy-managed records for this name
-    local existing, lerr = list_records_for_name(
-        zone.provider, zone.zone_id, domain, opts.record_type or "A")
-    if not existing then
-        local enriched = lerr or {code = "io_error", message = "Cloudflare call returned nil"}
-        enriched.details = enriched.details or {}
-        enriched.details.zone = {name = zone.zone_name, id = zone.zone_id}
-        return nil, enriched
-    end
-    -- Index by pop_id (when extractable) for O(1) diff lookup.
-    -- Records that are NOT wslproxy-managed are left untouched
-    -- regardless of their content — the marker is what protects
-    -- hand-curated records from this orchestrator.
-    local by_pop = {}
-    local untracked_ours = {}  -- our records with no pop_id parseable
-    for _, r in ipairs(existing) do
-        if is_wslproxy_managed(r) then
-            local rpop = extract_pop_id(r)
-            if rpop then
-                by_pop[rpop] = r
-            else
-                table.insert(untracked_ours, r)
-            end
-        end
-    end
-
-    -- 5. Compute the action plan: for each desired POP, decide
-    -- create / update / unchanged.  Then collect orphans for delete.
+    -- 4. Dispatch on record_type.  CNAME is a fundamentally different
+    -- shape (one record, no POP fan-out) so it has its own planner.
+    -- A / AAAA / BOTH all share the per-POP planner; BOTH runs it
+    -- twice and accumulates.
     local actions = {}
-    local seen_pops = {}
-    for _, d in ipairs(desired) do
-        seen_pops[d.pop_id] = true
-        local existing_rec = by_pop[d.pop_id]
-        local desired_comment = build_comment(opts.server_id, opts.profile_id, d.pop_id)
-        if not existing_rec then
-            table.insert(actions, {
-                pop_id = d.pop_id,
-                action = "create",
-                content = d.content,
-                comment = desired_comment,
-            })
-        elseif existing_rec.content == d.content then
-            table.insert(actions, {
-                pop_id = d.pop_id,
-                action = "unchanged",
-                content = d.content,
-                record_id = existing_rec.id,
-            })
+    local skipped = {}
+    if record_type == "CNAME" then
+        local cnames, cskipped, cerr = plan_cname(opts, server, zone)
+        if cerr then return nil, cerr end
+        -- `or {}` fallbacks are defensive: plan_cname's contract is
+        -- "return (actions, skipped) OR (nil, nil, err)", but the
+        -- LSP can't narrow that across the error guard above.
+        actions = cnames or {}
+        skipped = cskipped or {}
+    else
+        local pop_ids = server.pop_ids
+        if type(pop_ids) ~= "table" or #pop_ids == 0 then
+            return nil, {
+                code = "no_pops_assigned",
+                message = "Server '" .. opts.server_id ..
+                    "' has no pop_ids assigned.  Assign at least one POP on the server form before provisioning DNS.",
+            }
+        end
+        -- BOTH mode → run the planner twice; A and AAAA → once.
+        -- Each pass returns actions tagged with its record_type so
+        -- the executor below can route to the right CF endpoint.
+        local types_to_do
+        if record_type == "BOTH" then
+            types_to_do = {{type = "A", field = "public_ipv4", reason = "no_public_ipv4"},
+                           {type = "AAAA", field = "public_ipv6", reason = "no_public_ipv6"}}
+        elseif record_type == "AAAA" then
+            types_to_do = {{type = "AAAA", field = "public_ipv6", reason = "no_public_ipv6"}}
         else
-            table.insert(actions, {
-                pop_id = d.pop_id,
-                action = "update",
-                content = d.content,
-                comment = desired_comment,
-                record_id = existing_rec.id,
-                from_content = existing_rec.content,
-            })
+            types_to_do = {{type = "A", field = "public_ipv4", reason = "no_public_ipv4"}}
         end
-    end
-    for pop_id, rec in pairs(by_pop) do
-        if not seen_pops[pop_id] then
-            table.insert(actions, {
-                pop_id = pop_id,
-                action = "delete",
-                record_id = rec.id,
-                from_content = rec.content,
-            })
+        for _, t in ipairs(types_to_do) do
+            local pacts, pskipped, perr = plan_per_pop(
+                opts, server, zone, pop_ids, t.type, t.field, t.reason)
+            if perr then return nil, perr end
+            -- Same defensive narrowing as the CNAME branch.
+            for _, x in ipairs(pacts or {}) do table.insert(actions, x) end
+            for _, x in ipairs(pskipped or {}) do table.insert(skipped, x) end
         end
-    end
-    -- Also clean up any legacy our-records that have no pop_id —
-    -- these would be from earlier provisioning shapes and don't
-    -- belong in the new desired set.
-    for _, rec in ipairs(untracked_ours) do
-        table.insert(actions, {
-            pop_id = nil,
-            action = "delete_legacy",
-            record_id = rec.id,
-            from_content = rec.content,
-        })
+        -- "no_targets" only fires when every plan came back empty
+        -- AND there are no deletes either.  For BOTH mode this means
+        -- both v4 and v6 had no work — usually because every POP was
+        -- skipped (e.g. all in maintenance).  Deletes are still
+        -- useful work, so an actions list of [delete, delete] is
+        -- allowed through.
+        local has_any_action = #actions > 0
+        if not has_any_action then
+            return nil, {
+                code = "no_targets",
+                message = "No active POPs to provision and no records to clean up.  All assigned POPs were skipped — see the `skipped` list.",
+                details = {skipped = skipped, record_type = record_type},
+            }
+        end
     end
 
     -- 6. Execute (or just plan)
@@ -623,6 +786,7 @@ function _M.provision_for_server(opts)
             domain = domain,
             zone_id = zone.zone_id,
             zone_name = zone.zone_name,
+            record_type = record_type,
             actions = actions,
             skipped = skipped,
         }
@@ -630,9 +794,14 @@ function _M.provision_for_server(opts)
 
     local executed = {}
     for _, a in ipairs(actions) do
+        -- Per-action record_type — BOTH mode produces a mixed list
+        -- of A and AAAA actions; each must call CF with its own type.
+        -- Fallback to opts.record_type is for old callers and CNAME
+        -- (where every action already carries `record_type = "CNAME"`).
+        local rt = a.record_type or opts.record_type or "A"
         if a.action == "create" then
             local rec, err = create_record(zone.provider, zone.zone_id, {
-                type = opts.record_type or "A",
+                type = rt,
                 name = domain,
                 content = a.content,
                 ttl = zone.provider.default_ttl,
@@ -643,17 +812,18 @@ function _M.provision_for_server(opts)
                 table.insert(executed, {
                     action = "created", pop_id = a.pop_id,
                     content = a.content, record_id = rec.id,
+                    record_type = rt,
                 })
             else
                 table.insert(executed, {
                     action = "error", pop_id = a.pop_id,
-                    content = a.content,
+                    content = a.content, record_type = rt,
                     error = (err and err.message) or "unknown error",
                 })
             end
         elseif a.action == "update" then
             local rec, err = update_record(zone.provider, zone.zone_id, a.record_id, {
-                type = opts.record_type or "A",
+                type = rt,
                 name = domain,
                 content = a.content,
                 ttl = zone.provider.default_ttl,
@@ -665,11 +835,12 @@ function _M.provision_for_server(opts)
                     action = "updated", pop_id = a.pop_id,
                     content = a.content, record_id = rec.id,
                     from_content = a.from_content,
+                    record_type = rt,
                 })
             else
                 table.insert(executed, {
                     action = "error", pop_id = a.pop_id,
-                    content = a.content,
+                    content = a.content, record_type = rt,
                     error = (err and err.message) or "unknown error",
                 })
             end
@@ -679,11 +850,12 @@ function _M.provision_for_server(opts)
                 table.insert(executed, {
                     action = a.action == "delete_legacy" and "deleted_legacy" or "deleted",
                     pop_id = a.pop_id, from_content = a.from_content,
-                    record_id = a.record_id,
+                    record_id = a.record_id, record_type = rt,
                 })
             else
                 table.insert(executed, {
                     action = "error", pop_id = a.pop_id,
+                    record_type = rt,
                     error = (err and err.message) or "unknown error",
                 })
             end
@@ -691,6 +863,7 @@ function _M.provision_for_server(opts)
             table.insert(executed, {
                 action = "unchanged", pop_id = a.pop_id,
                 content = a.content, record_id = a.record_id,
+                record_type = rt,
             })
         end
     end
@@ -701,6 +874,7 @@ function _M.provision_for_server(opts)
             profile_id = opts.profile_id,
             domain = domain,
             zone_id = zone.zone_id,
+            record_type = record_type,
             actions_count = #executed,
             skipped = skipped,
         })
@@ -710,6 +884,7 @@ function _M.provision_for_server(opts)
         domain = domain,
         zone_id = zone.zone_id,
         zone_name = zone.zone_name,
+        record_type = record_type,
         actions = executed,
         skipped = skipped,
     }

--- a/api/mcp/README.md
+++ b/api/mcp/README.md
@@ -242,6 +242,37 @@ JSON, and summarise. To exercise write tools:
 > a 305 rule that proxies everything to `https://backend.local:8080`. Use
 > dry_run first."*
 
+#### POPs + DNS examples
+
+POPs and DNS provisioning have their own dedicated tools.  Some flows that
+work today:
+
+> *"List all the POPs."*  → calls `list_pops`
+
+> *"What's the status of `pop0`?"*  → calls `get_pop`
+
+> *"Add a new POP called `lon2` in London with IP `192.0.2.42` — preview
+> first, then create."*  → calls `create_pop` with `dry_run: true`, then
+> after your confirmation, `dry_run: false`.
+
+> *"Drain `lon1` — set its status to maintenance."*  → calls `update_pop`
+
+> *"Delete the unused `us-east-1` POP."*  → calls `delete_pop` (which
+> previews referencing servers first; you confirm; then it cascades).
+
+> *"What DNS records does Cloudflare have for `api.example.com`?"*  →
+> calls `lookup_dns` and annotates each record with whether wslproxy owns
+> it.
+
+> *"Provision DNS for `host:api.example.com` in prod."*  → calls
+> `provision_dns` (which defaults to `dry_run: true`), shows the
+> create/update/delete plan, and waits for your "yes" before applying with
+> `dry_run: false`.
+
+For the full Cloudflare token setup, `settings.json` configuration, dashboard
+walkthrough, and troubleshooting — see **[POPS_AND_DNS_GUIDE.md](../../POPS_AND_DNS_GUIDE.md)**
+at the repo root.
+
 ---
 
 ## Integrate with Cursor / other MCP clients
@@ -360,8 +391,17 @@ curl -sS -H "X-MCP-API-Key: $KEY" -H 'Content-Type: application/json' \
 | **`update_rule`** | Partial update of an existing rule | Yes | No_op response when nothing actually differs |
 | **`delete_server`** | Delete a server and detach from referencing rules | Yes | **Destructive** — requires `confirm: true` or returns preview |
 | **`delete_rule`** | Delete a rule and strip from every server's `rules` + `match_cases` | Yes | **Destructive** — requires `confirm: true` or returns preview |
+| **`list_pops`** | List Points of Presence with status / region / search filters | No | |
+| **`get_pop`** | Fetch one POP record by id | No | |
+| **`create_pop`** | Create a new POP (edge server) | Yes | Supports `dry_run: true`. id must be lowercase slug |
+| **`update_pop`** | Partial update of a POP (status, capacity_weight, etc.) | Yes | Supports `dry_run: true` |
+| **`delete_pop`** | Delete a POP; refuses if servers reference it (use `force: true` to cascade-detach) | Yes | **Destructive** — requires `confirm: true` or returns preview with referencing servers |
+| **`lookup_dns`** | Read current Cloudflare DNS records for a domain (annotated with `managed_by_wslproxy` + `pop_id`) | No | Refuses domains outside `managed_zones` before any HTTP call |
+| **`provision_dns`** | Converge Cloudflare A records for a server to match its `pop_ids` | Yes | **`dry_run: true` is the DEFAULT** — must pass `dry_run: false` to actually apply |
 
-**Bold = added in this MCP CRUD pass.**
+**Bold = added in the MCP CRUD pass and the POPs/DNS pass.**
+
+> 📘 **End-to-end POPs + DNS setup** (Cloudflare token generation, settings.json, dashboard walkthrough, troubleshooting): see **[POPS_AND_DNS_GUIDE.md](../../POPS_AND_DNS_GUIDE.md)** at the repo root.
 
 ### Write-mode gate
 

--- a/api/mcp/tools.lua
+++ b/api/mcp/tools.lua
@@ -592,6 +592,177 @@ _M.TOOL_REGISTRY = {
             idempotentHint = true,
             openWorldHint = false
         }
+    },
+    -- ──────────────────────────────────────────────────────────────
+    -- POPs (Points of Presence) — the edge locations running wslproxy.
+    -- Servers reference these by id (in `pop_ids`) to decide which
+    -- POPs serve them.  The DNS provisioner reads the same list to
+    -- decide which Cloudflare A records to publish.
+    -- ──────────────────────────────────────────────────────────────
+    {
+        name = "list_pops",
+        description = "List all POPs (Points of Presence) with optional filtering by status / region.  Read-only.  Returns id, display_name, public_ipv4, region, city, status, capacity_weight, tags for each.  Use this to discover available POPs before assigning them to a server or provisioning DNS.",
+        inputSchema = {
+            type = "object",
+            properties = {
+                status = {type = "string", description = "Optional filter: only POPs with this status ('active', 'draining', 'maintenance', 'down')."},
+                region = {type = "string", description = "Optional filter: only POPs in this region (e.g. 'eu-west-1')."},
+                q = {type = "string", description = "Optional free-text search across id/display_name/city/region/public_ipv4/provider."},
+                limit = {type = "integer", description = "Max number of POPs to return (default 100, cap 500)."}
+            },
+            required = {}
+        },
+        annotations = {
+            title = "List POPs",
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        }
+    },
+    {
+        name = "get_pop",
+        description = "Fetch a single POP by id.  Read-only.  Returns the full record including metadata, lat/lng, country_code, provider, and timestamps.",
+        inputSchema = {
+            type = "object",
+            properties = {
+                pop_id = {type = "string", description = "POP id (e.g. 'pop0', 'lon1', 'us-east-1')."}
+            },
+            required = {"pop_id"}
+        },
+        annotations = {
+            title = "Get POP",
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        }
+    },
+    {
+        name = "create_pop",
+        description = "Create a new POP.  The id must be lowercase alphanumeric with optional dashes (2-32 chars, e.g. 'pop0', 'lon1', 'us-east-1').  public_ipv4 is required and must be a valid IPv4 address — this is the IP that DNS provisioning will publish.  Returns the created record.  Default behaviour is to actually create; pass dry_run=true to preview the validated payload without writing.",
+        inputSchema = {
+            type = "object",
+            properties = {
+                id = {type = "string", description = "Slug id, lowercase alphanumeric with optional dashes (e.g. 'lon2', 'us-west-1')."},
+                display_name = {type = "string", description = "Human-readable name (e.g. 'London POP 2')."},
+                public_ipv4 = {type = "string", description = "Public IPv4 address — the A record content DNS provisioning will publish."},
+                public_ipv6 = {type = "string", description = "Optional public IPv6 address."},
+                region = {type = "string", description = "Region identifier (e.g. 'eu-west-1')."},
+                city = {type = "string", description = "City name."},
+                country_code = {type = "string", description = "ISO 3166-1 alpha-2 (e.g. 'GB', 'US')."},
+                provider = {type = "string", description = "Hosting provider name (e.g. 'aws', 'linode')."},
+                status = {type = "string", description = "One of 'active', 'draining', 'maintenance', 'down' (default 'active')."},
+                capacity_weight = {type = "number", description = "Routing weight in [0, 10]; 1.0 = default, 0 = drain (default 1.0)."},
+                tags = {type = "array", items = {type = "string"}, description = "Optional tags (default [])."},
+                dry_run = {type = "boolean", description = "If true, validates the payload but doesn't write.  Default false = actually create."}
+            },
+            required = {"id", "public_ipv4"}
+        },
+        annotations = {
+            title = "Create POP",
+            readOnlyHint = false,
+            destructiveHint = false,
+            idempotentHint = false,
+            openWorldHint = false
+        }
+    },
+    {
+        name = "update_pop",
+        description = "Update an existing POP by id.  Partial updates supported — only fields provided are changed.  Use this to flip status (drain → active), adjust capacity_weight, or fix metadata.  Default behaviour is to actually update; pass dry_run=true to preview.",
+        inputSchema = {
+            type = "object",
+            properties = {
+                pop_id = {type = "string", description = "POP id to update."},
+                display_name = {type = "string"},
+                public_ipv4 = {type = "string"},
+                public_ipv6 = {type = "string"},
+                region = {type = "string"},
+                city = {type = "string"},
+                country_code = {type = "string"},
+                provider = {type = "string"},
+                status = {type = "string", description = "One of 'active', 'draining', 'maintenance', 'down'."},
+                capacity_weight = {type = "number"},
+                tags = {type = "array", items = {type = "string"}},
+                dry_run = {type = "boolean", description = "If true, validates the update but doesn't write.  Default false."}
+            },
+            required = {"pop_id"}
+        },
+        annotations = {
+            title = "Update POP",
+            readOnlyHint = false,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = false
+        }
+    },
+    {
+        name = "delete_pop",
+        description = "Delete a POP.  Destructive — requires `confirm: true` or returns a preview of which servers currently reference it.  If any server references the POP and `force: true` is not set, the call refuses with 409 + the list of referencing servers.  When `force: true`, every referencing server is detached (pop removed from its pop_ids) before the POP file is deleted.  If ANY detach fails, the whole operation aborts to avoid dangling pop_ids.",
+        inputSchema = {
+            type = "object",
+            properties = {
+                pop_id = {type = "string", description = "POP id to delete."},
+                confirm = {type = "boolean", description = "Must be true to actually delete.  Default false = preview which servers would be affected."},
+                force = {type = "boolean", description = "If true and servers reference this POP, detach them first then delete.  Default false = refuse if referenced."}
+            },
+            required = {"pop_id"}
+        },
+        annotations = {
+            title = "Delete POP",
+            readOnlyHint = false,
+            destructiveHint = true,
+            idempotentHint = true,
+            openWorldHint = false
+        }
+    },
+    -- ──────────────────────────────────────────────────────────────
+    -- DNS Manager (Cloudflare provisioning).
+    -- These talk to the live Cloudflare API.  lookup_dns is read-
+    -- only.  provision_dns mutates external state (creates / updates
+    -- / deletes A records); default dry_run=true so an agent gets the
+    -- plan first and must explicitly opt in to apply.
+    -- ──────────────────────────────────────────────────────────────
+    {
+        name = "lookup_dns",
+        description = "Look up the current Cloudflare DNS records for a domain.  Read-only — calls Cloudflare's GET /zones/{id}/dns_records.  Returns each record annotated with `managed_by_wslproxy` (true if the record was created by wslproxy and carries the marker comment) and `pop_id` (the POP id parsed from the marker comment, if any).  The domain must fall under a zone listed in settings.dns.providers[].managed_zones, otherwise zone_not_allowed is returned BEFORE any HTTP call.",
+        inputSchema = {
+            type = "object",
+            properties = {
+                domain = {type = "string", description = "Fully-qualified domain to query (e.g. 'api.example.com')."},
+                record_type = {type = "string", description = "Optional DNS record type filter (default: any; common: 'A')."}
+            },
+            required = {"domain"}
+        },
+        annotations = {
+            title = "Lookup DNS Records",
+            readOnlyHint = true,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = true
+        }
+    },
+    {
+        name = "provision_dns",
+        description = "Converge Cloudflare DNS records for a server to match its pop_ids.  Computes a plan (create / update / delete / unchanged per POP) and either previews it (dry_run=true) or applies it (dry_run=false).  Default is dry_run=true so an agent ALWAYS sees the plan first; pass dry_run=false in a follow-up call to apply.  Only modifies records created by wslproxy (carrying the marker comment) — hand-curated records are never touched.  Returns the action list, including any skipped POPs and the reason.",
+        inputSchema = {
+            type = "object",
+            properties = {
+                server_id = {type = "string", description = "Server id (e.g. 'host:api.example.com')."},
+                profile_id = {type = "string", description = "Environment profile (e.g. 'prod', 'int')."},
+                dry_run = {type = "boolean", description = "If true (DEFAULT), returns the action plan without calling Cloudflare to write.  Pass false to actually apply."},
+                include_inactive = {type = "boolean", description = "If true, POPs in 'down' or 'maintenance' status are included in the desired set.  Default false."},
+                record_type = {type = "string", description = "DNS record type to manage (default 'A')."}
+            },
+            required = {"server_id", "profile_id"}
+        },
+        annotations = {
+            title = "Provision DNS (Cloudflare)",
+            readOnlyHint = false,
+            destructiveHint = false,
+            idempotentHint = true,
+            openWorldHint = true
+        }
     }
 }
 
@@ -2545,6 +2716,228 @@ function _M.delete_rule(params)
     }
 end
 
+-- ──────────────────────────────────────────────────────────────────
+-- POPs + DNS — implementations
+-- ──────────────────────────────────────────────────────────────────
+
+-- Helper: wrap a (data, err) backend return in the MCP response
+-- shape.  Keeps each handler short and uniform.
+local function pop_response(tool, data, err)
+    if not data then
+        return {
+            tool = tool,
+            result = {
+                error = err and err.code or "internal_error",
+                message = err and err.message or "Unknown error",
+                details = err and err.details or nil,
+            },
+            isError = true,
+        }
+    end
+    return {tool = tool, result = data, isError = false}
+end
+
+-- Tool: list_pops
+function _M.list_pops(params)
+    local Pops = require("pops")
+    local limit = tonumber(params.limit) or 100
+    if limit > 500 then limit = 500 end
+    local filter = {}
+    if params.status and params.status ~= "" then filter.status = params.status end
+    if params.region and params.region ~= "" then filter.region = params.region end
+    if params.q and params.q ~= "" then filter.q = params.q end
+    local data, total = Pops.list({
+        pagination = {page = 1, perPage = limit},
+        sort = {field = "id", order = "ASC"},
+        filter = filter,
+    })
+    return {
+        tool = "list_pops",
+        result = {pops = data, total = total, returned = #data},
+        isError = false,
+    }
+end
+
+-- Tool: get_pop
+function _M.get_pop(params)
+    local Pops = require("pops")
+    if not params.pop_id or params.pop_id == "" then
+        return pop_response("get_pop", nil, {
+            code = "validation_failed", message = "pop_id is required"})
+    end
+    local rec, err = Pops.get(params.pop_id)
+    return pop_response("get_pop", rec, err)
+end
+
+-- Tool: create_pop
+function _M.create_pop(params)
+    local Pops = require("pops")
+    local payload = {
+        id = params.id,
+        display_name = params.display_name,
+        public_ipv4 = params.public_ipv4,
+        public_ipv6 = params.public_ipv6,
+        region = params.region,
+        city = params.city,
+        country_code = params.country_code,
+        provider = params.provider,
+        status = params.status,
+        capacity_weight = params.capacity_weight,
+        tags = params.tags,
+    }
+    -- dry_run defaults to false here — operators creating POPs via an
+    -- agent usually want the create to actually happen.  Pass
+    -- dry_run=true explicitly to preview without writing.
+    if params.dry_run then
+        -- Lightweight preview: validate by running create then... not
+        -- applying.  Pops doesn't expose a separate validator, so we
+        -- approximate by returning what would be persisted alongside
+        -- the message.  A future enhancement is to add Pops.validate().
+        return {
+            tool = "create_pop",
+            result = {
+                dry_run = true,
+                would_create = payload,
+                next_steps = "Re-run with dry_run=false to actually create.",
+            },
+            isError = false,
+        }
+    end
+    local rec, err = Pops.create(payload, "mcp")
+    if rec then
+        ngx.log(ngx.INFO, "MCP: POP '", rec.id, "' created by ", ngx.var.remote_addr)
+    end
+    return pop_response("create_pop", rec, err)
+end
+
+-- Tool: update_pop
+function _M.update_pop(params)
+    local Pops = require("pops")
+    if not params.pop_id or params.pop_id == "" then
+        return pop_response("update_pop", nil, {
+            code = "validation_failed", message = "pop_id is required"})
+    end
+    -- Build the delta — only include fields the caller actually
+    -- passed, so an update of `status` doesn't accidentally clear
+    -- `tags` by sending nil.
+    local delta = {}
+    for _, k in ipairs({"display_name", "public_ipv4", "public_ipv6",
+                       "region", "city", "country_code", "provider",
+                       "status", "capacity_weight", "tags"}) do
+        if params[k] ~= nil then delta[k] = params[k] end
+    end
+    if params.dry_run then
+        return {
+            tool = "update_pop",
+            result = {
+                dry_run = true,
+                pop_id = params.pop_id,
+                would_patch = delta,
+                next_steps = "Re-run with dry_run=false to apply.",
+            },
+            isError = false,
+        }
+    end
+    local rec, err = Pops.update(params.pop_id, delta, "mcp")
+    if rec then
+        ngx.log(ngx.INFO, "MCP: POP '", params.pop_id, "' updated by ", ngx.var.remote_addr)
+    end
+    return pop_response("update_pop", rec, err)
+end
+
+-- Tool: delete_pop
+function _M.delete_pop(params)
+    local Pops = require("pops")
+    if not params.pop_id or params.pop_id == "" then
+        return pop_response("delete_pop", nil, {
+            code = "validation_failed", message = "pop_id is required"})
+    end
+    -- Always inventory references first so the preview is useful
+    -- (and so the destructive-action gate is informed).
+    local refs = Pops.find_servers_using(params.pop_id) or {}
+    if not params.confirm then
+        return {
+            tool = "delete_pop",
+            result = {
+                confirmed = false,
+                pop_id = params.pop_id,
+                referencing_servers = refs,
+                will_cascade_detach = (#refs > 0) and (params.force or false) or nil,
+                next_steps = (#refs > 0 and not params.force)
+                    and "Servers reference this POP.  Re-run with confirm=true AND force=true to cascade-detach + delete, OR detach those servers first."
+                    or "Re-run with confirm=true to actually delete.",
+            },
+            isError = false,
+        }
+    end
+    local result, err = Pops.delete(
+        params.pop_id, {force = params.force or false}, "mcp")
+    if result then
+        ngx.log(ngx.INFO, "MCP: POP '", params.pop_id, "' deleted by ",
+            ngx.var.remote_addr, " (force=", tostring(params.force or false), ")")
+        -- Pops.delete returns bare `true` on success; replace with a
+        -- structured payload so the agent / dashboard sees what
+        -- actually happened rather than an opaque boolean.
+        return {
+            tool = "delete_pop",
+            result = {
+                deleted = true,
+                pop_id = params.pop_id,
+                forced = params.force or false,
+                detached_servers = (#refs > 0) and refs or nil,
+            },
+            isError = false,
+        }
+    end
+    return pop_response("delete_pop", nil, err)
+end
+
+-- Tool: lookup_dns
+function _M.lookup_dns(params)
+    local DnsManager = require("dns_manager")
+    if not params.domain or params.domain == "" then
+        return pop_response("lookup_dns", nil, {
+            code = "validation_failed", message = "domain is required"})
+    end
+    local result, err = DnsManager.lookup({
+        domain = params.domain,
+        type = params.record_type,
+    })
+    return pop_response("lookup_dns", result, err)
+end
+
+-- Tool: provision_dns
+function _M.provision_dns(params)
+    local DnsManager = require("dns_manager")
+    if not params.server_id or params.server_id == "" then
+        return pop_response("provision_dns", nil, {
+            code = "validation_failed", message = "server_id is required"})
+    end
+    if not params.profile_id or params.profile_id == "" then
+        return pop_response("provision_dns", nil, {
+            code = "validation_failed", message = "profile_id is required"})
+    end
+    -- DEFAULT TO DRY-RUN.  This is the opposite of create_pop /
+    -- update_pop: provisioning touches external state (Cloudflare),
+    -- so an agent must always see the plan first.  The caller has
+    -- to explicitly pass dry_run=false to actually apply.
+    local dry_run = params.dry_run
+    if dry_run == nil then dry_run = true end
+    local result, err = DnsManager.provision_for_server({
+        server_id = params.server_id,
+        profile_id = params.profile_id,
+        dry_run = dry_run,
+        include_inactive = params.include_inactive,
+        record_type = params.record_type,
+    })
+    if result and not dry_run then
+        ngx.log(ngx.INFO, "MCP: DNS provisioned for server '",
+            params.server_id, "' by ", ngx.var.remote_addr,
+            " (", #(result.actions or {}), " actions)")
+    end
+    return pop_response("provision_dns", result, err)
+end
+
 -- Execute a tool by name
 function _M.execute(tool_name, params)
     local config = McpConfig.load()
@@ -2574,7 +2967,15 @@ function _M.execute(tool_name, params)
         update_server = function() return _M.update_server(params) end,
         update_rule = function() return _M.update_rule(params) end,
         delete_server = function() return _M.delete_server(params) end,
-        delete_rule = function() return _M.delete_rule(params) end
+        delete_rule = function() return _M.delete_rule(params) end,
+        -- POPs + DNS (added in feature/pops-and-cloudflare-dns)
+        list_pops = function() return _M.list_pops(params) end,
+        get_pop = function() return _M.get_pop(params) end,
+        create_pop = function() return _M.create_pop(params) end,
+        update_pop = function() return _M.update_pop(params) end,
+        delete_pop = function() return _M.delete_pop(params) end,
+        lookup_dns = function() return _M.lookup_dns(params) end,
+        provision_dns = function() return _M.provision_dns(params) end
     }
 
     local handler = tool_handlers[tool_name]
@@ -2589,11 +2990,23 @@ function _M.execute(tool_name, params)
         deploy_varnish = true, purge_varnish = true,
         create_server = true, create_rule = true, attach_rule = true,
         update_server = true, update_rule = true,
-        delete_server = true, delete_rule = true
+        delete_server = true, delete_rule = true,
+        -- POPs + DNS write tools.  provision_dns is in here even
+        -- though it defaults to dry_run=true: a dry-run-only call
+        -- doesn't mutate Cloudflare, but it still counts as a
+        -- "write tool" for permission gating so an operator
+        -- running MCP in read-only mode can't reach the apply path
+        -- by accident.
+        create_pop = true, update_pop = true, delete_pop = true,
+        provision_dns = true
     }
     if write_tools[tool_name] then
         if tool_name == "reload_config" and params.dry_run ~= false then
             -- dry_run reload is read-only, allow it
+        elseif tool_name == "provision_dns" and params.dry_run ~= false then
+            -- dry_run provision is read-only (no Cloudflare writes),
+            -- so allow even in read-only mode.  Mirrors the
+            -- reload_config exception above.
         elseif McpConfig.is_read_only(config) then
             return nil, "Tool '" .. tool_name .. "' requires write mode. MCP is currently in read-only mode."
         end

--- a/api/mcp/tools.lua
+++ b/api/mcp/tools.lua
@@ -744,7 +744,7 @@ _M.TOOL_REGISTRY = {
     },
     {
         name = "provision_dns",
-        description = "Converge Cloudflare DNS records for a server to match its pop_ids.  Computes a plan (create / update / delete / unchanged per POP) and either previews it (dry_run=true) or applies it (dry_run=false).  Default is dry_run=true so an agent ALWAYS sees the plan first; pass dry_run=false in a follow-up call to apply.  Only modifies records created by wslproxy (carrying the marker comment) — hand-curated records are never touched.  Returns the action list, including any skipped POPs and the reason.",
+        description = "Converge Cloudflare DNS records for a server.  Supports four modes via `record_type`: \"A\" (default — one A per active POP using public_ipv4), \"AAAA\" (one AAAA per active POP using public_ipv6), \"BOTH\" (dual-stack — A AND AAAA), and \"CNAME\" (a single CNAME pointing at the server's dns_cname_target; POPs are not used).  If `record_type` is omitted, the server's stored `dns_record_type` is used (defaulting to \"A\" for backwards compatibility).  Computes a plan (create / update / delete / unchanged) and either previews it (dry_run=true) or applies it (dry_run=false).  Default is dry_run=true so an agent ALWAYS sees the plan first.  Only modifies records created by wslproxy (carrying the marker comment) — hand-curated records are never touched.  Returns the action list with each action tagged by its record_type, plus any skipped POPs with reasons.",
         inputSchema = {
             type = "object",
             properties = {
@@ -752,7 +752,7 @@ _M.TOOL_REGISTRY = {
                 profile_id = {type = "string", description = "Environment profile (e.g. 'prod', 'int')."},
                 dry_run = {type = "boolean", description = "If true (DEFAULT), returns the action plan without calling Cloudflare to write.  Pass false to actually apply."},
                 include_inactive = {type = "boolean", description = "If true, POPs in 'down' or 'maintenance' status are included in the desired set.  Default false."},
-                record_type = {type = "string", description = "DNS record type to manage (default 'A')."}
+                record_type = {type = "string", description = "One of \"A\", \"AAAA\", \"BOTH\", \"CNAME\".  Overrides the server's stored dns_record_type.  Omit to use whatever the server has configured."}
             },
             required = {"server_id", "profile_id"}
         },

--- a/api/pops.lua
+++ b/api/pops.lua
@@ -1,0 +1,651 @@
+-- POPs (Points of Presence) Manager Module for WSLProxy
+--
+-- A POP is a physical edge location running wslproxy — pop0 in London,
+-- lon1 in London-DC2, jfk1 in New York, etc.  POPs are first-class
+-- entities so that DNS provisioning, geo-aware routing, and health-
+-- driven failover can reason about them by id rather than by
+-- baked-in IPs scattered across configs.
+--
+-- Storage: data/pops/{id}.json — GLOBAL (not profile-scoped).
+-- A pop is physical infrastructure; pop0 is pop0 whether the
+-- referencing server lives in `prod`, `int`, or `test`.  This mirrors
+-- how `data/profiles/` and `data/settings.json` work.
+--
+-- Public API:
+--   _M.list(params)              → (list, total) | (nil, err)
+--   _M.get(id)                   → record | (nil, err)
+--   _M.create(payload, user)     → record | (nil, err)
+--   _M.update(id, payload, user) → record | (nil, err)
+--   _M.delete(id, opts, user)    → true | (nil, err)
+--   _M.set_status(id, status, user) → record | (nil, err)
+--   _M.find_servers_using(id)    → list of {server_id, profile_id}
+--
+-- Errors are returned as Lua tables of the form:
+--   { code = "validation_failed", message = "...", details = {...} }
+-- so the HTTP layer can translate to 400/409/404/500 cleanly and the
+-- dashboard can highlight specific fields.
+
+local _M = {}
+
+local cjson = Cjson or require("cjson")
+local lfs = LFS or require("lfs")
+local Helper = require("helpers")
+local AuditLogger = require("audit_logger")
+
+local configPath = os.getenv("NGINX_CONFIG_DIR") or "/opt/nginx/"
+
+-- ============================================================
+-- Constants & schema
+-- ============================================================
+
+local POPS_DIR = configPath .. "data/pops"
+
+-- Status enum.  Each state has a distinct operational meaning —
+-- `draining` and `maintenance` look the same at the request layer
+-- but signal different things to the oncall (planned vs unplanned)
+-- and to the DNS health-checker (re-introduce vs leave-out).
+local VALID_STATUSES = {
+    active = true,        -- in rotation, accepting traffic
+    draining = true,      -- not accepting new traffic, completing in-flight
+    down = true,          -- unplanned outage, oncall paged
+    maintenance = true,   -- planned outage, oncall NOT paged
+}
+
+-- Fields the caller is NEVER allowed to set or mutate.  `id` is
+-- immutable after creation; `created_at` is set once; `updated_at`
+-- is managed by the module.  These are stripped from any payload
+-- before persistence.
+local SERVER_MANAGED_FIELDS = {
+    created_at = true,
+    updated_at = true,
+}
+
+-- Slug pattern for `id`: lowercase alphanumeric + dash, 1-32 chars.
+-- Matches the convention used elsewhere (e.g. profile ids) and is
+-- safe in URLs, filesystem paths, and as a config-file basename.
+local ID_PATTERN = "^[a-z0-9][a-z0-9%-]*[a-z0-9]$"
+
+-- Cheap IPv4 sanity check.  Full RFC validation would mean writing
+-- 100 lines of parser; this catches the obvious typos and lets the
+-- network layer surface the rare edge case at first use.
+local function is_valid_ipv4(s)
+    if type(s) ~= "string" then return false end
+    local a, b, c, d = s:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
+    if not a then return false end
+    for _, octet in ipairs({a, b, c, d}) do
+        local n = tonumber(octet)
+        if not n or n < 0 or n > 255 then return false end
+    end
+    return true
+end
+
+-- IPv6 is checked structurally only: at least two colons, hex digits
+-- and colons only, length under 45 chars.  Same rationale as IPv4 —
+-- precision-validating in Lua isn't worth the LOC cost.
+local function is_valid_ipv6(s)
+    if type(s) ~= "string" then return false end
+    if #s > 45 or not s:find(":") then return false end
+    if not s:match("^[%x:]+$") then return false end
+    local _, count = s:gsub(":", "")
+    return count >= 2
+end
+
+local function is_valid_country_code(s)
+    return type(s) == "string" and #s == 2 and s:match("^[A-Z][A-Z]$") ~= nil
+end
+
+-- ============================================================
+-- Internal helpers
+-- ============================================================
+
+local function ensure_pops_dir()
+    if Helper.isDirectoryExists(POPS_DIR) then return true end
+    local ok, err = pcall(Helper.createDirectoryRecursive, POPS_DIR)
+    if not ok then
+        ngx.log(ngx.ERR, "Pops: failed to create directory ", POPS_DIR, ": ", tostring(err))
+        return false
+    end
+    return true
+end
+
+local function pop_path(id)
+    return POPS_DIR .. "/" .. id .. ".json"
+end
+
+local function file_exists(path)
+    local f = io.open(path, "rb")
+    if not f then return false end
+    f:close()
+    return true
+end
+
+local function read_pop_file(id)
+    local content = Helper.getDataFromFile(pop_path(id))
+    if not content then return nil end
+    local ok, decoded = pcall(cjson.decode, content)
+    if not ok or type(decoded) ~= "table" then return nil end
+    return decoded
+end
+
+local function write_pop_file(id, record)
+    local f, err = io.open(pop_path(id), "wb")
+    if not f then return false, "Failed to open " .. pop_path(id) .. ": " .. tostring(err) end
+    f:write(cjson.encode(record))
+    f:close()
+    return true
+end
+
+local function delete_pop_file(id)
+    local ok, err = os.remove(pop_path(id))
+    if not ok then return false, tostring(err) end
+    return true
+end
+
+local function get_user(provided)
+    if provided and provided ~= "" then return provided end
+    local h = ngx.req.get_headers()["x-user"]
+    if h and h ~= "" then return h end
+    return "system"
+end
+
+-- ============================================================
+-- Validation
+-- ============================================================
+
+-- Returns `nil` on success, or a list of {field, message} pairs on
+-- failure.  Callers wrap the list into a structured error response.
+--
+-- `for_update = true` relaxes required-field enforcement, since
+-- updates may be partial and only need to validate the fields the
+-- caller actually passed.
+local function validate(payload, for_update)
+    local errs = {}
+
+    local function bad(field, msg)
+        table.insert(errs, {field = field, message = msg})
+    end
+
+    if type(payload) ~= "table" then
+        return {{field = "_root", message = "Payload must be a JSON object."}}
+    end
+
+    -- ── id ───────────────────────────────────────────────────────────
+    -- Required on create, forbidden in the body on update (URL carries it).
+    if not for_update then
+        if not payload.id or payload.id == "" then
+            bad("id", "id is required")
+        elseif type(payload.id) ~= "string" then
+            bad("id", "id must be a string")
+        elseif not payload.id:match(ID_PATTERN) then
+            bad("id", "id must be lowercase alphanumeric with optional dashes, 2-32 chars (e.g. 'pop0', 'lon1', 'us-east-1')")
+        elseif #payload.id > 32 then
+            bad("id", "id must be 32 characters or fewer")
+        end
+    end
+
+    -- ── display_name ─────────────────────────────────────────────────
+    if not for_update or payload.display_name ~= nil then
+        if not payload.display_name or payload.display_name == "" then
+            bad("display_name", "display_name is required")
+        elseif type(payload.display_name) ~= "string" then
+            bad("display_name", "display_name must be a string")
+        elseif #payload.display_name > 100 then
+            bad("display_name", "display_name must be 100 characters or fewer")
+        end
+    end
+
+    -- ── public_ipv4 ──────────────────────────────────────────────────
+    -- The single field this whole feature exists for — required.
+    if not for_update or payload.public_ipv4 ~= nil then
+        if not payload.public_ipv4 or payload.public_ipv4 == "" then
+            bad("public_ipv4", "public_ipv4 is required")
+        elseif not is_valid_ipv4(payload.public_ipv4) then
+            bad("public_ipv4", "public_ipv4 must be a valid IPv4 address (e.g. '187.124.112.155')")
+        end
+    end
+
+    -- ── public_ipv6 (optional but if present, must be valid) ────────
+    if payload.public_ipv6 ~= nil and payload.public_ipv6 ~= ngx.null and payload.public_ipv6 ~= "" then
+        if not is_valid_ipv6(payload.public_ipv6) then
+            bad("public_ipv6", "public_ipv6 must be a valid IPv6 address")
+        end
+    end
+
+    -- ── country_code (optional but must be ISO if present) ──────────
+    if payload.country_code ~= nil and payload.country_code ~= "" then
+        if not is_valid_country_code(payload.country_code) then
+            bad("country_code", "country_code must be an uppercase ISO 3166-1 alpha-2 code (e.g. 'GB', 'US')")
+        end
+    end
+
+    -- ── lat / lng (optional, but checked together if either present) ─
+    if payload.lat ~= nil or payload.lng ~= nil then
+        local lat, lng = tonumber(payload.lat), tonumber(payload.lng)
+        if payload.lat ~= nil then
+            if not lat then
+                bad("lat", "lat must be a number")
+            elseif lat < -90 or lat > 90 then
+                bad("lat", "lat must be between -90 and 90")
+            end
+        end
+        if payload.lng ~= nil then
+            if not lng then
+                bad("lng", "lng must be a number")
+            elseif lng < -180 or lng > 180 then
+                bad("lng", "lng must be between -180 and 180")
+            end
+        end
+    end
+
+    -- ── status ───────────────────────────────────────────────────────
+    if payload.status ~= nil then
+        if not VALID_STATUSES[payload.status] then
+            bad("status", "status must be one of: active, draining, down, maintenance")
+        end
+    end
+
+    -- ── capacity_weight ──────────────────────────────────────────────
+    if payload.capacity_weight ~= nil then
+        local w = tonumber(payload.capacity_weight)
+        if not w then
+            bad("capacity_weight", "capacity_weight must be a number")
+        elseif w < 0 or w > 1 then
+            bad("capacity_weight", "capacity_weight must be between 0.0 and 1.0")
+        end
+    end
+
+    -- ── tags (optional array of strings) ─────────────────────────────
+    if payload.tags ~= nil and payload.tags ~= ngx.null then
+        if type(payload.tags) ~= "table" then
+            bad("tags", "tags must be an array of strings")
+        else
+            for i, v in ipairs(payload.tags) do
+                if type(v) ~= "string" then
+                    bad("tags", "tag at index " .. i .. " must be a string")
+                    break
+                end
+            end
+        end
+    end
+
+    -- ── metadata (optional object) ──────────────────────────────────
+    if payload.metadata ~= nil and payload.metadata ~= ngx.null then
+        if type(payload.metadata) ~= "table" then
+            bad("metadata", "metadata must be an object")
+        end
+    end
+
+    -- ── string fields with no special validation, only type/length ──
+    local string_fields = {
+        region = 50,
+        city = 100,
+        internal_hostname = 253,
+        provider = 50,
+    }
+    for field, maxlen in pairs(string_fields) do
+        if payload[field] ~= nil and payload[field] ~= "" then
+            if type(payload[field]) ~= "string" then
+                bad(field, field .. " must be a string")
+            elseif #payload[field] > maxlen then
+                bad(field, field .. " must be " .. maxlen .. " characters or fewer")
+            end
+        end
+    end
+
+    if #errs > 0 then return errs end
+    return nil
+end
+
+-- Strip server-managed fields and normalise so storage shape is
+-- consistent.  Optional fields that arrived as empty strings or
+-- ngx.null are normalised to nil so the on-disk JSON stays clean.
+local function normalise(payload)
+    local out = {}
+    for k, v in pairs(payload) do
+        if not SERVER_MANAGED_FIELDS[k] and v ~= ngx.null then
+            -- treat empty string the same as absence for nullable fields
+            if v == "" and k ~= "display_name" and k ~= "id" then
+                -- skip — don't persist empty optional strings
+            else
+                out[k] = v
+            end
+        end
+    end
+    return out
+end
+
+-- ============================================================
+-- Public API
+-- ============================================================
+
+--- List POPs with pagination, sort, and filter.
+---
+--- Returns `(records, total)` on success or `(nil, err)` on failure.
+--- The error table follows the module-wide shape:
+--- `{ code = "...", message = "...", details? = {...} }`.
+---
+--- @param params table  `{ pagination={page,perPage}, sort={field,order}, filter={q,status,region} }`
+--- @return table|nil records  Array of pop records, or nil on error
+--- @return integer|table total_or_err  Total count on success, error table on failure
+function _M.list(params)
+    if not ensure_pops_dir() then
+        return nil, {code = "io_error", message = "Pops directory unavailable"}
+    end
+    params = params or {}
+    local pagination = params.pagination or {}
+    local sort = params.sort or {}
+    local filter = params.filter or {}
+
+    local page = tonumber(pagination.page) or 1
+    local per_page = tonumber(pagination.perPage) or 25
+    local sort_field = sort.field or "id"
+    local sort_order = sort.order or "ASC"
+    sort_order = sort_order:upper()
+    if sort_order ~= "ASC" and sort_order ~= "DESC" then sort_order = "ASC" end
+
+    local all = {}
+    for fname in lfs.dir(POPS_DIR) do
+        if fname:match("%.json$") then
+            local id = fname:sub(1, -6)
+            local record = read_pop_file(id)
+            if record then table.insert(all, record) end
+        end
+    end
+
+    -- Apply filters.  Empty values are ignored so a UI can send
+    -- {q="", status=""} without filtering anything out.
+    local filtered = {}
+    local q = filter.q and filter.q ~= "" and filter.q:lower() or nil
+    local status_filter = filter.status and filter.status ~= "" or nil
+    local region_filter = filter.region and filter.region ~= "" or nil
+    for _, p in ipairs(all) do
+        if status_filter and p.status ~= filter.status then goto continue end
+        if region_filter and p.region ~= filter.region then goto continue end
+        if q then
+            local match = false
+            for _, field in ipairs({"id", "display_name", "city", "region", "public_ipv4", "provider"}) do
+                if p[field] and tostring(p[field]):lower():find(q, 1, true) then
+                    match = true; break
+                end
+            end
+            if not match then goto continue end
+        end
+        table.insert(filtered, p)
+        ::continue::
+    end
+
+    -- Sort
+    table.sort(filtered, function(a, b)
+        local av, bv = a[sort_field], b[sort_field]
+        if av == nil then return false end
+        if bv == nil then return true end
+        if sort_order == "ASC" then return tostring(av) < tostring(bv)
+        else return tostring(av) > tostring(bv) end
+    end)
+
+    -- Paginate
+    local total = #filtered
+    local start_idx = (page - 1) * per_page + 1
+    local end_idx = math.min(start_idx + per_page - 1, total)
+    local page_data = {}
+    for i = start_idx, end_idx do table.insert(page_data, filtered[i]) end
+
+    return page_data, total
+end
+
+--- Get a single POP by id.
+function _M.get(id)
+    if not id or id == "" then
+        return nil, {code = "validation_failed", message = "id is required"}
+    end
+    local record = read_pop_file(id)
+    if not record then
+        return nil, {code = "not_found", message = "POP '" .. id .. "' not found"}
+    end
+    return record
+end
+
+--- Create a new POP.  Errors with code="conflict" if id exists.
+function _M.create(payload, user)
+    if not ensure_pops_dir() then
+        return nil, {code = "io_error", message = "Pops directory unavailable"}
+    end
+
+    local verrs = validate(payload, false)
+    if verrs then
+        return nil, {code = "validation_failed", message = "Invalid payload", details = verrs}
+    end
+
+    if file_exists(pop_path(payload.id)) then
+        return nil, {
+            code = "conflict",
+            message = "POP '" .. payload.id .. "' already exists",
+            details = {existing_id = payload.id},
+        }
+    end
+
+    local now = ngx.time()
+    local record = normalise(payload)
+    record.created_at = now
+    record.updated_at = now
+    -- Apply sane defaults for fields the caller omitted.
+    if record.status == nil then record.status = "active" end
+    if record.capacity_weight == nil then record.capacity_weight = 1.0 end
+    if record.tags == nil then record.tags = setmetatable({}, cjson.empty_array_mt or nil) end
+    if record.metadata == nil then record.metadata = setmetatable({}, cjson.empty_array_mt or nil) end
+
+    local ok, err = write_pop_file(record.id, record)
+    if not ok then
+        return nil, {code = "io_error", message = err}
+    end
+
+    pcall(function()
+        AuditLogger.log("pop_create", get_user(user), "pops", record.id, {
+            display_name = record.display_name,
+            region = record.region,
+            public_ipv4 = record.public_ipv4,
+            status = record.status,
+        })
+    end)
+
+    return record
+end
+
+--- Update an existing POP.  Partial — only fields in payload are
+--- changed.  Returns the resulting record, or no_op if nothing
+--- differed.
+function _M.update(id, payload, user)
+    local existing, err = _M.get(id)
+    if not existing then return nil, err end
+
+    -- The id in the URL is authoritative.  An id field in the body
+    -- is silently dropped (per SERVER_MANAGED_FIELDS) but we also
+    -- reject an attempt to change it explicitly because that's
+    -- usually a caller bug, not intent.
+    if payload.id ~= nil and payload.id ~= id then
+        return nil, {
+            code = "validation_failed",
+            message = "id cannot be changed; delete + create the POP under a new id instead",
+            details = {{field = "id", message = "id is immutable"}},
+        }
+    end
+
+    local verrs = validate(payload, true)
+    if verrs then
+        return nil, {code = "validation_failed", message = "Invalid payload", details = verrs}
+    end
+
+    local normalised = normalise(payload)
+    local changed = {}
+    for k, v in pairs(normalised) do
+        if existing[k] ~= v then
+            existing[k] = v
+            table.insert(changed, k)
+        end
+    end
+
+    if #changed == 0 then
+        return existing, nil  -- no-op
+    end
+
+    existing.updated_at = ngx.time()
+
+    local ok, werr = write_pop_file(id, existing)
+    if not ok then
+        return nil, {code = "io_error", message = werr}
+    end
+
+    pcall(function()
+        AuditLogger.log("pop_update", get_user(user), "pops", id, {
+            changed_fields = changed,
+        })
+    end)
+
+    return existing
+end
+
+--- Quick helper for the common case of just flipping status.
+--- Logged as a distinct action so it shows up clearly in the audit
+--- trail (e.g. when an oncall drains a POP, that's worth its own row).
+function _M.set_status(id, new_status, user)
+    if not VALID_STATUSES[new_status] then
+        return nil, {
+            code = "validation_failed",
+            message = "status must be one of: active, draining, down, maintenance",
+            details = {{field = "status", message = "invalid status"}},
+        }
+    end
+    local existing, err = _M.get(id)
+    if not existing then return nil, err end
+    if existing.status == new_status then
+        return existing, nil  -- already there
+    end
+
+    local prev_status = existing.status
+    existing.status = new_status
+    existing.updated_at = ngx.time()
+
+    local ok, werr = write_pop_file(id, existing)
+    if not ok then
+        return nil, {code = "io_error", message = werr}
+    end
+
+    pcall(function()
+        AuditLogger.log("pop_status_change", get_user(user), "pops", id, {
+            from = prev_status,
+            to = new_status,
+        })
+    end)
+
+    return existing
+end
+
+--- Find all servers across all profiles that reference this POP.
+--- Used by delete to enforce referential integrity, and exposed
+--- publicly so the dashboard can render "in use by" badges.
+function _M.find_servers_using(id)
+    local servers_dir = configPath .. "data/servers"
+    local results = {}
+
+    -- Don't wrap `lfs.dir` in pcall — it returns (iterator, state,
+    -- control) and pcall only captures the first value, which breaks
+    -- the for-loop protocol.  Check the directory exists with
+    -- lfs.attributes first; if missing or not a directory, there's
+    -- nothing to walk and we return empty.
+    local attr = lfs.attributes(servers_dir)
+    if not attr or attr.mode ~= "directory" then return results end
+
+    for profile in lfs.dir(servers_dir) do
+        if profile ~= "." and profile ~= ".." then
+            local profile_dir = servers_dir .. "/" .. profile
+            local profile_attr = lfs.attributes(profile_dir)
+            if profile_attr and profile_attr.mode == "directory" then
+                for fname in lfs.dir(profile_dir) do
+                    if fname:match("^host:.*%.json$") then
+                        local content = Helper.getDataFromFile(profile_dir .. "/" .. fname)
+                        if content then
+                            local ok_d, server = pcall(cjson.decode, content)
+                            if ok_d and type(server) == "table"
+                                    and type(server.pop_ids) == "table" then
+                                for _, pid in ipairs(server.pop_ids) do
+                                    if pid == id then
+                                        table.insert(results, {
+                                            server_id = server.id,
+                                            server_name = server.server_name,
+                                            profile_id = profile,
+                                        })
+                                        break
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return results
+end
+
+--- Delete a POP.  Default refuses if any server references it.
+--- Pass {force=true} to cascade-detach (audited separately per
+--- detached server).
+function _M.delete(id, opts, user)
+    opts = opts or {}
+    local existing, err = _M.get(id)
+    if not existing then return nil, err end
+
+    local refs = _M.find_servers_using(id)
+    if #refs > 0 and not opts.force then
+        return nil, {
+            code = "conflict",
+            message = "POP '" .. id .. "' is in use by " .. #refs ..
+                " server(s); pass force=true to cascade-detach",
+            details = {referencing_servers = refs},
+        }
+    end
+
+    -- Cascade-detach if forced.  We write each server before
+    -- deleting the POP so an error mid-way leaves the system in a
+    -- safe state (no dangling pop_ids referencing a deleted POP).
+    local detached = {}
+    if opts.force and #refs > 0 then
+        for _, ref in ipairs(refs) do
+            local spath = configPath .. "data/servers/" .. ref.profile_id ..
+                "/" .. ref.server_id .. ".json"
+            local content = Helper.getDataFromFile(spath)
+            if content then
+                local ok_d, server = pcall(cjson.decode, content)
+                if ok_d and type(server) == "table" and type(server.pop_ids) == "table" then
+                    local kept = {}
+                    for _, pid in ipairs(server.pop_ids) do
+                        if pid ~= id then table.insert(kept, pid) end
+                    end
+                    server.pop_ids = kept
+                    local f = io.open(spath, "wb")
+                    if f then
+                        f:write(cjson.encode(server))
+                        f:close()
+                        table.insert(detached, ref.server_id)
+                    end
+                end
+            end
+        end
+    end
+
+    local ok, derr = delete_pop_file(id)
+    if not ok then
+        return nil, {code = "io_error", message = "Failed to remove file: " .. derr}
+    end
+
+    pcall(function()
+        AuditLogger.log("pop_delete", get_user(user), "pops", id, {
+            forced = opts.force or false,
+            detached_servers = detached,
+        })
+    end)
+
+    return true
+end
+
+return _M

--- a/api/pops.lua
+++ b/api/pops.lua
@@ -123,7 +123,16 @@ local function read_pop_file(id)
     local content = Helper.getDataFromFile(pop_path(id))
     if not content then return nil end
     local ok, decoded = pcall(cjson.decode, content)
-    if not ok or type(decoded) ~= "table" then return nil end
+    if not ok or type(decoded) ~= "table" then
+        -- Log to nginx error.log so corrupted POP JSON shows up in
+        -- ops dashboards rather than silently vanishing from /pops.
+        -- We still return nil — list() can't reasonably surface a
+        -- single-record corruption error per-call without breaking
+        -- the whole listing — but at least the operator can see it.
+        ngx.log(ngx.ERR, "pops: failed to decode '", pop_path(id),
+            "': ", tostring(decoded))
+        return nil
+    end
     return decoded
 end
 
@@ -431,8 +440,12 @@ function _M.create(payload, user)
     -- Apply sane defaults for fields the caller omitted.
     if record.status == nil then record.status = "active" end
     if record.capacity_weight == nil then record.capacity_weight = 1.0 end
+    -- tags is a string[] — force JSON `[]` for empty so the dashboard
+    -- `.map()` doesn't crash on `{}` (CLAUDE.md §13).  metadata is a
+    -- key/value object — leave the default `{}` shape so consumers
+    -- can do `metadata.foo` lookups without a runtime type check.
     if record.tags == nil then record.tags = setmetatable({}, cjson.empty_array_mt or nil) end
-    if record.metadata == nil then record.metadata = setmetatable({}, cjson.empty_array_mt or nil) end
+    if record.metadata == nil then record.metadata = {} end
 
     local ok, err = write_pop_file(record.id, record)
     if not ok then
@@ -605,31 +618,75 @@ function _M.delete(id, opts, user)
         }
     end
 
-    -- Cascade-detach if forced.  We write each server before
-    -- deleting the POP so an error mid-way leaves the system in a
-    -- safe state (no dangling pop_ids referencing a deleted POP).
+    -- Cascade-detach if forced.  Every referencing server must be
+    -- successfully rewritten BEFORE we delete the POP file — any
+    -- read / decode / write failure aborts the whole delete with
+    -- io_error so we never leave a dangling pop_id behind.  This is
+    -- the opposite of "best-effort detach": correctness over
+    -- progress, because dangling pop_ids cause silent DNS-provision
+    -- errors that are far harder to debug than a refused delete.
     local detached = {}
     if opts.force and #refs > 0 then
         for _, ref in ipairs(refs) do
             local spath = configPath .. "data/servers/" .. ref.profile_id ..
                 "/" .. ref.server_id .. ".json"
             local content = Helper.getDataFromFile(spath)
-            if content then
-                local ok_d, server = pcall(cjson.decode, content)
-                if ok_d and type(server) == "table" and type(server.pop_ids) == "table" then
-                    local kept = {}
-                    for _, pid in ipairs(server.pop_ids) do
-                        if pid ~= id then table.insert(kept, pid) end
-                    end
-                    server.pop_ids = kept
-                    local f = io.open(spath, "wb")
-                    if f then
-                        f:write(cjson.encode(server))
-                        f:close()
-                        table.insert(detached, ref.server_id)
-                    end
-                end
+            if not content then
+                return nil, {
+                    code = "io_error",
+                    message = "Refusing to delete POP '" .. id ..
+                        "': could not read referencing server '" ..
+                        ref.server_id .. "' to detach it.  Fix the file " ..
+                        "access problem and retry.",
+                    details = {server_id = ref.server_id, path = spath},
+                }
             end
+            local ok_d, server = pcall(cjson.decode, content)
+            if not ok_d or type(server) ~= "table" then
+                return nil, {
+                    code = "io_error",
+                    message = "Refusing to delete POP '" .. id ..
+                        "': server '" .. ref.server_id ..
+                        "' JSON is corrupted and cannot be safely detached.",
+                    details = {server_id = ref.server_id,
+                               parse_error = tostring(server)},
+                }
+            end
+            if type(server.pop_ids) == "table" then
+                local kept = {}
+                for _, pid in ipairs(server.pop_ids) do
+                    if pid ~= id then table.insert(kept, pid) end
+                end
+                server.pop_ids = kept
+            end
+            -- Encode FIRST so a serialisation failure doesn't truncate
+            -- the file mid-write.  Then open, write, check the write
+            -- return, then close — surface any I/O failure as a hard
+            -- abort rather than silently marking the server detached.
+            local encoded = cjson.encode(server)
+            local f, oerr = io.open(spath, "wb")
+            if not f then
+                return nil, {
+                    code = "io_error",
+                    message = "Refusing to delete POP '" .. id ..
+                        "': could not open server '" .. ref.server_id ..
+                        "' for write: " .. tostring(oerr),
+                    details = {server_id = ref.server_id, path = spath},
+                }
+            end
+            local wrote, werr = f:write(encoded)
+            f:close()
+            if not wrote then
+                return nil, {
+                    code = "io_error",
+                    message = "Refusing to delete POP '" .. id ..
+                        "': write to server '" .. ref.server_id ..
+                        "' failed (" .. tostring(werr) ..
+                        ").  Server JSON may be truncated; check the file.",
+                    details = {server_id = ref.server_id, path = spath},
+                }
+            end
+            table.insert(detached, ref.server_id)
         end
     end
 

--- a/api/pops.lua
+++ b/api/pops.lua
@@ -137,6 +137,17 @@ local function read_pop_file(id)
 end
 
 local function write_pop_file(id, record)
+    -- Re-stamp the empty-array metatable on tags BEFORE encoding.
+    -- read_pop_file decodes JSON into a plain Lua table with no
+    -- metatable; without re-stamping, an empty `tags: []` on disk
+    -- round-trips through read → update → write as `tags: {}`,
+    -- which then crashes downstream `.map(...)` calls in the
+    -- dashboard (CLAUDE.md §13).  metadata is intentionally left as
+    -- an object — it's a Record<string, unknown>, not an array.
+    if cjson.empty_array_mt and type(record.tags) == "table"
+            and next(record.tags) == nil then
+        setmetatable(record.tags, cjson.empty_array_mt)
+    end
     local f, err = io.open(pop_path(id), "wb")
     if not f then return false, "Failed to open " .. pop_path(id) .. ": " .. tostring(err) end
     f:write(cjson.encode(record))

--- a/infra/ansible/roles/wslproxy/defaults/main.yml
+++ b/infra/ansible/roles/wslproxy/defaults/main.yml
@@ -45,3 +45,47 @@ ip2location_download_url: "https://edgeone-public.s3.eu-west-2.amazonaws.com/src
 # `*-*-01 03:30:00` = 03:30 UTC on the 1st of every month.  The LITE
 # DB is updated by IP2Location around the start of each month.
 ip2location_refresh_schedule: "*-*-01 03:30:00"
+
+# ── POPs (Points of Presence) seed ───────────────────────────────────────
+#
+# Default seeds for the two production POPs (pop0 + lon1).  These are
+# only written if the file doesn't already exist on the target host
+# (`force: no` in tasks/seed_pops.yml), so any edit an operator made
+# via the dashboard survives a re-run of the role.
+#
+# To customise per-environment:
+#   - Override `wslproxy_pops` in inventory / group_vars to ADD POPs
+#     specific to that environment (e.g. a per-region edge fleet).
+#   - To DELETE a POP that the seed would otherwise create, use the
+#     dashboard or `DELETE /api/pops/<id>`.  Re-deploying the role
+#     won't recreate it because the seed only writes missing files.
+#
+# Fields match the schema validated by api/pops.lua.  See
+# POPS_AND_DNS_GUIDE.md §1 for what each field means.
+wslproxy_pops:
+  - id: pop0
+    display_name: "London POP 0"
+    public_ipv4: "187.124.112.155"
+    provider: hetzner
+    region: eu-west
+    city: London
+    country_code: GB
+    status: active
+    capacity_weight: 1.0
+    tags:
+      - production
+      - primary
+    metadata: {}
+  - id: lon1
+    display_name: "London POP 1"
+    public_ipv4: "72.62.211.28"
+    provider: vultr
+    region: eu-west
+    city: London
+    country_code: GB
+    status: active
+    capacity_weight: 1.0
+    tags:
+      - production
+      - secondary
+    metadata: {}

--- a/infra/ansible/roles/wslproxy/tasks/main.yml
+++ b/infra/ansible/roles/wslproxy/tasks/main.yml
@@ -108,6 +108,11 @@
   include_tasks: deploy_data.yml
   tags: [servers, code]
 
+# Step 6.1.5: Seed default POPs (idempotent — only writes missing files)
+- name: Seed POPs
+  include_tasks: seed_pops.yml
+  tags: [servers, code, pops]
+
 # Step 6.2: Install Lua dependencies (luarocks, CDN deps)
 - name: Install Lua dependencies
   include_tasks: deploy_deps.yml

--- a/infra/ansible/roles/wslproxy/tasks/seed_pops.yml
+++ b/infra/ansible/roles/wslproxy/tasks/seed_pops.yml
@@ -1,0 +1,36 @@
+---
+# Seed the data/pops/ directory with the default POP records defined
+# in `wslproxy_pops` (defaults/main.yml).  Idempotent — only writes
+# files that don't already exist, so dashboard edits and operator-
+# created POPs survive role re-runs.
+
+- name: "POPs: ensure data/pops/ directory exists"
+  ansible.builtin.file:
+    path: /opt/nginx/data/pops
+    state: directory
+    mode: '0775'
+    owner: "{{ wslproxy_app_user | default('www-data') }}"
+    group: root
+  tags: [servers, code, pops]
+
+- name: "POPs: seed default POP records (only if missing)"
+  ansible.builtin.copy:
+    # `pop_record` is the loop variable; merging in created_at/updated_at
+    # at template time so the seed produces a record that already passes
+    # api/pops.lua's validate() without needing a separate normalisation
+    # pass.  `now('utc', '%s') | int` resolves to a Unix timestamp.
+    content: "{{ (pop_record | combine({'created_at': (now(true, '%s') | int), 'updated_at': (now(true, '%s') | int)})) | to_nice_json }}"
+    dest: "/opt/nginx/data/pops/{{ pop_record.id }}.json"
+    mode: '0664'
+    owner: "{{ wslproxy_app_user | default('www-data') }}"
+    group: root
+    # `force: no` is the key safety property — if the file already
+    # exists (operator edited via dashboard, or this isn't a fresh
+    # install), we leave it alone.  Re-running the role on an
+    # existing fleet is a no-op for these records.
+    force: no
+  loop: "{{ wslproxy_pops | default([]) }}"
+  loop_control:
+    loop_var: pop_record
+    label: "{{ pop_record.id }} ({{ pop_record.public_ipv4 | default('no-ip') }})"
+  tags: [servers, code, pops]

--- a/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
@@ -77,6 +77,17 @@ http {
     lua_package_path "/usr/local/openresty/nginx/html/api/?.lua;/usr/local/openresty/nginx/html/api/?/init.lua;/usr/local/openresty/lualib/?.lua;/usr/local/openresty/site/lualib/?.lua;/usr/local/openresty/luajit/share/lua/5.1/?.lua;/usr/local/openresty/luajit/share/lua/5.1/?/init.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua;;";
     lua_package_cpath '/usr/local/openresty/site/lualib/resty/?.so;/usr/local/openresty/lualib/?.so;/usr/local/openresty/luajit/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/?.so;;';
 
+    # Trust store for outbound HTTPS from Lua (lua-resty-http) — used
+    # by api/dns_manager.lua to talk to the Cloudflare API and by any
+    # future HTTPS callers (AI providers, etc.).  Without this,
+    # `httpc:request_uri(...)` against an HTTPS URL fails with OpenSSL
+    # error 20 "unable to get local issuer certificate".  Debian /
+    # Ubuntu ship the bundle at this exact path via the
+    # ca-certificates package (preinstalled in os_setup_debian.yml).
+    # Kept in sync with nginx-dev.conf.tmpl per CLAUDE.md §6.
+    lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+    lua_ssl_verify_depth 5;
+
     # Include dynamic upstream configurations
     include /opt/nginx/data/upstreams/*/upstreams.conf;
 

--- a/nginx-dev.conf.tmpl
+++ b/nginx-dev.conf.tmpl
@@ -63,6 +63,15 @@ http {
     lua_package_path "/usr/local/openresty/nginx/html/api/?.lua;/usr/local/openresty/nginx/html/api/?/init.lua;/usr/local/openresty/lualib/?.lua;/usr/local/openresty/site/lualib/?.lua;;";
     lua_package_cpath '/usr/local/openresty/site/lualib/resty/?.so;/usr/local/openresty/lualib/?.so;;';
 
+    # Trust store for outbound HTTPS from Lua (lua-resty-http →
+    # Cloudflare for dns_manager.lua, Let's Encrypt ACME, AI providers
+    # etc.).  Without this, lua-resty-http fails TLS verification with
+    # OpenSSL error 20 "unable to get local issuer certificate".
+    # Alpine ships the bundle at this exact path via the
+    # ca-certificates package.
+    lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+    lua_ssl_verify_depth 5;
+
     # WebSocket support: map Upgrade header to Connection header value
     map $http_upgrade $connection_upgrade {
         default upgrade;

--- a/openresty-admin-next/src/app/(dashboard)/pops/[id]/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/pops/[id]/page.tsx
@@ -1,0 +1,620 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  Save,
+  Trash2,
+  Globe2,
+  AlertTriangle,
+  Power,
+  PowerOff,
+} from "lucide-react";
+import { useOne, useDataProvider } from "@/hooks/useResource";
+import { useNotification } from "@/contexts/NotificationContext";
+import PageHeader from "@/components/ui/PageHeader";
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import Input from "@/components/ui/Input";
+import Select from "@/components/ui/Select";
+import Skeleton from "@/components/ui/Skeleton";
+import FetchErrorState from "@/components/ui/FetchErrorState";
+import ConfirmDialog from "@/components/ui/ConfirmDialog";
+import Badge from "@/components/ui/Badge";
+import type { Pop } from "@/types";
+
+/**
+ * Create / edit / delete a POP.
+ *
+ * `/pops/create`  — create-mode (id editable, no delete button)
+ * `/pops/{id}`    — edit-mode (id read-only, delete button visible)
+ *
+ * Delete refuses with 409 + a list of referencing servers when in
+ * use; the confirm dialog surfaces that list and offers `force=true`
+ * to cascade-detach.  Mirrors the backend's posture exactly.
+ */
+
+const STATUS_OPTIONS = [
+  { value: "active", label: "Active — in rotation" },
+  { value: "draining", label: "Draining — finish in-flight only" },
+  { value: "down", label: "Down — unplanned (pages oncall)" },
+  { value: "maintenance", label: "Maintenance — planned (no page)" },
+];
+
+interface ReferencingServer {
+  server_id: string;
+  server_name?: string;
+  profile_id: string;
+}
+
+interface PopBackendError {
+  error?: string;
+  message?: string;
+  details?:
+    | Array<{ field: string; message: string }>
+    | { referencing_servers?: ReferencingServer[]; existing_id?: string };
+}
+
+// Empty form shape used on /pops/create and as the reset target.  All
+// optional fields default to empty strings (Input prefers controlled
+// strings) and the form normalises to nulls / numbers at submit time.
+const EMPTY_FORM = {
+  id: "",
+  display_name: "",
+  region: "",
+  country_code: "",
+  city: "",
+  lat: "",
+  lng: "",
+  public_ipv4: "",
+  public_ipv6: "",
+  internal_hostname: "",
+  status: "active",
+  capacity_weight: "1.0",
+  provider: "",
+  tags: "", // comma-separated in the form, split on submit
+};
+
+export default function PopDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const dataProvider = useDataProvider();
+  const { notify } = useNotification();
+  const id = params.id as string;
+  const isCreate = id === "create";
+
+  const { data, isLoading, error, mutate } = useOne<Pop>(
+    isCreate ? null : "pops",
+    isCreate ? null : id,
+  );
+
+  const [form, setForm] = useState({ ...EMPTY_FORM });
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+  const [referencingServers, setReferencingServers] = useState<
+    ReferencingServer[] | null
+  >(null);
+  // Field-level errors keyed by field name.  Populated from the
+  // backend's 400 validation_failed response which carries
+  // `details: [{field, message}]`.
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (data) {
+      // Hydrate form from the loaded record.  Empty-string display
+      // (rather than undefined) keeps inputs controlled.
+      setForm({
+        id: data.id ?? "",
+        display_name: data.display_name ?? "",
+        region: data.region ?? "",
+        country_code: data.country_code ?? "",
+        city: data.city ?? "",
+        lat: data.lat !== undefined && data.lat !== null ? String(data.lat) : "",
+        lng: data.lng !== undefined && data.lng !== null ? String(data.lng) : "",
+        public_ipv4: data.public_ipv4 ?? "",
+        public_ipv6: data.public_ipv6 ?? "",
+        internal_hostname: data.internal_hostname ?? "",
+        status: data.status ?? "active",
+        capacity_weight:
+          data.capacity_weight !== undefined && data.capacity_weight !== null
+            ? String(data.capacity_weight)
+            : "1.0",
+        provider: data.provider ?? "",
+        tags: Array.isArray(data.tags) ? data.tags.join(", ") : "",
+      });
+    }
+  }, [data]);
+
+  const handleChange = useCallback(
+    (field: keyof typeof form, value: string) => {
+      setForm((prev) => ({ ...prev, [field]: value }));
+      // Clear the field error as soon as the user starts typing in
+      // that field — saves them having to wait until next submit.
+      setFieldErrors((prev) => {
+        if (!prev[field]) return prev;
+        const next = { ...prev };
+        delete next[field];
+        return next;
+      });
+    },
+    [],
+  );
+
+  /** Translate form → API payload.  Numeric fields parse here so
+   *  the Pop type's contract (numbers, not strings) is upheld at the
+   *  network boundary, and empty strings become `null` / `undefined`
+   *  so the on-disk shape stays clean. */
+  const buildPayload = useCallback(() => {
+    const payload: Record<string, unknown> = {
+      display_name: form.display_name.trim(),
+      public_ipv4: form.public_ipv4.trim(),
+      status: form.status,
+    };
+    if (isCreate) payload.id = form.id.trim();
+    if (form.region.trim()) payload.region = form.region.trim();
+    if (form.country_code.trim())
+      payload.country_code = form.country_code.trim().toUpperCase();
+    if (form.city.trim()) payload.city = form.city.trim();
+    if (form.lat.trim()) payload.lat = Number(form.lat);
+    if (form.lng.trim()) payload.lng = Number(form.lng);
+    if (form.public_ipv6.trim()) payload.public_ipv6 = form.public_ipv6.trim();
+    if (form.internal_hostname.trim())
+      payload.internal_hostname = form.internal_hostname.trim();
+    if (form.capacity_weight.trim())
+      payload.capacity_weight = Number(form.capacity_weight);
+    if (form.provider.trim()) payload.provider = form.provider.trim();
+    if (form.tags.trim()) {
+      payload.tags = form.tags
+        .split(",")
+        .map((t) => t.trim())
+        .filter(Boolean);
+    }
+    return payload;
+  }, [form, isCreate]);
+
+  // Translate the backend's structured error envelope into
+  // field-level errors + a notification.  Reads from the flat
+  // ApiError shape — `message`, `code`, `details` live directly on
+  // the instance; parseBackendError populates them from the
+  // backend's nested `{ error: { message, code, details } }` body.
+  const handleApiError = useCallback(
+    (err: unknown, fallback: string) => {
+      const errObj = err as {
+        message?: string;
+        code?: string;
+        details?: unknown;
+      };
+      const details = errObj?.details;
+      if (Array.isArray(details)) {
+        const map: Record<string, string> = {};
+        for (const d of details as Array<{ field?: string; message?: string }>) {
+          if (d.field && d.message) map[d.field] = d.message;
+        }
+        setFieldErrors(map);
+        notify(errObj.message || fallback, { type: "error" });
+        return;
+      }
+      notify(errObj?.message || fallback, { type: "error" });
+    },
+    [notify],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    setSaving(true);
+    setFieldErrors({});
+    try {
+      const payload = buildPayload();
+      if (isCreate) {
+        await dataProvider.create("pops", payload);
+        notify("POP created", { type: "success" });
+      } else {
+        await dataProvider.update("pops", id, payload);
+        notify("POP updated", { type: "success" });
+      }
+      router.push("/pops");
+    } catch (err) {
+      handleApiError(err, "Failed to save POP");
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    isCreate,
+    buildPayload,
+    dataProvider,
+    id,
+    notify,
+    router,
+    handleApiError,
+  ]);
+
+  // Single-click status flips — common operational gestures (drain,
+  // re-activate, mark down).  Persist immediately rather than
+  // requiring the user to also click Save: this is the only field
+  // that should react that way because it's the one that operators
+  // change *during* incidents.
+  const handleStatusFlip = useCallback(
+    async (next: NonNullable<Pop["status"]>) => {
+      if (isCreate) {
+        // In create mode there's nothing to flip yet — just update
+        // the form state.
+        handleChange("status", next);
+        return;
+      }
+      setSaving(true);
+      try {
+        await dataProvider.update("pops", id, { status: next });
+        notify(`Status set to ${next}`, { type: "success" });
+        await mutate();
+        handleChange("status", next);
+      } catch (err) {
+        handleApiError(err, "Failed to update status");
+      } finally {
+        setSaving(false);
+      }
+    },
+    [
+      isCreate,
+      dataProvider,
+      id,
+      notify,
+      mutate,
+      handleChange,
+      handleApiError,
+    ],
+  );
+
+  const handleDelete = useCallback(
+    async (force = false) => {
+      setDeleting(true);
+      try {
+        // Pass `force=true` as a query param — matches what the Lua
+        // wrapper reads via ngx.req.get_uri_args().  The dataProvider
+        // doesn't currently expose a clean per-resource hook for
+        // delete query params, so we fall through to a direct fetch.
+        await dataProvider.remove("pops", id + (force ? "?force=true" : ""));
+        notify(force ? "POP force-deleted" : "POP deleted", {
+          type: "success",
+        });
+        router.push("/pops");
+      } catch (err) {
+        const errObj = err as {
+          message?: string;
+          status?: number;
+          details?: { referencing_servers?: ReferencingServer[] };
+        };
+        const refs = errObj?.details;
+        if (errObj?.status === 409 && refs?.referencing_servers) {
+          // First click: surface the conflict in the dialog so the
+          // user can review the servers and decide whether to force.
+          setReferencingServers(refs.referencing_servers);
+          notify(
+            errObj.message ||
+              "POP is in use; review and confirm cascade-detach",
+            { type: "info" },
+          );
+        } else {
+          handleApiError(err, "Failed to delete POP");
+          setShowDelete(false);
+        }
+      } finally {
+        setDeleting(false);
+      }
+    },
+    [dataProvider, id, notify, router, handleApiError],
+  );
+
+  // Reset the delete-dialog state whenever the dialog is opened or
+  // closed so a stale `referencingServers` from a previous attempt
+  // doesn't bleed through.
+  const openDeleteDialog = useCallback(() => {
+    setReferencingServers(null);
+    setShowDelete(true);
+  }, []);
+  const closeDeleteDialog = useCallback(() => {
+    setReferencingServers(null);
+    setShowDelete(false);
+  }, []);
+
+  // ── Loading / error states for edit-mode hydration ───────────────
+  if (!isCreate && isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton variant="rectangular" />
+      </div>
+    );
+  }
+  if (!isCreate && error) {
+    return <FetchErrorState error={error} onRetry={() => mutate()} />;
+  }
+
+  const currentStatus = (form.status || "active") as NonNullable<Pop["status"]>;
+
+  return (
+    <div>
+      <PageHeader
+        title={isCreate ? "Create POP" : `POP: ${data?.display_name ?? id}`}
+        subtitle={
+          isCreate
+            ? "A new Point of Presence — a physical edge location running wslproxy."
+            : "Edit POP configuration.  Status changes apply immediately."
+        }
+        icon={Globe2}
+        actions={
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => router.push("/pops")}
+              icon={<ArrowLeft className="h-4 w-4" />}
+            >
+              Back
+            </Button>
+            {!isCreate && (
+              <Button
+                variant="danger"
+                onClick={openDeleteDialog}
+                icon={<Trash2 className="h-4 w-4" />}
+              >
+                Delete
+              </Button>
+            )}
+            <Button
+              onClick={handleSubmit}
+              loading={saving}
+              icon={<Save className="h-4 w-4" />}
+            >
+              {isCreate ? "Create POP" : "Save Changes"}
+            </Button>
+          </div>
+        }
+      />
+
+      {/* Quick-action row for edit-mode: one-click drain / activate.
+          Hidden on create because there's nothing to flip yet. */}
+      {!isCreate && (
+        <Card className="mb-4">
+          <Card.Body>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                  Current status:
+                </span>
+                <Badge
+                  variant={
+                    currentStatus === "active"
+                      ? "success"
+                      : currentStatus === "draining"
+                        ? "warning"
+                        : currentStatus === "down"
+                          ? "danger"
+                          : "info"
+                  }
+                >
+                  {currentStatus}
+                </Badge>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {currentStatus !== "active" && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => handleStatusFlip("active")}
+                    loading={saving}
+                    icon={<Power className="h-4 w-4" />}
+                  >
+                    Activate
+                  </Button>
+                )}
+                {currentStatus === "active" && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => handleStatusFlip("draining")}
+                    loading={saving}
+                    icon={<PowerOff className="h-4 w-4" />}
+                  >
+                    Drain
+                  </Button>
+                )}
+                {currentStatus !== "maintenance" && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleStatusFlip("maintenance")}
+                    loading={saving}
+                  >
+                    Mark Maintenance
+                  </Button>
+                )}
+              </div>
+            </div>
+          </Card.Body>
+        </Card>
+      )}
+
+      <Card>
+        <Card.Header>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Configuration
+          </h2>
+        </Card.Header>
+        <Card.Body>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <Input
+              label="ID (slug)"
+              value={form.id}
+              onChange={(e) => handleChange("id", e.target.value)}
+              disabled={!isCreate}
+              hint={
+                isCreate
+                  ? "Lowercase alphanumeric + dashes, 2-32 chars (e.g. pop0, lon1, us-east-1).  Immutable after creation."
+                  : "POP id is immutable — delete and recreate under a new id if needed."
+              }
+              error={fieldErrors.id}
+              placeholder="pop0"
+            />
+            <Input
+              label="Display Name"
+              value={form.display_name}
+              onChange={(e) => handleChange("display_name", e.target.value)}
+              hint="Human-friendly name shown in dashboards."
+              error={fieldErrors.display_name}
+              placeholder="London POP 0"
+            />
+            <Input
+              label="Public IPv4"
+              value={form.public_ipv4}
+              onChange={(e) => handleChange("public_ipv4", e.target.value)}
+              hint="The IP DNS records will point at for traffic to reach this POP."
+              error={fieldErrors.public_ipv4}
+              placeholder="187.124.112.155"
+            />
+            <Input
+              label="Public IPv6 (optional)"
+              value={form.public_ipv6}
+              onChange={(e) => handleChange("public_ipv6", e.target.value)}
+              error={fieldErrors.public_ipv6}
+              placeholder="2a01:4f8:..."
+            />
+            <Input
+              label="Region"
+              value={form.region}
+              onChange={(e) => handleChange("region", e.target.value)}
+              hint="Free-form region tag (e.g. eu-west, us-east, apac)."
+              error={fieldErrors.region}
+              placeholder="eu-west"
+            />
+            <Input
+              label="Country Code (ISO 3166-1 alpha-2)"
+              value={form.country_code}
+              onChange={(e) =>
+                handleChange("country_code", e.target.value.toUpperCase())
+              }
+              hint="Two-letter uppercase (GB, US, DE, SG…)."
+              error={fieldErrors.country_code}
+              placeholder="GB"
+              maxLength={2}
+            />
+            <Input
+              label="City"
+              value={form.city}
+              onChange={(e) => handleChange("city", e.target.value)}
+              error={fieldErrors.city}
+              placeholder="London"
+            />
+            <Input
+              label="Internal Hostname"
+              value={form.internal_hostname}
+              onChange={(e) =>
+                handleChange("internal_hostname", e.target.value)
+              }
+              hint="Control-plane DNS name for this POP (used internally — not customer-facing)."
+              error={fieldErrors.internal_hostname}
+              placeholder="pop0.wslproxy.com"
+            />
+            <Input
+              label="Latitude (optional)"
+              value={form.lat}
+              onChange={(e) => handleChange("lat", e.target.value)}
+              hint="-90 to 90.  Used for geo-distance calculations in routing strategies."
+              error={fieldErrors.lat}
+              type="number"
+              step="0.0001"
+              placeholder="51.5074"
+            />
+            <Input
+              label="Longitude (optional)"
+              value={form.lng}
+              onChange={(e) => handleChange("lng", e.target.value)}
+              hint="-180 to 180."
+              error={fieldErrors.lng}
+              type="number"
+              step="0.0001"
+              placeholder="-0.1278"
+            />
+            <Select
+              label="Status"
+              value={form.status}
+              onChange={(e) => handleChange("status", e.target.value)}
+              options={STATUS_OPTIONS}
+              error={fieldErrors.status}
+            />
+            <Input
+              label="Capacity Weight"
+              value={form.capacity_weight}
+              onChange={(e) => handleChange("capacity_weight", e.target.value)}
+              hint="0.0–1.0.  Multiplier for traffic share in weighted DNS pools.  Set 0 to drain via routing without flipping status."
+              error={fieldErrors.capacity_weight}
+              type="number"
+              step="0.05"
+              min="0"
+              max="1"
+            />
+            <Input
+              label="Provider"
+              value={form.provider}
+              onChange={(e) => handleChange("provider", e.target.value)}
+              hint="Free-form datacenter / cloud provider tag."
+              error={fieldErrors.provider}
+              placeholder="hetzner"
+            />
+            <Input
+              label="Tags (comma-separated)"
+              value={form.tags}
+              onChange={(e) => handleChange("tags", e.target.value)}
+              hint="Free-form labels — e.g. production, primary, edge."
+              error={fieldErrors.tags}
+              placeholder="production, primary"
+            />
+          </div>
+        </Card.Body>
+      </Card>
+
+      <ConfirmDialog
+        open={showDelete}
+        title={
+          referencingServers
+            ? "POP is in use — force delete?"
+            : `Delete POP "${data?.display_name ?? id}"?`
+        }
+        message={
+          referencingServers ? (
+            <div className="space-y-3">
+              <div className="flex items-start gap-2 rounded-md bg-amber-50 p-3 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <div className="text-sm">
+                  This POP is referenced by{" "}
+                  <strong>{referencingServers.length}</strong> server
+                  {referencingServers.length === 1 ? "" : "s"}.  Forcing
+                  delete will strip the reference from each of them.
+                </div>
+              </div>
+              <ul className="max-h-48 overflow-y-auto rounded-md border border-slate-200 bg-slate-50 p-3 text-sm dark:border-slate-700 dark:bg-slate-800">
+                {referencingServers.map((s) => (
+                  <li
+                    key={s.server_id}
+                    className="font-mono text-xs text-slate-700 dark:text-slate-300"
+                  >
+                    {s.server_name ?? s.server_id}{" "}
+                    <span className="text-slate-400">({s.profile_id})</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            "This action cannot be undone."
+          )
+        }
+        confirmLabel={
+          referencingServers ? "Force-delete + detach" : "Delete"
+        }
+        confirmVariant="danger"
+        loading={deleting}
+        onConfirm={() => handleDelete(Boolean(referencingServers))}
+        onCancel={closeDeleteDialog}
+      />
+    </div>
+  );
+}

--- a/openresty-admin-next/src/app/(dashboard)/pops/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/pops/page.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Route } from "next";
+import { Globe2, Plus } from "lucide-react";
+import { useList } from "@/hooks/useResource";
+import PageHeader from "@/components/ui/PageHeader";
+import DataTable, { type Column } from "@/components/ui/DataTable";
+import Button from "@/components/ui/Button";
+import Badge from "@/components/ui/Badge";
+import type { Pop } from "@/types";
+
+/**
+ * POPs (Points of Presence) — list page.
+ *
+ * POPs are physical edge locations running wslproxy.  Each row links
+ * to its detail page where the operator can edit fields, flip
+ * status (drain / activate / maintenance), or delete.
+ */
+
+/** Status → badge colour.  Kept in one place so the list page and
+ *  the detail page render the same chip for the same value. */
+const STATUS_VARIANTS: Record<
+  NonNullable<Pop["status"]>,
+  "success" | "warning" | "danger" | "info"
+> = {
+  active: "success",
+  draining: "warning",
+  down: "danger",
+  maintenance: "info",
+};
+
+const STATUS_LABELS: Record<NonNullable<Pop["status"]>, string> = {
+  active: "Active",
+  draining: "Draining",
+  down: "Down",
+  maintenance: "Maintenance",
+};
+
+export default function PopsListPage() {
+  const router = useRouter();
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(25);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<{ field: string; order: "ASC" | "DESC" }>({
+    field: "id",
+    order: "ASC",
+  });
+
+  const params = useMemo(
+    () => ({
+      pagination: { page, perPage },
+      sort,
+      filter: search ? { q: search } : {},
+    }),
+    [page, perPage, sort, search],
+  );
+
+  const { data, total, isLoading, error, mutate } = useList<Pop>("pops", params);
+
+  const columns = useMemo<Column<Pop>[]>(
+    () => [
+      {
+        field: "id",
+        label: "ID",
+        sortable: true,
+        render: (r) => (
+          <span className="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100">
+            {r.id}
+          </span>
+        ),
+      },
+      {
+        field: "display_name",
+        label: "Display Name",
+        sortable: true,
+      },
+      {
+        field: "region",
+        label: "Region / City",
+        render: (r) => {
+          // Compact "region · city" rendering — most useful when the
+          // operator is scanning by geography rather than by id.
+          // Either field can be absent; show the present one alone.
+          const parts = [r.region, r.city].filter(Boolean) as string[];
+          return parts.length > 0 ? (
+            <span className="text-slate-600 dark:text-slate-400">
+              {parts.join(" · ")}
+            </span>
+          ) : (
+            <span className="text-slate-400">—</span>
+          );
+        },
+      },
+      {
+        field: "public_ipv4",
+        label: "Public IP",
+        render: (r) => (
+          <span className="font-mono text-xs text-slate-700 dark:text-slate-300">
+            {r.public_ipv4}
+          </span>
+        ),
+      },
+      {
+        field: "status",
+        label: "Status",
+        sortable: true,
+        render: (r) => {
+          const s = (r.status || "active") as NonNullable<Pop["status"]>;
+          return (
+            <Badge variant={STATUS_VARIANTS[s]} size="sm">
+              {STATUS_LABELS[s]}
+            </Badge>
+          );
+        },
+      },
+      {
+        field: "capacity_weight",
+        label: "Weight",
+        render: (r) => {
+          // Render as a percentage for readability — 1.0 → "100%",
+          // 0.5 → "50%".  Drained POPs (weight 0) get a muted dash so
+          // the eye can scan past them quickly.
+          const w = r.capacity_weight;
+          if (w === undefined || w === null) {
+            return <span className="text-slate-400">—</span>;
+          }
+          if (w === 0) {
+            return <span className="text-slate-400">0%</span>;
+          }
+          return (
+            <span className="font-mono text-xs text-slate-700 dark:text-slate-300">
+              {Math.round(w * 100)}%
+            </span>
+          );
+        },
+      },
+      {
+        field: "country_code",
+        label: "Country",
+        render: (r) =>
+          r.country_code ? (
+            <span className="font-mono text-xs uppercase text-slate-600 dark:text-slate-400">
+              {r.country_code}
+            </span>
+          ) : (
+            <span className="text-slate-400">—</span>
+          ),
+      },
+    ],
+    [],
+  );
+
+  const handleRowClick = useCallback(
+    (record: Pop) => {
+      // Route literal not statically known — cast to satisfy
+      // typedRoutes, same pattern as servers/rules pages.
+      router.push(`/pops/${encodeURIComponent(record.id)}` as Route);
+    },
+    [router],
+  );
+
+  const handleSort = useCallback((field: string) => {
+    setSort((prev) => ({
+      field,
+      order: prev.field === field && prev.order === "ASC" ? "DESC" : "ASC",
+    }));
+  }, []);
+
+  const handleSearch = useCallback((q: string) => {
+    setSearch(q);
+    setPage(1);
+  }, []);
+
+  return (
+    <div>
+      <PageHeader
+        title="POPs"
+        subtitle="Points of Presence — physical edge locations running wslproxy.  Servers reference these by id to control which POPs serve them."
+        icon={Globe2}
+        actions={
+          <Button
+            onClick={() => router.push("/pops/create" as Route)}
+            icon={<Plus className="h-4 w-4" />}
+          >
+            Create POP
+          </Button>
+        }
+      />
+      <DataTable
+        columns={columns}
+        data={data}
+        total={total}
+        loading={isLoading}
+        error={error}
+        onRetry={() => mutate()}
+        page={page}
+        perPage={perPage}
+        sort={sort}
+        onSort={handleSort}
+        onPageChange={setPage}
+        onPerPageChange={setPerPage}
+        onRowClick={handleRowClick}
+        onSearch={handleSearch}
+      />
+    </div>
+  );
+}

--- a/openresty-admin-next/src/app/(dashboard)/servers/[id]/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/servers/[id]/page.tsx
@@ -73,6 +73,8 @@ const DEFAULT_FORM: ServerFormState = {
   proxy_server_name: "",
   profile_id: "",
   pop_ids: [],
+  dns_record_type: "A",
+  dns_cname_target: "",
   servers_tags: [],
   root: "/var/www/html",
   index: "index.html",
@@ -183,6 +185,11 @@ function hydrateForm(data: ServerType): ServerFormState {
     proxy_server_name: data.proxy_server_name ?? "",
     profile_id: data.profile_id ?? "",
     pop_ids: Array.isArray(data.pop_ids) ? data.pop_ids : [],
+    // Defaults preserve backwards compatibility: an existing server
+    // saved before this field existed reads as `"A"` (the previous
+    // behaviour) so its DNS provisioning is unchanged on first edit.
+    dns_record_type: (data.dns_record_type as "A" | "AAAA" | "BOTH" | "CNAME") ?? "A",
+    dns_cname_target: data.dns_cname_target ?? "",
     servers_tags: Array.isArray(data.servers_tags) ? data.servers_tags : [],
     root: data.root ?? "/var/www/html",
     index: data.index ?? "index.html",
@@ -263,6 +270,12 @@ function buildPayload(form: ServerFormState): Record<string, unknown> {
     proxy_server_name: form.proxy_server_name,
     profile_id: form.profile_id,
     pop_ids: form.pop_ids,
+    dns_record_type: form.dns_record_type,
+    // Only persist dns_cname_target when the mode actually uses it
+    // — leaving stale CNAME targets on A-mode servers would be
+    // misleading state.
+    dns_cname_target:
+      form.dns_record_type === "CNAME" ? form.dns_cname_target : undefined,
     servers_tags: form.servers_tags,
     root: form.root,
     index: form.index,

--- a/openresty-admin-next/src/app/(dashboard)/servers/[id]/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/servers/[id]/page.tsx
@@ -54,7 +54,7 @@ const TopologyCanvas = dynamic(
     ssr: false,
   },
 );
-import type { Server as ServerType, WafPolicy, Rule } from "@/types";
+import type { Server as ServerType, WafPolicy, Rule, Pop } from "@/types";
 import type { ServerFormState, VarnishConfig, VarnishSnippet } from "@/components/servers/types";
 import type { LocationEntry } from "@/components/servers/sections/LocationBlockEditor";
 import {
@@ -72,6 +72,7 @@ const DEFAULT_FORM: ServerFormState = {
   server_name: "",
   proxy_server_name: "",
   profile_id: "",
+  pop_ids: [],
   servers_tags: [],
   root: "/var/www/html",
   index: "index.html",
@@ -181,6 +182,7 @@ function hydrateForm(data: ServerType): ServerFormState {
     server_name: data.server_name ?? "",
     proxy_server_name: data.proxy_server_name ?? "",
     profile_id: data.profile_id ?? "",
+    pop_ids: Array.isArray(data.pop_ids) ? data.pop_ids : [],
     servers_tags: Array.isArray(data.servers_tags) ? data.servers_tags : [],
     root: data.root ?? "/var/www/html",
     index: data.index ?? "index.html",
@@ -260,6 +262,7 @@ function buildPayload(form: ServerFormState): Record<string, unknown> {
     server_name: form.server_name,
     proxy_server_name: form.proxy_server_name,
     profile_id: form.profile_id,
+    pop_ids: form.pop_ids,
     servers_tags: form.servers_tags,
     root: form.root,
     index: form.index,
@@ -335,6 +338,15 @@ export default function ServerDetailPage() {
   const { data: profiles } = useList<{ id: string; name: string }>("profiles");
   const { data: wafPolicies, isLoading: wafPoliciesLoading } = useList<WafPolicy>("waf_policies");
   const { data: rulesData } = useList<Rule>("rules");
+  // POPs feed the PopMultiSelect picker.  Fetched once and passed
+  // straight through — the picker handles its own filtering /
+  // grouping / status rendering.  perPage:500 because there's no
+  // realistic fleet that won't fit comfortably; capping smaller
+  // would silently truncate.
+  const { data: popsData, isLoading: popsLoading } = useList<Pop>("pops", {
+    pagination: { page: 1, perPage: 500 },
+    sort: { field: "id", order: "ASC" },
+  });
 
   /* ── Derived option lists ────────────────────────────────────────── */
 
@@ -662,8 +674,11 @@ export default function ServerDetailPage() {
           form={form}
           setForm={setForm}
           isCreate={isCreate}
+          serverId={isCreate ? undefined : (id as string)}
           profileOptions={profileOptions}
           wafPolicyOptions={wafPolicyOptions}
+          pops={popsData ?? []}
+          popsLoading={popsLoading}
           fieldErrors={fieldErrors}
         />
       )}

--- a/openresty-admin-next/src/app/(dashboard)/servers/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/servers/page.tsx
@@ -101,6 +101,38 @@ export default function ServersListPage() {
         sortable: true,
       },
       {
+        // Synthetic column — pop_ids has no native sort/filter
+        // semantics from the backend, so we just render chips.
+        // Truncate at 3 visible chips so the column doesn't blow
+        // out when a server is multi-region; show "+N" for the rest.
+        field: "_pop_ids",
+        label: "POPs",
+        render: (r) => {
+          const ids = Array.isArray(r.pop_ids) ? r.pop_ids : [];
+          if (ids.length === 0) {
+            return (
+              <span className="text-xs text-slate-400">profile default</span>
+            );
+          }
+          const visible = ids.slice(0, 3);
+          const overflow = ids.length - visible.length;
+          return (
+            <div className="flex flex-wrap items-center gap-1">
+              {visible.map((id) => (
+                <Badge key={id} variant="info" size="sm">
+                  {id}
+                </Badge>
+              ))}
+              {overflow > 0 && (
+                <Badge variant="default" size="sm">
+                  +{overflow}
+                </Badge>
+              )}
+            </div>
+          );
+        },
+      },
+      {
         field: "ssl_enabled",
         label: "SSL",
         render: (r) => (

--- a/openresty-admin-next/src/components/layout/Sidebar.tsx
+++ b/openresty-admin-next/src/components/layout/Sidebar.tsx
@@ -32,6 +32,7 @@ import {
   BookOpen,
   Info,
   Share2,
+  Globe2,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
@@ -92,6 +93,7 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
           // Cast: typedRoutes union is built from existing routes; new
           // routes need an explicit cast until the next build.
           { label: "Ingress", href: "/ingress" as Route, icon: Share2 },
+          { label: "POPs", href: "/pops" as Route, icon: Globe2 },
           { label: "Servers", href: "/servers", icon: Server },
           { label: "Rules", href: "/rules", icon: GitBranch },
           { label: "Profiles", href: "/profiles", icon: Layers },

--- a/openresty-admin-next/src/components/servers/NginxServerTab.tsx
+++ b/openresty-admin-next/src/components/servers/NginxServerTab.tsx
@@ -10,8 +10,11 @@ import Button from "@/components/ui/Button";
 import ArrayFieldEditor from "./sections/ArrayFieldEditor";
 import LocationBlockEditor from "./sections/LocationBlockEditor";
 import ConfigPreview from "./sections/ConfigPreview";
+import PopMultiSelect from "./sections/PopMultiSelect";
+import DnsStatePanel from "./sections/DnsStatePanel";
 import type { ServerFormState } from "./types";
 import type { LocationEntry } from "./sections/LocationBlockEditor";
+import type { Pop } from "@/types";
 import { ExternalLink, Plus, Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils/cn";
 
@@ -21,8 +24,18 @@ export interface NginxServerTabProps {
   form: ServerFormState;
   setForm: Dispatch<SetStateAction<ServerFormState>>;
   isCreate: boolean;
+  /** Server id (e.g. `host:foo.com`) — only meaningful in edit mode.
+   *  Passed through to DnsStatePanel for /api/dns/lookup +
+   *  /api/dns/provision calls.  Undefined in create mode (the panel
+   *  hides itself there anyway). */
+  serverId?: string;
   profileOptions: { value: string; label: string }[];
   wafPolicyOptions: { value: string; label: string }[];
+  /** Full POP list — passed straight through to the picker.  Parent
+   *  fetches via `useList<Pop>("pops", ...)`; the picker handles
+   *  grouping / sorting / status rendering. */
+  pops?: Pop[];
+  popsLoading?: boolean;
   /**
    * Per-field validation errors from the parent's `runValidationGate`
    * call.  Keys are dotted paths into the form (e.g. `server_name`,
@@ -72,8 +85,11 @@ const NginxServerTab: React.FC<NginxServerTabProps> = ({
   form,
   setForm,
   isCreate,
+  serverId,
   profileOptions,
   wafPolicyOptions,
+  pops,
+  popsLoading,
   fieldErrors,
 }) => {
   /* ── Helpers ──────────────────────────────────────────────────────── */
@@ -350,6 +366,36 @@ const NginxServerTab: React.FC<NginxServerTabProps> = ({
           </div>
         </Card.Body>
       </Card>
+
+      {/* ── POPs (Points of Presence) ───────────────────────────────────
+          Sits right after the profile selection — POP assignment is a
+          foundational routing decision, on par with which environment
+          profile this server belongs to.  The picker handles its own
+          empty / loading states; we just feed it the data. */}
+      <PopMultiSelect
+        pops={pops ?? []}
+        value={form.pop_ids}
+        onChange={(next) =>
+          setForm((prev) => ({ ...prev, pop_ids: next }))
+        }
+        isLoading={popsLoading}
+      />
+
+      {/* ── DNS State (Cloudflare) ──────────────────────────────────────
+          Sits right under the POP picker because the two are tightly
+          coupled — every change to pop_ids affects the DNS plan, and
+          the operator should be able to see/apply the impact without
+          navigating away.  The panel hides itself in create mode
+          (nothing to provision until the server is saved). */}
+      {!isCreate && serverId && form.server_name && (
+        <DnsStatePanel
+          serverId={serverId}
+          profileId={form.profile_id}
+          serverName={form.server_name}
+          popIds={form.pop_ids}
+          isCreate={isCreate}
+        />
+      )}
 
       {/* ── Listen Ports ─────────────────────────────────────────────── */}
       <Card>

--- a/openresty-admin-next/src/components/servers/NginxServerTab.tsx
+++ b/openresty-admin-next/src/components/servers/NginxServerTab.tsx
@@ -11,6 +11,7 @@ import ArrayFieldEditor from "./sections/ArrayFieldEditor";
 import LocationBlockEditor from "./sections/LocationBlockEditor";
 import ConfigPreview from "./sections/ConfigPreview";
 import PopMultiSelect from "./sections/PopMultiSelect";
+import DnsRecordTypeCard from "./sections/DnsRecordTypeCard";
 import DnsStatePanel from "./sections/DnsStatePanel";
 import type { ServerFormState } from "./types";
 import type { LocationEntry } from "./sections/LocationBlockEditor";
@@ -379,6 +380,31 @@ const NginxServerTab: React.FC<NginxServerTabProps> = ({
           setForm((prev) => ({ ...prev, pop_ids: next }))
         }
         isLoading={popsLoading}
+      />
+
+      {/* ── DNS Record Type (A / AAAA / BOTH / CNAME) ───────────────────
+          Sits between POPs and the DNS State panel so the order on the
+          form reads "where do I serve from? what shape of record?
+          what's actually in Cloudflare now?".  The v6-warning surfaces
+          when the operator picked AAAA/BOTH but no selected POP has
+          public_ipv6 — that misconfiguration would otherwise only
+          surface at provision time as a skipped-POP. */}
+      <DnsRecordTypeCard
+        value={form.dns_record_type}
+        cnameTarget={form.dns_cname_target}
+        onChange={(next) =>
+          setForm((prev) => ({ ...prev, dns_record_type: next }))
+        }
+        onCnameTargetChange={(next) =>
+          setForm((prev) => ({ ...prev, dns_cname_target: next }))
+        }
+        selectedPopsHaveV6={
+          form.pop_ids.length === 0
+            ? undefined
+            : (pops ?? []).some(
+                (p) => form.pop_ids.includes(p.id) && !!p.public_ipv6,
+              )
+        }
       />
 
       {/* ── DNS State (Cloudflare) ──────────────────────────────────────

--- a/openresty-admin-next/src/components/servers/sections/DnsProvisionDialog.tsx
+++ b/openresty-admin-next/src/components/servers/sections/DnsProvisionDialog.tsx
@@ -52,6 +52,10 @@ type ActionKind =
 interface PlanAction {
   action: ActionKind;
   pop_id?: string;
+  /** Record type the action targets — present when BOTH mode produces
+   *  a mixed list (A + AAAA), and on every action emitted by the
+   *  refactored planner.  Older plans omit it (treated as "A"). */
+  record_type?: "A" | "AAAA" | "CNAME";
   content?: string;
   from_content?: string;
   record_id?: string;
@@ -234,7 +238,9 @@ export default function DnsProvisionDialog({
                       {a.pop_id}
                     </span>
                   )}
-                  <span className="text-xs text-slate-500">A record</span>
+                  <span className="text-xs text-slate-500">
+                    {a.record_type || "A"} record
+                  </span>
                 </div>
                 <div className="mt-1 font-mono text-xs text-slate-700 dark:text-slate-300">
                   {a.from_content && a.content && a.from_content !== a.content ? (

--- a/openresty-admin-next/src/components/servers/sections/DnsProvisionDialog.tsx
+++ b/openresty-admin-next/src/components/servers/sections/DnsProvisionDialog.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Loader2,
+  Plus,
+  Pencil,
+  Trash2,
+  Check,
+  AlertCircle,
+  AlertTriangle,
+} from "lucide-react";
+import Dialog from "@/components/ui/Dialog";
+import Button from "@/components/ui/Button";
+import Badge from "@/components/ui/Badge";
+import { useDataProvider } from "@/hooks/useResource";
+import { useNotification } from "@/contexts/NotificationContext";
+
+/**
+ * Two-step DNS provisioning dialog.
+ *
+ * Phase 1 — PREVIEW (dry_run=true):
+ *   On open, calls `dataProvider.provisionDns({dry_run: true})` to
+ *   build the action plan.  Shows each (POP → IP, action) row so the
+ *   operator can review *before* anything writes.  This is the
+ *   "what will happen?" surface.
+ *
+ * Phase 2 — APPLY (dry_run=false):
+ *   Clicking "Apply N changes" calls the same endpoint without
+ *   dry_run.  Renders the executed results inline, including any
+ *   per-action errors (Cloudflare can succeed on some records and
+ *   fail on others; the orchestrator reports each independently).
+ *
+ * Why a single dialog rather than two: the user is making one
+ * decision — "is this plan correct?" — and the moment of confirmation
+ * shouldn't navigate them somewhere else.  The same dialog rerenders
+ * results in-place after apply, with a clear "Close" once done.
+ */
+
+type ActionKind =
+  | "created"
+  | "updated"
+  | "unchanged"
+  | "deleted"
+  | "deleted_legacy"
+  | "create"
+  | "update"
+  | "delete"
+  | "delete_legacy"
+  | "error";
+
+interface PlanAction {
+  action: ActionKind;
+  pop_id?: string;
+  content?: string;
+  from_content?: string;
+  record_id?: string;
+  error?: string;
+}
+
+interface Plan {
+  domain: string;
+  zone_id: string;
+  zone_name: string;
+  dry_run?: boolean;
+  actions: PlanAction[];
+  skipped: Array<{ pop_id: string; reason: string }>;
+}
+
+// Matches the ApiError thrown by apiFetch — flat fields on the error
+// instance.  parseBackendError reads from the backend's nested
+// `{ error: { message, code, details } }` envelope and exposes the
+// extracted values directly on the ApiError.
+interface ApiError {
+  message?: string;
+  code?: string;
+  status?: number;
+  details?: unknown;
+}
+
+interface DnsProvisionDialogProps {
+  open: boolean;
+  serverId: string;
+  profileId: string;
+  serverName: string;
+  onClose: () => void;
+  /** Called after a successful apply so the parent can refresh its
+   *  DNS state panel. */
+  onApplied?: () => void;
+}
+
+/** Action → visual treatment.  Kept in one place so plan rows and
+ *  result rows render identically.  Mutating actions (create / update
+ *  / delete) get distinct icons + colours; unchanged is muted; error
+ *  is loud. */
+const ACTION_META: Record<
+  ActionKind,
+  {
+    label: string;
+    badge: "success" | "warning" | "danger" | "info" | "default";
+    icon: typeof Plus;
+  }
+> = {
+  create: { label: "Create", badge: "success", icon: Plus },
+  created: { label: "Created", badge: "success", icon: Check },
+  update: { label: "Update", badge: "warning", icon: Pencil },
+  updated: { label: "Updated", badge: "warning", icon: Check },
+  delete: { label: "Delete", badge: "danger", icon: Trash2 },
+  deleted: { label: "Deleted", badge: "danger", icon: Check },
+  delete_legacy: { label: "Delete (legacy)", badge: "danger", icon: Trash2 },
+  deleted_legacy: { label: "Deleted (legacy)", badge: "danger", icon: Check },
+  unchanged: { label: "Unchanged", badge: "default", icon: Check },
+  error: { label: "Error", badge: "danger", icon: AlertCircle },
+};
+
+/** Skip reason → human-readable explanation.  POPs get filtered out
+ *  of the desired set for one of a few reasons; surface them so the
+ *  operator can see *why* a POP they assigned isn't in the plan. */
+const SKIP_REASONS: Record<string, string> = {
+  not_found: "POP id doesn't exist in data/pops/",
+  no_public_ipv4: "POP has no public_ipv4 set",
+  status_down: "POP status is 'down' — excluded by default",
+  status_maintenance: "POP status is 'maintenance' — excluded by default",
+};
+
+export default function DnsProvisionDialog({
+  open,
+  serverId,
+  profileId,
+  serverName,
+  onClose,
+  onApplied,
+}: DnsProvisionDialogProps) {
+  const dataProvider = useDataProvider();
+  const { notify } = useNotification();
+
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [planLoading, setPlanLoading] = useState(false);
+  const [planError, setPlanError] = useState<string | null>(null);
+  const [applyLoading, setApplyLoading] = useState(false);
+  const [appliedResult, setAppliedResult] = useState<Plan | null>(null);
+
+  const fetchPlan = useCallback(async () => {
+    setPlanLoading(true);
+    setPlanError(null);
+    setAppliedResult(null);
+    try {
+      const res = await dataProvider.provisionDns({
+        server_id: serverId,
+        profile_id: profileId,
+        dry_run: true,
+      });
+      setPlan(res?.data ?? null);
+    } catch (err) {
+      // Surface the structured error message from the Lua module
+      // verbatim — it's already designed to be operator-facing.
+      const errObj = err as ApiError;
+      setPlanError(errObj?.message || "Failed to build plan");
+    } finally {
+      setPlanLoading(false);
+    }
+  }, [dataProvider, serverId, profileId]);
+
+  // Re-fetch the plan every time the dialog opens (or when the
+  // server identity changes).  Closing the dialog leaves the plan
+  // in state, but the next open() resets to a fresh fetch — we
+  // don't want a stale plan from 10 minutes ago when something has
+  // changed in the meantime.
+  useEffect(() => {
+    if (open) {
+      void fetchPlan();
+    }
+  }, [open, fetchPlan]);
+
+  const handleApply = useCallback(async () => {
+    setApplyLoading(true);
+    try {
+      const res = await dataProvider.provisionDns({
+        server_id: serverId,
+        profile_id: profileId,
+        dry_run: false,
+      });
+      const result = res?.data ?? null;
+      setAppliedResult(result);
+      const errorCount = (result?.actions ?? []).filter(
+        (a) => a.action === "error",
+      ).length;
+      if (errorCount > 0) {
+        notify(`Applied with ${errorCount} error(s) — review below`, {
+          type: "warning",
+        });
+      } else {
+        notify("DNS provisioning applied", { type: "success" });
+        onApplied?.();
+      }
+    } catch (err) {
+      const errObj = err as ApiError;
+      notify(errObj?.message || "Failed to apply", { type: "error" });
+    } finally {
+      setApplyLoading(false);
+    }
+  }, [dataProvider, serverId, profileId, notify, onApplied]);
+
+  // The body we show depends on what stage we're at: loading the
+  // plan, failed to build the plan, plan visible (preview), applying,
+  // applied.  Each branch returns its own JSX so the rendering logic
+  // stays linear and easy to reason about.
+  const renderActions = (actions: PlanAction[]) => {
+    if (actions.length === 0) {
+      return (
+        <div className="rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200">
+          ✓ Cloudflare already matches the desired state — nothing to do.
+        </div>
+      );
+    }
+    return (
+      <div className="space-y-2">
+        {actions.map((a, idx) => {
+          const meta = ACTION_META[a.action];
+          const Icon = meta.icon;
+          return (
+            <div
+              key={`${a.action}-${a.pop_id ?? a.record_id ?? idx}`}
+              className="flex items-start gap-3 rounded-md border border-slate-200 bg-white p-3 dark:border-slate-700 dark:bg-slate-800/50"
+            >
+              <Icon className="mt-0.5 h-4 w-4 shrink-0 text-slate-500" />
+              <div className="flex-1 min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant={meta.badge} size="sm">
+                    {meta.label}
+                  </Badge>
+                  {a.pop_id && (
+                    <span className="font-mono text-xs text-slate-700 dark:text-slate-300">
+                      {a.pop_id}
+                    </span>
+                  )}
+                  <span className="text-xs text-slate-500">A record</span>
+                </div>
+                <div className="mt-1 font-mono text-xs text-slate-700 dark:text-slate-300">
+                  {a.from_content && a.content && a.from_content !== a.content ? (
+                    <>
+                      <span className="text-slate-400">{a.from_content}</span>
+                      <span className="mx-1 text-slate-400">→</span>
+                      <span>{a.content}</span>
+                    </>
+                  ) : (
+                    a.content || a.from_content || ""
+                  )}
+                </div>
+                {a.error && (
+                  <div className="mt-1 text-xs text-rose-600 dark:text-rose-400">
+                    {a.error}
+                  </div>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderSkipped = (
+    skipped: Array<{ pop_id: string; reason: string }>,
+  ) => {
+    if (skipped.length === 0) return null;
+    return (
+      <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
+        <div className="mb-1 flex items-center gap-2 text-xs font-semibold text-amber-800 dark:text-amber-200">
+          <AlertTriangle className="h-4 w-4" />
+          Skipped POPs ({skipped.length})
+        </div>
+        <ul className="space-y-1 text-xs text-amber-700 dark:text-amber-300">
+          {skipped.map((s) => (
+            <li key={s.pop_id}>
+              <span className="font-mono">{s.pop_id}</span> —{" "}
+              {SKIP_REASONS[s.reason] || s.reason}
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  };
+
+  // Build the visible plan based on which state we're in.  After an
+  // apply, the appliedResult takes precedence (operator wants to see
+  // what actually happened, not what was planned).
+  const visiblePlan = appliedResult ?? plan;
+  const hasApplied = appliedResult !== null;
+  const mutatingActionsCount = (plan?.actions ?? []).filter(
+    (a) => a.action !== "unchanged",
+  ).length;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={`DNS Provisioning — ${serverName}`}
+      className="max-w-2xl"
+      footer={
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="ghost" onClick={onClose} disabled={applyLoading}>
+            {hasApplied ? "Close" : "Cancel"}
+          </Button>
+          {!hasApplied && plan && !planError && (
+            <Button
+              variant="primary"
+              onClick={handleApply}
+              loading={applyLoading}
+              disabled={mutatingActionsCount === 0}
+            >
+              {mutatingActionsCount === 0
+                ? "Nothing to apply"
+                : `Apply ${mutatingActionsCount} change${mutatingActionsCount === 1 ? "" : "s"}`}
+            </Button>
+          )}
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        {/* ── Zone summary line — always visible once we have data ── */}
+        {visiblePlan && (
+          <div className="rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-600 dark:bg-slate-800/50 dark:text-slate-400">
+            Zone:{" "}
+            <span className="font-mono text-slate-700 dark:text-slate-300">
+              {visiblePlan.zone_name}
+            </span>{" "}
+            ·{" "}
+            <span className="font-mono text-slate-500">
+              {visiblePlan.zone_id}
+            </span>
+          </div>
+        )}
+
+        {/* ── Loading state ────────────────────────────────────────── */}
+        {planLoading && (
+          <div className="flex items-center gap-2 rounded-md bg-slate-50 px-3 py-4 text-sm text-slate-600 dark:bg-slate-800/50 dark:text-slate-300">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Building plan…
+          </div>
+        )}
+
+        {/* ── Plan error ────────────────────────────────────────────── */}
+        {planError && !planLoading && (
+          <div className="rounded-md border border-rose-200 bg-rose-50 p-3 text-sm text-rose-800 dark:border-rose-800 dark:bg-rose-900/20 dark:text-rose-200">
+            <div className="flex items-start gap-2">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div>
+                <div className="font-medium">Could not build plan</div>
+                <div className="mt-1 text-xs">{planError}</div>
+              </div>
+            </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="mt-3"
+              onClick={fetchPlan}
+            >
+              Retry
+            </Button>
+          </div>
+        )}
+
+        {/* ── Plan visible (preview) ───────────────────────────────── */}
+        {visiblePlan && !planLoading && (
+          <>
+            <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              {hasApplied
+                ? "Executed actions"
+                : `Planned actions (${mutatingActionsCount} mutating)`}
+            </div>
+            {renderActions(visiblePlan.actions)}
+            {renderSkipped(visiblePlan.skipped)}
+          </>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/openresty-admin-next/src/components/servers/sections/DnsRecordTypeCard.tsx
+++ b/openresty-admin-next/src/components/servers/sections/DnsRecordTypeCard.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { Globe, AlertTriangle } from "lucide-react";
+import Card from "@/components/ui/Card";
+import Badge from "@/components/ui/Badge";
+
+/**
+ * "DNS Record Type" card — lives between the POPs picker and the DNS
+ * State panel on the server form.  Lets the operator choose which
+ * record type the provisioner manages for this server:
+ *
+ *   - **A**     : one A record per active POP (using public_ipv4).
+ *                 The default — backwards compatible with servers
+ *                 created before this field existed.
+ *   - **AAAA**  : one AAAA record per active POP (using public_ipv6).
+ *                 POPs without v6 set get skipped with reason
+ *                 "no_public_ipv6".
+ *   - **BOTH**  : A AND AAAA — dual-stack publishing.
+ *   - **CNAME** : ONE CNAME record pointing at `dns_cname_target`;
+ *                 POPs are not used.  Cannot coexist with A/AAAA on
+ *                 the same name (DNS spec).
+ *
+ * Why a separate card (not inline in NginxServerTab): the mode is a
+ * load-bearing routing decision that an operator wants to inspect at
+ * a glance — and CNAME mode needs a conditional target input, which
+ * gets noisy inline.
+ */
+
+type DnsRecordType = "A" | "AAAA" | "BOTH" | "CNAME";
+
+interface DnsRecordTypeCardProps {
+  value: DnsRecordType;
+  cnameTarget: string;
+  onChange: (type: DnsRecordType) => void;
+  onCnameTargetChange: (target: string) => void;
+  /** Show v6-only warning if no selected POP has public_ipv6 yet. */
+  selectedPopsHaveV6?: boolean;
+}
+
+const OPTIONS: Array<{
+  value: DnsRecordType;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "A",
+    label: "A — IPv4 per POP",
+    description:
+      "One A record per active POP using its public_ipv4.  Backwards-compatible default.",
+  },
+  {
+    value: "AAAA",
+    label: "AAAA — IPv6 per POP",
+    description:
+      "One AAAA record per active POP using its public_ipv6.  POPs without v6 set are skipped.",
+  },
+  {
+    value: "BOTH",
+    label: "BOTH — Dual-stack",
+    description:
+      "Publishes A AND AAAA records.  POPs without v6 still get an A record; the AAAA pass skips them.",
+  },
+  {
+    value: "CNAME",
+    label: "CNAME — Single hostname",
+    description:
+      "ONE CNAME pointing at the target hostname below.  POPs are ignored.  Cannot coexist with A/AAAA records on this name.",
+  },
+];
+
+export default function DnsRecordTypeCard({
+  value,
+  cnameTarget,
+  onChange,
+  onCnameTargetChange,
+  selectedPopsHaveV6,
+}: DnsRecordTypeCardProps) {
+  // Warn when AAAA/BOTH is selected but no chosen POP has IPv6 — the
+  // provisioner will skip every POP for the AAAA pass, which surprises
+  // operators who forgot to set public_ipv6 on the POPs.
+  const showV6Warning =
+    (value === "AAAA" || value === "BOTH") && selectedPopsHaveV6 === false;
+
+  return (
+    <Card>
+      <Card.Header>
+        <div className="flex flex-wrap items-center gap-2">
+          <Globe className="h-5 w-5 text-slate-500" />
+          <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+            DNS Record Type
+          </h3>
+          <Badge variant="info" size="sm">
+            {value}
+          </Badge>
+        </div>
+      </Card.Header>
+      <Card.Body>
+        <p className="mb-4 text-sm text-slate-600 dark:text-slate-400">
+          Choose how the provisioner should publish this server&apos;s domain
+          in Cloudflare.  The default <strong>A</strong> matches the legacy
+          behaviour and is the right choice for most setups.
+        </p>
+
+        {/* ── Radio grid ─────────────────────────────────────────────── */}
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+          {OPTIONS.map((opt) => {
+            const selected = value === opt.value;
+            return (
+              <label
+                key={opt.value}
+                className={
+                  "flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors " +
+                  (selected
+                    ? "border-primary-500 bg-primary-50 dark:border-primary-600 dark:bg-primary-900/20"
+                    : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800/50 dark:hover:border-slate-600 dark:hover:bg-slate-700/60")
+                }
+              >
+                <input
+                  type="radio"
+                  name="dns_record_type"
+                  value={opt.value}
+                  checked={selected}
+                  onChange={() => onChange(opt.value)}
+                  className="mt-0.5 h-4 w-4 border-slate-300 text-primary-600 focus:ring-2 focus:ring-primary-500"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100">
+                    {opt.label}
+                  </div>
+                  <div className="mt-0.5 text-xs text-slate-600 dark:text-slate-400">
+                    {opt.description}
+                  </div>
+                </div>
+              </label>
+            );
+          })}
+        </div>
+
+        {/* ── Conditional CNAME target input ─────────────────────────── */}
+        {value === "CNAME" && (
+          <div className="mt-4">
+            <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+              CNAME target <span className="text-rose-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={cnameTarget}
+              onChange={(e) => onCnameTargetChange(e.target.value)}
+              placeholder="edge.wslproxy.com"
+              className="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm placeholder:text-slate-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              required
+            />
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              The hostname this server&apos;s domain should point at.  Must
+              be an FQDN (no protocol, no trailing dot).  Cloudflare will
+              follow the CNAME chain on resolution.
+            </p>
+          </div>
+        )}
+
+        {/* ── Warnings ───────────────────────────────────────────────── */}
+        {showV6Warning && (
+          <div className="mt-4 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              <div className="font-medium">No POPs have IPv6 set</div>
+              <div className="mt-1 text-xs">
+                You picked <strong>{value}</strong> mode but none of your
+                selected POPs have <code>public_ipv6</code> configured.  The
+                provisioner will skip every POP for the AAAA pass.  Edit the
+                POP records (in <code>/pops</code>) to add IPv6 addresses, or
+                switch to <strong>A</strong> mode.
+              </div>
+            </div>
+          </div>
+        )}
+      </Card.Body>
+    </Card>
+  );
+}

--- a/openresty-admin-next/src/components/servers/sections/DnsStatePanel.tsx
+++ b/openresty-admin-next/src/components/servers/sections/DnsStatePanel.tsx
@@ -261,6 +261,22 @@ function DnsStateBody({
         />
       );
     }
+    if (code === "no_cname_target") {
+      return (
+        <InfoBanner
+          tone="warning"
+          title="CNAME target not set"
+          body={
+            <p>
+              You picked <strong>CNAME</strong> mode for this server but
+              haven&apos;t set the target hostname yet.  Scroll up to the{" "}
+              <strong>DNS Record Type</strong> card and fill in the
+              <em> CNAME target</em> input.
+            </p>
+          }
+        />
+      );
+    }
     if (code === "provider_error" || code === "network_error") {
       const zone = error.details?.zone;
       const cfHttp = error.details?.http_status;

--- a/openresty-admin-next/src/components/servers/sections/DnsStatePanel.tsx
+++ b/openresty-admin-next/src/components/servers/sections/DnsStatePanel.tsx
@@ -1,0 +1,524 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import type { Route } from "next";
+import {
+  Cloud,
+  RefreshCw,
+  PlayCircle,
+  AlertCircle,
+  ExternalLink,
+  ShieldCheck,
+  Eye,
+} from "lucide-react";
+import Card from "@/components/ui/Card";
+import Button from "@/components/ui/Button";
+import Badge from "@/components/ui/Badge";
+import { useDataProvider } from "@/hooks/useResource";
+import DnsProvisionDialog from "./DnsProvisionDialog";
+
+/**
+ * "DNS State (Cloudflare)" panel — lives on the server form.
+ *
+ * Shows the current Cloudflare records for `serverName`, annotated
+ * with which ones wslproxy manages.  Surfaces three operator
+ * actions:
+ *   1. Refresh — re-fetch from Cloudflare
+ *   2. Preview & Provision — opens DnsProvisionDialog (dry-run plan
+ *      first, then apply)
+ *   3. (implicit) "Configure DNS" link when the backend says the
+ *      dns block is missing
+ *
+ * Why this lives on the server form rather than its own page:
+ *   - DNS provisioning is per-server.  The state and actions are
+ *     meaningful only in the context of *this* server's pop_ids and
+ *     server_name.
+ *   - Operators editing pop_ids will want to immediately see the
+ *     DNS impact and apply it without navigating away.
+ *
+ * Hidden during create-mode — there's no persisted server to
+ * provision DNS for yet.  Once the server is saved, the panel
+ * appears on subsequent edits.
+ */
+
+interface Record {
+  id: string;
+  type: string;
+  name: string;
+  content: string;
+  ttl: number;
+  proxied: boolean;
+  comment?: string;
+  managed_by_wslproxy: boolean;
+  pop_id?: string;
+}
+
+interface LookupResult {
+  domain: string;
+  zone_id: string;
+  zone_name: string;
+  records: Record[];
+}
+
+// Matches the ApiError class thrown by apiFetch — fields are flat on
+// the error instance itself, not nested in `body`.  parseBackendError
+// extracts these from the backend's `{ error: { message, code,
+// details } }` envelope.
+interface ApiError {
+  message?: string;
+  code?: string;
+  status?: number;
+  details?: {
+    managed_zones?: string[];
+    /** Set on provider_error / network_error responses by
+     *  dns_manager.lua so the operator sees *which* zone CF refused. */
+    zone?: { name: string; id: string };
+    /** Cloudflare's underlying HTTP status (e.g. 403). */
+    http_status?: number;
+    /** Cloudflare's structured errors array. */
+    cloudflare_errors?: Array<{ code: number; message: string }>;
+  };
+}
+
+interface DnsStatePanelProps {
+  serverId: string;
+  profileId: string;
+  serverName: string;
+  popIds: string[];
+  isCreate: boolean;
+}
+
+export default function DnsStatePanel({
+  serverId,
+  profileId,
+  serverName,
+  popIds,
+  isCreate,
+}: DnsStatePanelProps) {
+  const dataProvider = useDataProvider();
+
+  const [lookup, setLookup] = useState<LookupResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<ApiError | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const fetchLookup = useCallback(async () => {
+    if (isCreate || !serverName) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await dataProvider.lookupDns(serverName, "A");
+      setLookup(res?.data ?? null);
+    } catch (err) {
+      setError(err as ApiError);
+      setLookup(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [dataProvider, serverName, isCreate]);
+
+  useEffect(() => {
+    void fetchLookup();
+  }, [fetchLookup]);
+
+  // Hide entirely in create mode — the rest of the form makes no
+  // sense to render here until the server has been persisted.
+  if (isCreate) return null;
+
+  return (
+    <>
+      <Card>
+        <Card.Header>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <Cloud className="h-5 w-5 text-slate-500" />
+              <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+                DNS State (Cloudflare)
+              </h3>
+              {lookup && (
+                <Badge variant="info" size="sm">
+                  {lookup.records.length} record
+                  {lookup.records.length === 1 ? "" : "s"}
+                </Badge>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={fetchLookup}
+                loading={loading}
+                icon={<RefreshCw className="h-4 w-4" />}
+              >
+                Refresh
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => setDialogOpen(true)}
+                disabled={popIds.length === 0 || Boolean(error)}
+                icon={<PlayCircle className="h-4 w-4" />}
+              >
+                Preview &amp; Provision
+              </Button>
+            </div>
+          </div>
+        </Card.Header>
+        <Card.Body>
+          <DnsStateBody
+            serverName={serverName}
+            popIds={popIds}
+            loading={loading}
+            error={error}
+            lookup={lookup}
+          />
+        </Card.Body>
+      </Card>
+
+      <DnsProvisionDialog
+        open={dialogOpen}
+        serverId={serverId}
+        profileId={profileId}
+        serverName={serverName}
+        onClose={() => setDialogOpen(false)}
+        onApplied={() => {
+          // Re-fetch lookup after a successful apply so the panel
+          // reflects the new state without requiring a page reload.
+          void fetchLookup();
+        }}
+      />
+    </>
+  );
+}
+
+// Extracted into a sub-component so the main panel's render stays
+// readable.  Branches on the operator-visible state machine: missing
+// config → zone not allowed → no POPs → loading → error → empty →
+// records.
+function DnsStateBody({
+  serverName,
+  popIds,
+  loading,
+  error,
+  lookup,
+}: {
+  serverName: string;
+  popIds: string[];
+  loading: boolean;
+  error: ApiError | null;
+  lookup: LookupResult | null;
+}) {
+  // ── Specific, helpful error states ──────────────────────────────
+  if (error) {
+    const code = error.code;
+    const message = error.message;
+    if (code === "not_configured" || code === "disabled") {
+      return (
+        <InfoBanner
+          tone="info"
+          title="DNS provisioning is not configured"
+          body={
+            <>
+              <p>{message}</p>
+              <p className="mt-2 text-xs">
+                Add a <code>dns</code> block to{" "}
+                <code className="rounded bg-slate-100 px-1 py-0.5 dark:bg-slate-800">
+                  data/settings.json
+                </code>{" "}
+                with your Cloudflare API token and the list of zones wslproxy
+                may write to.  See the README for the schema.
+              </p>
+            </>
+          }
+        />
+      );
+    }
+    if (code === "zone_not_allowed") {
+      const allowed = error.details?.managed_zones ?? [];
+      return (
+        <InfoBanner
+          tone="warning"
+          title={`No managed zone covers ${serverName}`}
+          body={
+            <>
+              <p>{message}</p>
+              {allowed.length > 0 && (
+                <div className="mt-2 text-xs">
+                  Currently allowed zones:{" "}
+                  {allowed.map((z, i) => (
+                    <span key={z}>
+                      <code className="rounded bg-slate-100 px-1 py-0.5 dark:bg-slate-800">
+                        {z}
+                      </code>
+                      {i < allowed.length - 1 ? ", " : ""}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </>
+          }
+        />
+      );
+    }
+    if (code === "provider_error" || code === "network_error") {
+      const zone = error.details?.zone;
+      const cfHttp = error.details?.http_status;
+      const cfErrors = error.details?.cloudflare_errors ?? [];
+      // Detect the placeholder zone_id (all zeros) explicitly — that's
+      // the most common reason new operators see "Authentication
+      // error" right after configuring the dns block.  Surface it as
+      // a clear "this is a placeholder, replace it" message rather
+      // than dumping the CF error.
+      const isPlaceholder =
+        zone?.id !== undefined && /^0+$/.test(zone.id);
+      const title = isPlaceholder
+        ? "Replace the placeholder zone in settings.json"
+        : code === "network_error"
+          ? "Could not reach Cloudflare"
+          : `Cloudflare rejected the request${cfHttp ? ` (HTTP ${cfHttp})` : ""}`;
+      return (
+        <InfoBanner
+          tone={isPlaceholder ? "info" : "warning"}
+          title={title}
+          body={
+            <div className="space-y-2">
+              {isPlaceholder ? (
+                <p>
+                  The configured zone_id for{" "}
+                  <code className="rounded bg-slate-100 px-1 py-0.5 dark:bg-slate-800">
+                    {zone?.name}
+                  </code>{" "}
+                  is a placeholder (<code>{zone?.id}</code>).  Cloudflare
+                  refused the lookup because no zone has that id.  Edit{" "}
+                  <code className="rounded bg-slate-100 px-1 py-0.5 dark:bg-slate-800">
+                    data/settings.json
+                  </code>{" "}
+                  → <code>dns.providers[0].managed_zones</code> and replace
+                  the placeholder with a real <code>zone_id</code> from your
+                  Cloudflare dashboard (copy from the right sidebar of the
+                  zone&apos;s overview page).
+                </p>
+              ) : (
+                <p>{message}</p>
+              )}
+              {zone && (
+                <div className="text-xs text-slate-700 dark:text-slate-300">
+                  Zone tried: <code>{zone.name}</code> ·{" "}
+                  <code className="text-slate-500">{zone.id}</code>
+                </div>
+              )}
+              {cfErrors.length > 0 && (
+                <div className="text-xs">
+                  Cloudflare said:{" "}
+                  {cfErrors.map((e, i) => (
+                    <span key={i}>
+                      <code className="rounded bg-slate-100 px-1 py-0.5 dark:bg-slate-800">
+                        {e.code}: {e.message}
+                      </code>
+                      {i < cfErrors.length - 1 ? ", " : ""}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          }
+        />
+      );
+    }
+    return (
+      <InfoBanner
+        tone="error"
+        title="Could not load DNS state"
+        body={<p>{message || "Unknown error"}</p>}
+      />
+    );
+  }
+
+  // ── Loading / empty pre-conditions ──────────────────────────────
+  if (loading && !lookup) {
+    return <p className="text-sm text-slate-500">Loading current records…</p>;
+  }
+
+  if (popIds.length === 0) {
+    return (
+      <InfoBanner
+        tone="info"
+        title="No POPs assigned"
+        body={
+          <p>
+            This server has no POPs assigned, so DNS provisioning has nothing
+            to publish.  Pick at least one POP in the section above to enable
+            this.
+          </p>
+        }
+      />
+    );
+  }
+
+  // ── Records visible ─────────────────────────────────────────────
+  if (lookup) {
+    const managed = lookup.records.filter((r) => r.managed_by_wslproxy);
+    const unmanaged = lookup.records.filter((r) => !r.managed_by_wslproxy);
+    return (
+      <div className="space-y-4">
+        <ZoneSummary zoneName={lookup.zone_name} zoneId={lookup.zone_id} />
+
+        {lookup.records.length === 0 && (
+          <p className="rounded-md bg-slate-50 px-3 py-2 text-sm text-slate-600 dark:bg-slate-800/50 dark:text-slate-400">
+            Cloudflare has no records for <code>{serverName}</code> yet.  Click
+            <strong> Preview &amp; Provision</strong> to publish A records for
+            this server&apos;s POPs.
+          </p>
+        )}
+
+        {managed.length > 0 && (
+          <RecordGroup
+            title="Managed by wslproxy"
+            badge="success"
+            description="These records were created by wslproxy and will be reconciled on each provision."
+            records={managed}
+          />
+        )}
+
+        {unmanaged.length > 0 && (
+          <RecordGroup
+            title="External records"
+            badge="default"
+            description="These records exist in Cloudflare but were NOT created by wslproxy.  They will never be modified or deleted by the provisioner."
+            records={unmanaged}
+          />
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ── Sub-components ───────────────────────────────────────────────────
+
+function ZoneSummary({ zoneName, zoneId }: { zoneName: string; zoneId: string }) {
+  // External link to the zone in Cloudflare's UI — handy for ops
+  // wanting to inspect a record directly.  Uses CF's known URL
+  // pattern; falls back gracefully if CF ever changes it (link
+  // breaks, but our UI doesn't).
+  const cfUrl = `https://dash.cloudflare.com/?to=/:account/${encodeURIComponent(zoneName)}/dns/records`;
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-md bg-slate-50 px-3 py-2 text-xs dark:bg-slate-800/50">
+      <span className="text-slate-600 dark:text-slate-400">Zone:</span>
+      <code className="font-mono text-slate-700 dark:text-slate-300">
+        {zoneName}
+      </code>
+      <span className="text-slate-400">·</span>
+      <code className="font-mono text-slate-500">{zoneId}</code>
+      <Link
+        href={cfUrl as Route}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="ml-auto inline-flex items-center gap-1 text-slate-500 hover:text-primary-600 dark:hover:text-primary-400"
+      >
+        Open in Cloudflare <ExternalLink className="h-3 w-3" />
+      </Link>
+    </div>
+  );
+}
+
+function RecordGroup({
+  title,
+  badge,
+  description,
+  records,
+}: {
+  title: string;
+  badge: "success" | "default";
+  description: string;
+  records: Record[];
+}) {
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-400">
+          {title}
+        </span>
+        <Badge variant={badge} size="sm">
+          {records.length}
+        </Badge>
+      </div>
+      <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+        {description}
+      </p>
+      <div className="space-y-1.5">
+        {records.map((r) => (
+          <RecordRow key={r.id} record={r} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RecordRow({ record }: { record: Record }) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-md border border-slate-200 bg-white px-3 py-2 text-xs dark:border-slate-700 dark:bg-slate-800/50">
+      <Badge variant="default" size="sm">
+        {record.type}
+      </Badge>
+      <code className="font-mono font-semibold text-slate-700 dark:text-slate-300">
+        {record.content}
+      </code>
+      {record.pop_id && (
+        <Badge variant="info" size="sm">
+          pop={record.pop_id}
+        </Badge>
+      )}
+      <span className="text-slate-500">TTL {record.ttl}s</span>
+      {record.proxied && (
+        <Badge variant="warning" size="sm">
+          proxied
+        </Badge>
+      )}
+      {record.managed_by_wslproxy && (
+        <span className="ml-auto inline-flex items-center gap-1 text-emerald-700 dark:text-emerald-400">
+          <ShieldCheck className="h-3 w-3" />
+          managed
+        </span>
+      )}
+      {!record.managed_by_wslproxy && (
+        <span className="ml-auto inline-flex items-center gap-1 text-slate-500">
+          <Eye className="h-3 w-3" />
+          external
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Generic info/warning/error banner used across the panel's states.
+// Kept here (not in the ui/ kit) because the specific styling is
+// scoped to this panel's needs.
+function InfoBanner({
+  tone,
+  title,
+  body,
+}: {
+  tone: "info" | "warning" | "error";
+  title: string;
+  body: React.ReactNode;
+}) {
+  const colours = {
+    info: "border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-200",
+    warning:
+      "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200",
+    error:
+      "border-rose-200 bg-rose-50 text-rose-900 dark:border-rose-800 dark:bg-rose-900/20 dark:text-rose-200",
+  }[tone];
+  return (
+    <div className={`flex items-start gap-2 rounded-md border p-3 ${colours}`}>
+      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+      <div className="text-sm">
+        <div className="font-medium">{title}</div>
+        <div className="mt-1 text-xs">{body}</div>
+      </div>
+    </div>
+  );
+}

--- a/openresty-admin-next/src/components/servers/sections/PopMultiSelect.tsx
+++ b/openresty-admin-next/src/components/servers/sections/PopMultiSelect.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useMemo } from "react";
+import Link from "next/link";
+import type { Route } from "next";
+import { Globe2, AlertCircle, ExternalLink } from "lucide-react";
+import Card from "@/components/ui/Card";
+import Badge from "@/components/ui/Badge";
+import { cn } from "@/lib/utils/cn";
+import type { Pop } from "@/types";
+
+interface PopMultiSelectProps {
+  /** All available POPs, fetched by the parent via `useList`.
+   *  Display ordering: active first, then by region/id. */
+  pops: Pop[];
+  /** Currently selected pop ids. */
+  value: string[];
+  onChange: (next: string[]) => void;
+  /** Show a small inline loading hint when the parent is fetching. */
+  isLoading?: boolean;
+  /** Disable the whole control (e.g. while the parent form is
+   *  submitting). */
+  disabled?: boolean;
+}
+
+/**
+ * Multi-select POP picker for the server form.
+ *
+ * Renders a checkbox grid grouped by region.  Each row shows the
+ * POP's display name, public IPv4, and a status badge — operators
+ * need to see those at a glance when deciding whether to attach a
+ * POP (you don't want to assign a server to a POP that's `down`).
+ *
+ * Why a custom component rather than a generic multi-select widget:
+ *  - The decision is domain-specific: status, region, IP matter.
+ *  - A bare `TagInput` of pop ids hides exactly the data the
+ *    operator needs to make a good choice.
+ *  - Grouping by region scales naturally as the fleet grows from 2
+ *    POPs to 20.
+ */
+export default function PopMultiSelect({
+  pops,
+  value,
+  onChange,
+  isLoading,
+  disabled,
+}: PopMultiSelectProps) {
+  // Memoise the grouping + sorting so we don't rebuild on every
+  // keystroke in the parent form.  Group by region, with an
+  // "Unassigned" bucket for POPs that have no region set; sort each
+  // bucket alphabetically by id; sort active POPs above
+  // draining/down/maintenance so they're the natural pick.
+  const grouped = useMemo(() => {
+    const byRegion = new Map<string, Pop[]>();
+    for (const p of pops) {
+      const key = p.region || "Unassigned";
+      if (!byRegion.has(key)) byRegion.set(key, []);
+      byRegion.get(key)!.push(p);
+    }
+    const statusOrder: Record<NonNullable<Pop["status"]>, number> = {
+      active: 0,
+      draining: 1,
+      maintenance: 2,
+      down: 3,
+    };
+    for (const arr of byRegion.values()) {
+      arr.sort((a, b) => {
+        const sa = statusOrder[a.status ?? "active"];
+        const sb = statusOrder[b.status ?? "active"];
+        if (sa !== sb) return sa - sb;
+        return a.id.localeCompare(b.id);
+      });
+    }
+    return Array.from(byRegion.entries()).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+  }, [pops]);
+
+  const selectedSet = useMemo(() => new Set(value), [value]);
+
+  const toggle = (popId: string) => {
+    if (disabled) return;
+    const next = selectedSet.has(popId)
+      ? value.filter((id) => id !== popId)
+      : [...value, popId];
+    onChange(next);
+  };
+
+  // ── Empty / loading states ─────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <Card>
+        <Card.Header>
+          <div className="flex items-center gap-2">
+            <Globe2 className="h-5 w-5 text-slate-500" />
+            <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+              POPs (Points of Presence)
+            </h3>
+          </div>
+        </Card.Header>
+        <Card.Body>
+          <p className="text-sm text-slate-500">Loading POPs…</p>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  if (pops.length === 0) {
+    return (
+      <Card>
+        <Card.Header>
+          <div className="flex items-center gap-2">
+            <Globe2 className="h-5 w-5 text-slate-500" />
+            <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+              POPs (Points of Presence)
+            </h3>
+          </div>
+        </Card.Header>
+        <Card.Body>
+          <div className="flex items-start gap-3 rounded-md bg-amber-50 p-3 dark:bg-amber-900/20">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+            <div className="space-y-2 text-sm">
+              <p className="text-amber-900 dark:text-amber-200">
+                No POPs are defined yet.  This server will fall back to the
+                profile default when DNS is provisioned — fine for now, but
+                you&apos;ll want to define your edge locations explicitly
+                before enabling multi-POP routing.
+              </p>
+              <Link
+                href={"/pops/create" as Route}
+                className="inline-flex items-center gap-1 text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400"
+              >
+                Create your first POP{" "}
+                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+              </Link>
+            </div>
+          </div>
+        </Card.Body>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <Card.Header>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Globe2 className="h-5 w-5 text-slate-500" />
+            <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+              POPs (Points of Presence)
+            </h3>
+            {value.length > 0 && (
+              <Badge variant="info" size="sm">
+                {value.length} selected
+              </Badge>
+            )}
+          </div>
+          <Link
+            href={"/pops" as Route}
+            className="inline-flex items-center gap-1 text-xs text-slate-500 hover:text-primary-600 dark:hover:text-primary-400"
+          >
+            Manage POPs <ExternalLink className="h-3 w-3" aria-hidden="true" />
+          </Link>
+        </div>
+      </Card.Header>
+      <Card.Body>
+        <p className="mb-4 text-sm text-slate-600 dark:text-slate-400">
+          Pick which POPs should serve this domain.  The DNS provisioner uses
+          this list to decide which A records to publish at Cloudflare for{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-xs dark:bg-slate-800">
+            {/* server_name displayed by caller via context — leaving placeholder generic */}
+            the server&apos;s domain
+          </code>
+          .  Empty = fall back to profile defaults.
+        </p>
+
+        <div className="space-y-4">
+          {grouped.map(([region, regionPops]) => (
+            <div key={region}>
+              <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                {region}
+                <span className="text-slate-400">·</span>
+                <span className="font-normal normal-case">
+                  {regionPops.length} POP{regionPops.length === 1 ? "" : "s"}
+                </span>
+              </div>
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                {regionPops.map((p) => {
+                  const selected = selectedSet.has(p.id);
+                  const status = (p.status ?? "active") as NonNullable<
+                    Pop["status"]
+                  >;
+                  // Down POPs are technically pickable — operators might
+                  // assign during planned recovery — but we visually
+                  // dim them so the eye flags the unusual choice.
+                  const isInactive = status === "down";
+                  return (
+                    <label
+                      key={p.id}
+                      className={cn(
+                        "flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors",
+                        selected
+                          ? // Selected: tinted background with primary border in both modes
+                            "border-primary-500 bg-primary-50 dark:border-primary-600 dark:bg-primary-900/20"
+                          : // Unselected: light mode lifts to a soft grey on hover; dark
+                            // mode lifts to a slightly brighter slate.  Without
+                            // `dark:hover:bg-slate-700/60`, the `hover:bg-slate-50` from the
+                            // light variant leaks into dark mode and renders near-white.
+                            "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800/50 dark:hover:border-slate-600 dark:hover:bg-slate-700/60",
+                        isInactive && "opacity-60",
+                        disabled && "cursor-not-allowed",
+                      )}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selected}
+                        onChange={() => toggle(p.id)}
+                        disabled={disabled}
+                        className="mt-0.5 h-4 w-4 rounded border-slate-300 text-primary-600 focus:ring-2 focus:ring-primary-500 dark:border-slate-600 dark:bg-slate-700"
+                        aria-label={`Select POP ${p.display_name}`}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-mono text-sm font-semibold text-slate-900 dark:text-slate-100">
+                            {p.id}
+                          </span>
+                          <Badge
+                            variant={
+                              status === "active"
+                                ? "success"
+                                : status === "draining"
+                                  ? "warning"
+                                  : status === "down"
+                                    ? "danger"
+                                    : "info"
+                            }
+                            size="sm"
+                          >
+                            {status}
+                          </Badge>
+                          {p.capacity_weight !== undefined &&
+                            p.capacity_weight !== null &&
+                            p.capacity_weight !== 1 && (
+                              <Badge variant="default" size="sm">
+                                weight {Math.round(p.capacity_weight * 100)}%
+                              </Badge>
+                            )}
+                        </div>
+                        <div className="mt-0.5 truncate text-xs text-slate-600 dark:text-slate-400">
+                          {p.display_name}
+                        </div>
+                        <div className="mt-0.5 truncate font-mono text-xs text-slate-500 dark:text-slate-500">
+                          {p.public_ipv4}
+                          {p.city && (
+                            <span className="ml-2 text-slate-400">
+                              · {p.city}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {value.length === 0 && (
+          <p className="mt-4 rounded-md bg-slate-50 px-3 py-2 text-xs text-slate-500 dark:bg-slate-800/50 dark:text-slate-400">
+            No POPs selected — this server will use the profile default for DNS
+            routing.  Tick at least one POP above to control DNS explicitly.
+          </p>
+        )}
+      </Card.Body>
+    </Card>
+  );
+}

--- a/openresty-admin-next/src/components/servers/sections/PopMultiSelect.tsx
+++ b/openresty-admin-next/src/components/servers/sections/PopMultiSelect.tsx
@@ -251,6 +251,11 @@ export default function PopMultiSelect({
                         </div>
                         <div className="mt-0.5 truncate font-mono text-xs text-slate-500 dark:text-slate-500">
                           {p.public_ipv4}
+                          {p.public_ipv6 && (
+                            <span className="ml-2 text-slate-400">
+                              · v6 {p.public_ipv6}
+                            </span>
+                          )}
                           {p.city && (
                             <span className="ml-2 text-slate-400">
                               · {p.city}

--- a/openresty-admin-next/src/components/servers/types.ts
+++ b/openresty-admin-next/src/components/servers/types.ts
@@ -38,6 +38,10 @@ export interface ServerFormState {
    *  Empty array = unassigned; the DNS provisioner falls back to a
    *  profile-default list when this is empty. */
   pop_ids: string[];
+  /** Which DNS record type the provisioner manages.  Default "A". */
+  dns_record_type: "A" | "AAAA" | "BOTH" | "CNAME";
+  /** Required when dns_record_type === "CNAME". */
+  dns_cname_target: string;
   servers_tags: string[];
   root: string;
   index: string;

--- a/openresty-admin-next/src/components/servers/types.ts
+++ b/openresty-admin-next/src/components/servers/types.ts
@@ -34,6 +34,10 @@ export interface ServerFormState {
   server_name: string;
   proxy_server_name: string;
   profile_id: string;
+  /** POPs (Points of Presence) this server should be served from.
+   *  Empty array = unassigned; the DNS provisioner falls back to a
+   *  profile-default list when this is empty. */
+  pop_ids: string[];
   servers_tags: string[];
   root: string;
   index: string;

--- a/openresty-admin-next/src/lib/api/data-provider.ts
+++ b/openresty-admin-next/src/lib/api/data-provider.ts
@@ -460,6 +460,75 @@ export const dataProvider: DataProvider = {
       body: JSON.stringify({ ...(data as Record<string, unknown>), profile: getEnvProfile(), timestamp: Date.now() }),
     }),
 
+  // ── DNS Manager (Cloudflare provisioning) ──────────────────────────
+  // Thin wrappers around the dns_manager.lua endpoints.  The dialog
+  // / state panel call these directly via useDataProvider() so error
+  // handling + response shapes stay consistent with the rest of the
+  // data layer.  Both return the standard `{data: ...}` envelope on
+  // success; on error apiFetch throws an ApiError that components
+  // catch for inline rendering.
+
+  lookupDns: (domain: string, recordType?: string) => {
+    const qs = new URLSearchParams({ domain });
+    if (recordType) qs.set("type", recordType);
+    return apiFetch<{
+      data: {
+        domain: string;
+        zone_id: string;
+        zone_name: string;
+        records: Array<{
+          id: string;
+          type: string;
+          name: string;
+          content: string;
+          ttl: number;
+          proxied: boolean;
+          comment?: string;
+          managed_by_wslproxy: boolean;
+          pop_id?: string;
+        }>;
+      };
+    }>(`/dns/lookup?${qs.toString()}`);
+  },
+
+  provisionDns: (opts: {
+    server_id: string;
+    profile_id: string;
+    dry_run?: boolean;
+    include_inactive?: boolean;
+    record_type?: string;
+  }) =>
+    apiFetch<{
+      data: {
+        domain: string;
+        zone_id: string;
+        zone_name: string;
+        dry_run?: boolean;
+        actions: Array<{
+          action:
+            | "created"
+            | "updated"
+            | "unchanged"
+            | "deleted"
+            | "deleted_legacy"
+            | "create"
+            | "update"
+            | "delete"
+            | "delete_legacy"
+            | "error";
+          pop_id?: string;
+          content?: string;
+          from_content?: string;
+          record_id?: string;
+          error?: string;
+        }>;
+        skipped: Array<{ pop_id: string; reason: string }>;
+      };
+    }>("/dns/provision", {
+      method: "POST",
+      body: JSON.stringify(opts),
+    }),
+
   syncAPI: async () => {
     const frontUrl = getWithDefault(STORAGE_KEYS.frontUrl, "");
     if (!frontUrl) return;

--- a/openresty-admin-next/src/types/index.ts
+++ b/openresty-admin-next/src/types/index.ts
@@ -69,6 +69,12 @@ export interface Server {
   error_log?: string;
   rules?: string[];
   match_cases?: { statement: string; condition: string }[];
+  /** Ordered list of POP ids that should serve this domain.  Read by
+   *  the DNS provisioner to know which IPs to publish as A records
+   *  for `server_name`.  Empty / absent = "no opinion" — the
+   *  provisioner falls back to the profile's default POPs.
+   *  See `api/pops.lua` and `data/pops/{id}.json`. */
+  pop_ids?: string[];
   locations?: LocationBlock[];
   custom_headers?: { header_key: string; header_value: string }[];
   custom_response_headers?: { header_key: string; header_value: string }[];
@@ -222,6 +228,38 @@ export interface Profile {
   name: string;
   description?: string;
   created_at?: number;
+}
+
+/** A POP (Point of Presence) — a physical edge location running
+ *  wslproxy.  Global (not profile-scoped) — a POP is physical
+ *  infrastructure shared by every profile that references it.
+ *
+ *  Mirrors the on-disk schema at `data/pops/{id}.json` and the Lua
+ *  module's validation rules (`api/pops.lua`). */
+export interface Pop {
+  id: string;
+  display_name: string;
+  region?: string;
+  country_code?: string;
+  city?: string;
+  lat?: number;
+  lng?: number;
+  public_ipv4: string;
+  public_ipv6?: string | null;
+  internal_hostname?: string;
+  /** `active` = in rotation; `draining` = no new traffic, finishing
+   *  in-flight; `down` = unplanned outage (pages oncall); `maintenance`
+   *  = planned outage (does not page). */
+  status?: "active" | "draining" | "down" | "maintenance";
+  /** 0.0-1.0 multiplier for traffic share when this POP is in a
+   *  weighted DNS pool.  Set to 0 to drain via the routing layer
+   *  without changing `status`. */
+  capacity_weight?: number;
+  provider?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  created_at?: number;
+  updated_at?: number;
 }
 
 export interface Bookmark {

--- a/openresty-admin-next/src/types/index.ts
+++ b/openresty-admin-next/src/types/index.ts
@@ -75,6 +75,19 @@ export interface Server {
    *  provisioner falls back to the profile's default POPs.
    *  See `api/pops.lua` and `data/pops/{id}.json`. */
   pop_ids?: string[];
+  /** DNS record type the provisioner should manage for this server's
+   *  domain.  Defaults to `"A"` (one A record per active POP using
+   *  `public_ipv4`).  `"AAAA"` uses `public_ipv6` instead; `"BOTH"`
+   *  publishes both (dual-stack); `"CNAME"` publishes a single CNAME
+   *  record pointing at `dns_cname_target` (POPs are ignored).  See
+   *  POPS_AND_DNS_GUIDE.md for when to use each. */
+  dns_record_type?: "A" | "AAAA" | "BOTH" | "CNAME";
+  /** Required when `dns_record_type === "CNAME"`: the hostname this
+   *  server's domain should point at via a CNAME record.  Ignored in
+   *  other modes.  CNAME records cannot coexist with A/AAAA records
+   *  at the same name (DNS spec), so picking CNAME removes any
+   *  A/AAAA records wslproxy was managing for this domain. */
+  dns_cname_target?: string;
   locations?: LocationBlock[];
   custom_headers?: { header_key: string; header_value: string }[];
   custom_response_headers?: { header_key: string; header_value: string }[];

--- a/resolver.conf.tmpl
+++ b/resolver.conf.tmpl
@@ -1,3 +1,7 @@
 #resolver 1.1.1.1;  # Cloudflare resolver
 #resolver OPSAPI Dashboard;  # Google resolver
-resolver 127.0.0.11;  # Docker resolver
+# `ipv6=off` is required: Docker's DNS bridge returns AAAA records for
+# external hosts like api.cloudflare.com, but the bridge network has
+# no v6 route, so lua-resty-http connect() fails with
+# `Network unreachable`.  Forcing v4-only resolution avoids that.
+resolver 127.0.0.11 ipv6=off;  # Docker resolver


### PR DESCRIPTION
## Summary

Introduces **POPs (Points of Presence)** as a first-class entity in wslproxy plus **end-to-end Cloudflare DNS provisioning** with hard safety guardrails. Operators declare which POPs serve a domain on the server form; the dashboard's **Preview & Provision** button (or the equivalent MCP / REST call) converges Cloudflare A / AAAA / CNAME records to match — without ever touching records wslproxy didn't create.

**Headline numbers:** 26 files, +5,553 / −5, 7 commits, no breaking changes (every existing server reads as `dns_record_type: "A"` on first edit — same behaviour as before).

## What you get

### Backend
- **`api/pops.lua`** (new) — CRUD module for POPs with validation, audit log, cascade-detach on force-delete (aborts if any referencing server can't be safely rewritten — never leaves a dangling pop_id).
- **`api/dns_manager.lua`** (new) — Cloudflare provider abstraction with a `managed_zones` allowlist (refuses any unlisted zone before any HTTP call). Idempotent ensure_record + 3-stage orchestrator (plan / inventory / converge). Records stamped with `wslproxy-managed | server=… | profile=… | pop=…` comment so hand-curated records are never touched.
- **Four record-type modes**: `A` (default), `AAAA`, `BOTH` (dual-stack), `CNAME`. Each action carries its own `record_type` so BOTH mode routes mixed plans correctly.
- **`api/api.lua`** — REST endpoints (`/api/pops/*`, `/api/dns/lookup`, `/api/dns/provision`) with nested `{error: {message, code, status, details}}` envelopes that the dashboard's parser handles.

### Dashboard
- **`/pops` route** — list + create/edit/delete page with status badges, capacity weight, force-delete dialog showing referencing servers.
- **POPs picker** on the server form (region-grouped checkbox grid with status / IP / weight; shows IPv6 next to IPv4 when set).
- **DNS Record Type card** — radio-grid selector for A / AAAA / BOTH / CNAME, conditional CNAME-target input, amber warning when AAAA/BOTH is picked but no chosen POP has `public_ipv6`.
- **DNS State panel** — calls `/api/dns/lookup` on mount; branches across 7+ states (not_configured / zone_not_allowed / no_cname_target / placeholder_zone / network_error / provider_error / records_visible) with operator-actionable banners.
- **Preview & Provision dialog** — two-phase modal: dry-run plan with action icons → apply → in-place results.

### MCP (Model Context Protocol) — 7 new tools
- `list_pops`, `get_pop`, `create_pop`, `update_pop`, `delete_pop`, `lookup_dns`, `provision_dns`
- `provision_dns` **defaults to dry-run** so an AI agent always shows the plan first; applying requires an explicit follow-up call.
- See [api/mcp/README.md](api/mcp/README.md) for the full client integration (Claude Desktop, Claude Code, Cursor, Continue.dev).

### Production deploy
- **Ansible seed** (`infra/ansible/roles/wslproxy/tasks/seed_pops.yml`) — idempotent. Uses `force: no` so dashboard edits and operator-created POPs survive role re-runs.
- Default `wslproxy_pops` variable seeds `pop0` (187.124.112.155, Hetzner/London) + `lon1` (72.62.211.28, Vultr/London).
- TLS trust store (`lua_ssl_trusted_certificate`) added to **both** dev and prod nginx templates per CLAUDE.md §6.
- IPv6 resolver fix (`ipv6=off`) in `resolver.conf.tmpl` so Docker bridge AAAA records don't fail with `Network unreachable`.

### Docs (for non-technical operators)
- **`POPS_AND_DNS_GUIDE.md`** (new, repo root) — end-to-end guide covering the mental model ("Save = wslproxy state; Provision = Cloudflare state"), Cloudflare token generation walkthrough, settings.json configuration, the four record-type modes with examples, day-to-day operations cheatsheet, troubleshooting, and a 10-question FAQ.

## Safety guarantees (five hard guardrails)

1. **`managed_zones` allowlist** — domains outside refuse before any HTTP call.
2. **`wslproxy-managed` comment marker** — only modifies records wslproxy created itself.
3. **POPs in down/maintenance are skipped by default**; `include_inactive: true` required to override.
4. **`dry_run: true` is the default for the MCP `provision_dns` tool** — apply requires explicit `dry_run: false`.
5. **POP deletion refuses while in use**; `force: true` cascade-detaches and aborts if any server can't be safely rewritten.

## Verified end-to-end

- Cloudflare API token validates, settings.json schema accepted by the orchestrator
- Real HTTPS round-trip to `api.cloudflare.com` works (TLS trust store + IPv6 fix in place)
- Provider errors flow back as structured 502s with zone context + Cloudflare error code in `details`
- All four record-type modes (A / AAAA / BOTH / CNAME) dispatch correctly; invalid types return 400 before any CF call
- CNAME without target returns 400 `no_cname_target` (was 500 before — added to error map)
- `dns_record_type` and `dns_cname_target` persist correctly on server JSON; orchestrator picks them up when `record_type` isn't passed explicitly
- All 7 new MCP tools registered (25 total); read flow + write flow + dry-run gating all work
- Ansible seed renders JSON that passes `pops.lua` `validate()` cleanly with `metadata: {}` and `tags: []` shapes
- Dashboard pages (`/pops`, `/servers/<id>`) render 200; HMR clean across all edits

## Test plan

- [ ] Configure Cloudflare token in `data/settings.json` (`dns.providers[0].api_token` + `managed_zones`)
- [ ] Reload OpenResty (`docker exec wslproxy-local /usr/local/openresty/bin/openresty -s reload`)
- [ ] Verify `/pops` lists `pop0` + `lon1` (seeded automatically if Ansible-deployed; manual create otherwise)
- [ ] Open any server, scroll to "POPs" section → tick POPs → Save
- [ ] Confirm "DNS State (Cloudflare)" card auto-loads current records
- [ ] Click **Preview & Provision** → review the action plan → click **Apply N changes**
- [ ] Verify records appear in Cloudflare dashboard with `wslproxy-managed` comment
- [ ] Try **AAAA** mode → confirm AAAA records published using `public_ipv6` from POPs
- [ ] Try **BOTH** mode → confirm A AND AAAA appear
- [ ] Try **CNAME** mode → confirm A records cleaned up, single CNAME published
- [ ] Try **force-delete a POP** with referencing servers — confirm cascade-detach works
- [ ] Connect Claude Desktop / Code via MCP → ask "list POPs" → ask "provision DNS for X" → verify dry-run plan + apply gate

## Commits

```
18f912a1  docs(pops/dns): two-move model + day-to-day operations cheatsheet
12940c4a  feat(dns): AAAA + BOTH + CNAME record support
7290401c  feat(ansible/pops): idempotent POPs seed on deploy + guide section
951376ac  docs(pops/dns): comprehensive POPs + Cloudflare DNS guide
13341065  feat(mcp): add POPs CRUD + Cloudflare DNS provisioning tools
cd90ac8b  fix(pops/dns): high-severity findings from code-review
a512e9fa  feat(pops/dns): add POPs as first-class entities + Cloudflare DNS provisioning
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)