### PR TITLE
fix(types): production build TS errors from pops/dns PR

### DIFF
--- a/openresty-admin-next/src/app/(dashboard)/pops/[id]/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/pops/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
+import type { Route } from "next";
 import {
   ArrowLeft,
   Save,
@@ -213,7 +214,7 @@ export default function PopDetailPage() {
         await dataProvider.update("pops", id, payload);
         notify("POP updated", { type: "success" });
       }
-      router.push("/pops");
+      router.push("/pops" as Route);
     } catch (err) {
       handleApiError(err, "Failed to save POP");
     } finally {
@@ -277,7 +278,7 @@ export default function PopDetailPage() {
         notify(force ? "POP force-deleted" : "POP deleted", {
           type: "success",
         });
-        router.push("/pops");
+        router.push("/pops" as Route);
       } catch (err) {
         const errObj = err as {
           message?: string;
@@ -346,7 +347,7 @@ export default function PopDetailPage() {
           <div className="flex items-center gap-2">
             <Button
               variant="ghost"
-              onClick={() => router.push("/pops")}
+              onClick={() => router.push("/pops" as Route)}
               icon={<ArrowLeft className="h-4 w-4" />}
             >
               Back

--- a/openresty-admin-next/src/components/ui/ConfirmDialog.tsx
+++ b/openresty-admin-next/src/components/ui/ConfirmDialog.tsx
@@ -9,7 +9,12 @@ export interface ConfirmDialogProps {
   onConfirm: () => void;
   onCancel: () => void;
   title?: string;
-  message?: string;
+  /** String for simple confirmations; ReactNode when the caller needs
+   *  rich content (e.g. a list of affected items, an inline warning
+   *  card).  When a non-string is passed we render it inside a <div>
+   *  instead of <p> so block-level children don't generate invalid
+   *  HTML — see pops/[id]/page.tsx's force-delete dialog. */
+  message?: React.ReactNode;
   confirmLabel?: string;
   confirmVariant?: "primary" | "danger" | "secondary" | "ghost";
   loading?: boolean;
@@ -45,7 +50,15 @@ const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
         </>
       }
     >
-      <p className="text-sm text-slate-600 dark:text-slate-400">{message}</p>
+      {typeof message === "string" ? (
+        <p className="text-sm text-slate-600 dark:text-slate-400">{message}</p>
+      ) : (
+        // ReactNode messages may contain block-level children (divs,
+        // lists, etc.) which are invalid inside a <p>; wrap in <div>.
+        <div className="text-sm text-slate-600 dark:text-slate-400">
+          {message}
+        </div>
+      )}
     </Dialog>
   );
 };

--- a/openresty-admin-next/src/types/index.ts
+++ b/openresty-admin-next/src/types/index.ts
@@ -712,6 +712,64 @@ export interface DataProvider {
   pushDataServers(resource: string, data: unknown): Promise<SingleResult>;
   syncAPI(): Promise<void>;
 
+  // DNS Manager (Cloudflare provisioning).  Thin wrappers around
+  // /api/dns/lookup and /api/dns/provision — return shapes match
+  // what dns_manager.lua emits, see POPS_AND_DNS_GUIDE.md.
+  lookupDns(
+    domain: string,
+    recordType?: string,
+  ): Promise<{
+    data: {
+      domain: string;
+      zone_id: string;
+      zone_name: string;
+      records: Array<{
+        id: string;
+        type: string;
+        name: string;
+        content: string;
+        ttl: number;
+        proxied: boolean;
+        comment?: string;
+        managed_by_wslproxy: boolean;
+        pop_id?: string;
+      }>;
+    };
+  }>;
+  provisionDns(opts: {
+    server_id: string;
+    profile_id: string;
+    dry_run?: boolean;
+    include_inactive?: boolean;
+    record_type?: string;
+  }): Promise<{
+    data: {
+      domain: string;
+      zone_id: string;
+      zone_name: string;
+      dry_run?: boolean;
+      actions: Array<{
+        action:
+          | "created"
+          | "updated"
+          | "unchanged"
+          | "deleted"
+          | "deleted_legacy"
+          | "create"
+          | "update"
+          | "delete"
+          | "delete_legacy"
+          | "error";
+        pop_id?: string;
+        content?: string;
+        from_content?: string;
+        record_id?: string;
+        error?: string;
+      }>;
+      skipped: Array<{ pop_id: string; reason: string }>;
+    };
+  }>;
+
   // Change requests
   getChangeRequests(params?: ListParams): Promise<ListResult<ChangeRequest>>;
   getPendingCRCount(): Promise<{ count: number }>;


### PR DESCRIPTION
## Summary

Fixes the three TypeScript errors that broke `next build` after #1072 merged.  CI deploy to int failed on commit `fecad8ae` ([run 27760923988](https://github.com/bwalia/wslproxy/actions/runs/27760923988)) — dev-mode HMR tolerated these but the production build runs strict type checks.

## Errors fixed

| File | Error | Fix |
|---|---|---|
| `src/types/index.ts` | `Property 'lookupDns' does not exist on type 'DataProvider'` (×3 sites) | Added typed `lookupDns()` + `provisionDns()` to the `DataProvider` interface, matching the runtime shapes in `data-provider.ts` |
| `src/components/ui/ConfirmDialog.tsx` | `Type 'string \| Element' is not assignable to type 'string \| undefined'` | Widened `message` prop to `React.ReactNode`; conditionally render `<div>` wrapper when message isn't a string (avoids invalid block-in-`<p>` HTML) |
| `src/app/(dashboard)/pops/[id]/page.tsx` | `Argument of type '"/pops"' is not assignable to parameter of type 'RouteImpl<"/pops">'` (×3 sites) | Imported `Route` from "next"; cast each `router.push("/pops" as Route)` — same pattern used in servers/[id]/page.tsx |

## Verified

- `npx tsc --noEmit` — clean, no errors
- `npx next build` — completes successfully through the full static + dynamic route manifest
- No runtime behaviour change; all fixes are purely type-level + invalid-HTML protection in ConfirmDialog

## Test plan

- [ ] CI build passes (was the failing step)
- [ ] Re-run deploy-int — should succeed where the previous run failed
- [ ] Open `/pops/<id>` in the dashboard, click Delete, verify the rich force-delete dialog still renders correctly