### PR TITLE
fix(ci): reclaim runner workspace ownership before checkout

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -88,6 +88,21 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      # Self-hosted runners reuse their workspace between jobs. A prior
+      # job (e.g. a Dockerized build) can leave root-owned files such as
+      # openresty-admin-next/.next, which actions/checkout — running as
+      # the runner user — cannot delete when it cleans the workspace.
+      # That fails the whole job at "Checkout code" (EACCES unlink). The
+      # runner deploys sequentially on a shared host, so the failure
+      # recurs every time a Next.js build precedes another deploy on the
+      # same runner. Reclaim ownership before checkout so the clean step
+      # always succeeds. No-op on a fresh/empty workspace.
+      - name: Reclaim runner workspace ownership
+        run: |
+          if [ -n "$GITHUB_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Problem

`deploy-prod-lon1` (and any deploy leg) intermittently fails at **Checkout code** with:

```
EACCES: permission denied, unlink '.../openresty-admin-next/.next/BUILD_ID'
Unable to clean or reset the repository. The repository will be recreated instead.
```

Self-hosted deploy jobs **share a runner workspace** between runs (e.g. `srv1467484` on the shared host runs pop0 **then** lon1 sequentially). A prior job can leave **root-owned** files (notably `openresty-admin-next/.next` from a Dockerized build). `actions/checkout`, running as the runner user (`bwalia`), can't `unlink` them when cleaning the workspace, so the job dies before Ansible even starts. Re-running doesn't help — the preceding Next.js build recreates the root-owned files every time.

## Fix

Add a pre-checkout step that `sudo chown -R`s `$GITHUB_WORKSPACE` back to the runner user, so the checkout clean step always succeeds. No-op on a fresh workspace; tolerant of missing sudo (`|| true`).

```yaml
- name: Reclaim runner workspace ownership
  run: |
    if [ -n "$GITHUB_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE" ]; then
      sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
    fi
```

## Notes

- Applies to every job using the reusable `deploy-environment.yml` (int/test/prod-pop0/prod-lon1).
- A deeper follow-up would stop the build leaving root-owned files in the first place (run the Docker build as `--user $(id -u):$(id -g)`), but this reclaim step fixes the recurring checkout failure regardless of origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)