### PR TITLE
fix(dns): empty record set crashes DNS panel (records.filter is not a function)

### DIFF
--- a/api/dns_manager.lua
+++ b/api/dns_manager.lua
@@ -492,6 +492,15 @@ function _M.lookup(opts)
             pop_id = extract_pop_id(r),
         })
     end
+    -- Force array encoding: an empty Lua table serialises as `{}` (a
+    -- JSON object) by default, which makes the dashboard's
+    -- `records.filter(...)` throw "filter is not a function".  This
+    -- fires whenever a zone resolves but has no records of the queried
+    -- type (e.g. a CNAME host with no A records).  array_mt pins it to
+    -- `[]`.  Guarded for older cjson builds without array_mt.
+    if cjson.array_mt then
+        setmetatable(annotated, cjson.array_mt)
+    end
     return {
         domain = domain,
         zone_id = zone.zone_id,

--- a/api/dns_manager.lua
+++ b/api/dns_manager.lua
@@ -931,6 +931,13 @@ function _M.provision_for_server(opts)
     end
 
     -- 6. Execute (or just plan)
+    -- Pin to array encoding: empty `actions`/`skipped` would otherwise
+    -- serialise as `{}` (JSON object) and break the dashboard's
+    -- `.map(...)` over them (e.g. a CNAME create has an empty skipped).
+    if cjson.array_mt then
+        setmetatable(actions, cjson.array_mt)
+        setmetatable(skipped, cjson.array_mt)
+    end
     if opts.dry_run then
         return {
             dry_run = true,
@@ -1031,6 +1038,10 @@ function _M.provision_for_server(opts)
         })
     end)
 
+    if cjson.array_mt then
+        setmetatable(executed, cjson.array_mt)
+        setmetatable(skipped, cjson.array_mt)
+    end
     return {
         domain = domain,
         zone_id = zone.zone_id,

--- a/openresty-admin-next/src/components/servers/sections/DnsProvisionDialog.tsx
+++ b/openresty-admin-next/src/components/servers/sections/DnsProvisionDialog.tsx
@@ -154,7 +154,14 @@ export default function DnsProvisionDialog({
         profile_id: profileId,
         dry_run: true,
       });
-      setPlan(res?.data ?? null);
+      const planData = (res?.data ?? null) as Plan | null;
+      if (planData) {
+        // Empty actions/skipped may arrive as `{}` (JSON object) from the
+        // Lua backend; coerce so renderActions/renderSkipped `.map` is safe.
+        if (!Array.isArray(planData.actions)) planData.actions = [];
+        if (!Array.isArray(planData.skipped)) planData.skipped = [];
+      }
+      setPlan(planData);
     } catch (err) {
       // Surface the structured error message from the Lua module
       // verbatim — it's already designed to be operator-facing.
@@ -184,7 +191,11 @@ export default function DnsProvisionDialog({
         profile_id: profileId,
         dry_run: false,
       });
-      const result = res?.data ?? null;
+      const result = (res?.data ?? null) as Plan | null;
+      if (result) {
+        if (!Array.isArray(result.actions)) result.actions = [];
+        if (!Array.isArray(result.skipped)) result.skipped = [];
+      }
       setAppliedResult(result);
       const errorCount = (result?.actions ?? []).filter(
         (a) => a.action === "error",

--- a/openresty-admin-next/src/components/servers/sections/DnsStatePanel.tsx
+++ b/openresty-admin-next/src/components/servers/sections/DnsStatePanel.tsx
@@ -109,7 +109,13 @@ export default function DnsStatePanel({
     setError(null);
     try {
       const res = await dataProvider.lookupDns(serverName, "A");
-      setLookup(res?.data ?? null);
+      const data = (res?.data ?? null) as LookupResult | null;
+      if (data && !Array.isArray(data.records)) {
+        // Backend may serialise an empty record set as `{}` (JSON object)
+        // rather than `[]`; coerce so `records.filter/map/length` are safe.
+        data.records = [];
+      }
+      setLookup(data);
     } catch (err) {
       setError(err as ApiError);
       setLookup(null);


### PR DESCRIPTION
## Problem

Opening a server whose domain resolves to a Cloudflare zone **with no records of the queried type** (e.g. a CNAME host — no A records) crashes the page:

```
Something went wrong
l.records.filter is not a function
```

## Root cause

`dns_manager.lua` `_M.lookup` builds `annotated = {}` and returns it as `records`. An **empty Lua table serialises as `{}` (JSON object)**, not `[]`. The dashboard's `DnsStatePanel` then calls `records.filter(...)` → `filter is not a function` → render crash.

## Fix

- **Backend** (`api/dns_manager.lua`): `setmetatable(annotated, cjson.array_mt)` so an empty record set encodes as `[]`. Guarded for cjson builds lacking `array_mt`. Verified on the host: `{"records":[]}` with the mt vs `{"records":{}}` without.
- **Frontend** (`DnsStatePanel.tsx`): coerce `data.records` to `[]` when not an array, so a stale backend or cached bundle can't crash the panel.

## Notes

- Backend fix already hot-applied to pop0 (md5-verified identical to `origin/main` before patching) and reloaded, so the page loads now even with the old cached JS.
- Frontend guard deploys with the next `dashboard-next` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)