### PR TITLE
release: DNS empty-array crash fixes + auto-discovery + runner workspace fix

### DIFF
--- a/api/dns_manager.lua
+++ b/api/dns_manager.lua
@@ -492,6 +492,15 @@ function _M.lookup(opts)
             pop_id = extract_pop_id(r),
         })
     end
+    -- Force array encoding: an empty Lua table serialises as `{}` (a
+    -- JSON object) by default, which makes the dashboard's
+    -- `records.filter(...)` throw "filter is not a function".  This
+    -- fires whenever a zone resolves but has no records of the queried
+    -- type (e.g. a CNAME host with no A records).  array_mt pins it to
+    -- `[]`.  Guarded for older cjson builds without array_mt.
+    if cjson.array_mt then
+        setmetatable(annotated, cjson.array_mt)
+    end
     return {
         domain = domain,
         zone_id = zone.zone_id,

--- a/api/dns_manager.lua
+++ b/api/dns_manager.lua
@@ -931,6 +931,13 @@ function _M.provision_for_server(opts)
     end
 
     -- 6. Execute (or just plan)
+    -- Pin to array encoding: empty `actions`/`skipped` would otherwise
+    -- serialise as `{}` (JSON object) and break the dashboard's
+    -- `.map(...)` over them (e.g. a CNAME create has an empty skipped).
+    if cjson.array_mt then
+        setmetatable(actions, cjson.array_mt)
+        setmetatable(skipped, cjson.array_mt)
+    end
     if opts.dry_run then
         return {
             dry_run = true,
@@ -1031,6 +1038,10 @@ function _M.provision_for_server(opts)
         })
     end)
 
+    if cjson.array_mt then
+        setmetatable(executed, cjson.array_mt)
+        setmetatable(skipped, cjson.array_mt)
+    end
     return {
         domain = domain,
         zone_id = zone.zone_id,

--- a/openresty-admin-next/src/components/servers/sections/DnsProvisionDialog.tsx
+++ b/openresty-admin-next/src/components/servers/sections/DnsProvisionDialog.tsx
@@ -154,7 +154,14 @@ export default function DnsProvisionDialog({
         profile_id: profileId,
         dry_run: true,
       });
-      setPlan(res?.data ?? null);
+      const planData = (res?.data ?? null) as Plan | null;
+      if (planData) {
+        // Empty actions/skipped may arrive as `{}` (JSON object) from the
+        // Lua backend; coerce so renderActions/renderSkipped `.map` is safe.
+        if (!Array.isArray(planData.actions)) planData.actions = [];
+        if (!Array.isArray(planData.skipped)) planData.skipped = [];
+      }
+      setPlan(planData);
     } catch (err) {
       // Surface the structured error message from the Lua module
       // verbatim — it's already designed to be operator-facing.
@@ -184,7 +191,11 @@ export default function DnsProvisionDialog({
         profile_id: profileId,
         dry_run: false,
       });
-      const result = res?.data ?? null;
+      const result = (res?.data ?? null) as Plan | null;
+      if (result) {
+        if (!Array.isArray(result.actions)) result.actions = [];
+        if (!Array.isArray(result.skipped)) result.skipped = [];
+      }
       setAppliedResult(result);
       const errorCount = (result?.actions ?? []).filter(
         (a) => a.action === "error",

--- a/openresty-admin-next/src/components/servers/sections/DnsStatePanel.tsx
+++ b/openresty-admin-next/src/components/servers/sections/DnsStatePanel.tsx
@@ -109,7 +109,13 @@ export default function DnsStatePanel({
     setError(null);
     try {
       const res = await dataProvider.lookupDns(serverName, "A");
-      setLookup(res?.data ?? null);
+      const data = (res?.data ?? null) as LookupResult | null;
+      if (data && !Array.isArray(data.records)) {
+        // Backend may serialise an empty record set as `{}` (JSON object)
+        // rather than `[]`; coerce so `records.filter/map/length` are safe.
+        data.records = [];
+      }
+      setLookup(data);
     } catch (err) {
       setError(err as ApiError);
       setLookup(null);


### PR DESCRIPTION
Promote `main` → `release`. Includes:

- **#1080** fix(dns): empty record set / empty actions+skipped no longer crash the DNS panel & provision dialog (`records.filter` / `d.map` is not a function). Backend pins arrays via `cjson.array_mt`; frontend coerces defensively.
- **#1078** fix(ci): reclaim runner workspace ownership before checkout (fixes recurring `actions/checkout` EACCES on the shared self-hosted runner).
- (already in release) #1076 DNS zone auto-discovery.

Backend DNS fixes are already hot-patched on pop0; this promotion makes them part of the normal deploy + ships the `dashboard-next` frontend guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)