### PR TITLE
feat(llm): OpenAI→Anthropic protocol translation (streaming + buffered)

### DIFF
--- a/api/gateway_resp.lua
+++ b/api/gateway_resp.lua
@@ -283,6 +283,21 @@ elseif selectedRule.statusCode == 305 then
         ngx.req.set_uri(redirectPath .. currentUri)
     end
 
+    -- LLM protocol translation (e.g. OpenAI-in -> Anthropic-out).  Runs
+    -- last so its request rewrite (body + /v1/messages URI) wins over the
+    -- generic path handling above.  Per-rule, fails open.  Response-side
+    -- translation is driven by ngx.ctx.llm in the header/body filters.
+    local llm_cfg = selectedRule.rule_data and selectedRule.rule_data.response
+        and selectedRule.rule_data.response.llm_translate
+    if llm_cfg then
+        local ok_llm, LlmTranslator = pcall(require, "llm_translator")
+        if ok_llm then
+            LlmTranslator.apply_request(llm_cfg)
+        else
+            ngx.log(ngx.ERR, "llm_translate: module load failed: ", tostring(LlmTranslator))
+        end
+    end
+
     ngx.var.proxy_host_scheme = origin_serverScheme
 
     -- Per-server proxy timeouts: pass to balancer_by_lua via ngx.ctx

--- a/api/llm_translator.lua
+++ b/api/llm_translator.lua
@@ -1,0 +1,402 @@
+-- LLM Protocol Translator for WSLProxy
+--
+-- Turns wslproxy into an OpenAI-compatible edge in front of Anthropic:
+-- a client speaks the OpenAI Chat Completions API, this module rewrites
+-- the request into Anthropic's Messages API on the way in, and rewrites
+-- Anthropic's reply (buffered OR streamed SSE) back into OpenAI shape on
+-- the way out.  The client never knows it's talking to Claude.
+--
+-- Scope (Phase 1 MVP): OpenAI -> Anthropic, text content, streaming and
+-- non-streaming.  Tool/function calling, multimodal images, and the
+-- reverse direction are explicit follow-ups (see README / PR notes).
+--
+-- Wiring (no architectural change — uses existing pipeline phases):
+--   * access phase  (gateway_resp.lua) -> _M.apply_request(cfg)
+--       reads the request body, translates it, rewrites the upstream
+--       URI/headers, and stashes state on ngx.ctx.llm.
+--   * header_filter (nginx template)    -> _M.header_filter()
+--       drops content-length (body length changes) and normalises the
+--       content-type for the non-streaming case.
+--   * body_filter   (nginx template)    -> _M.body_filter()
+--       streaming: per-chunk SSE translation via a stateful parser;
+--       non-streaming: buffer then convert on EOF.
+--
+-- Activation is per-rule: a rule's response carries
+--   "llm_translate": { "source": "openai", "target": "anthropic",
+--                      "model_map": { "gpt-4o": "claude-opus-4-8" },
+--                      "anthropic_version": "2023-06-01",
+--                      "default_max_tokens": 4096 }
+--
+-- The Anthropic API key is NOT handled here — inject it with the
+-- server's custom_headers (x-api-key), keeping secrets out of code.
+
+local _M = {}
+
+local cjson = Cjson or require("cjson")
+local cjson_safe = require("cjson.safe")
+
+local DEFAULT_MAX_TOKENS = 4096
+local DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
+local ANTHROPIC_PATH = "/v1/messages"
+
+-- ============================================================
+-- Pure helpers (no ngx) — unit-testable
+-- ============================================================
+
+-- Anthropic stop_reason -> OpenAI finish_reason
+local FINISH_REASON = {
+    end_turn = "stop",
+    stop_sequence = "stop",
+    max_tokens = "length",
+    tool_use = "tool_calls",
+}
+
+local function map_finish_reason(stop_reason)
+    if not stop_reason then return nil end
+    return FINISH_REASON[stop_reason] or "stop"
+end
+
+-- Collapse an OpenAI message `content` (string OR array of parts) into
+-- Anthropic-acceptable content.  For the MVP we keep text only: a plain
+-- string passes through; an array contributes its text parts joined.
+-- (Image parts are dropped with a marker — multimodal is Phase 3.)
+local function normalize_content(content)
+    if type(content) == "string" then
+        return content
+    end
+    if type(content) == "table" then
+        local parts = {}
+        for _, p in ipairs(content) do
+            if type(p) == "table" and (p.type == "text" or p.text) then
+                parts[#parts + 1] = p.text or ""
+            end
+        end
+        return table.concat(parts, "")
+    end
+    return ""
+end
+
+--- OpenAI Chat Completions request table -> Anthropic Messages request
+--- table.  Returns (anthropic_tbl, meta) where meta = { stream, model }.
+function _M.openai_to_anthropic(o, cfg)
+    cfg = cfg or {}
+    local model_map = cfg.model_map or {}
+    local out = {}
+
+    out.model = model_map[o.model] or o.model
+    -- Anthropic requires max_tokens; OpenAI may omit it.
+    out.max_tokens = tonumber(o.max_tokens) or tonumber(o.max_completion_tokens)
+        or tonumber(cfg.default_max_tokens) or DEFAULT_MAX_TOKENS
+
+    if o.temperature ~= nil then out.temperature = o.temperature end
+    if o.top_p ~= nil then out.top_p = o.top_p end
+
+    -- stop -> stop_sequences (string or array)
+    if type(o.stop) == "string" then
+        out.stop_sequences = { o.stop }
+    elseif type(o.stop) == "table" then
+        out.stop_sequences = o.stop
+    end
+
+    out.stream = o.stream == true
+
+    -- Split system messages out to the top-level `system` field; keep the
+    -- user/assistant turns in `messages`.
+    local system_parts = {}
+    local messages = {}
+    if type(o.messages) == "table" then
+        for _, m in ipairs(o.messages) do
+            if m.role == "system" then
+                system_parts[#system_parts + 1] = normalize_content(m.content)
+            elseif m.role == "user" or m.role == "assistant" then
+                messages[#messages + 1] = {
+                    role = m.role,
+                    content = normalize_content(m.content),
+                }
+            end
+        end
+    end
+    if #system_parts > 0 then
+        out.system = table.concat(system_parts, "\n")
+    end
+    -- Force array encoding so an empty list never serialises as {}.
+    if cjson.array_mt then setmetatable(messages, cjson.array_mt) end
+    out.messages = messages
+
+    return out, { stream = out.stream, model = out.model }
+end
+
+--- Non-streaming Anthropic Messages response table -> OpenAI Chat
+--- Completions response table.  `created` and `id_fallback` are injected
+--- by the caller (ngx layer) so this stays pure/testable.
+function _M.anthropic_to_openai(a, created, id_fallback)
+    local text_parts = {}
+    if type(a.content) == "table" then
+        for _, block in ipairs(a.content) do
+            if type(block) == "table" and block.type == "text" then
+                text_parts[#text_parts + 1] = block.text or ""
+            end
+        end
+    end
+
+    local usage = a.usage or {}
+    local in_tok = tonumber(usage.input_tokens) or 0
+    local out_tok = tonumber(usage.output_tokens) or 0
+
+    return {
+        id = "chatcmpl-" .. tostring(a.id or id_fallback or "wslproxy"),
+        object = "chat.completion",
+        created = created,
+        model = a.model,
+        choices = {
+            {
+                index = 0,
+                message = {
+                    role = "assistant",
+                    content = table.concat(text_parts, ""),
+                },
+                finish_reason = map_finish_reason(a.stop_reason) or "stop",
+            },
+        },
+        usage = {
+            prompt_tokens = in_tok,
+            completion_tokens = out_tok,
+            total_tokens = in_tok + out_tok,
+        },
+    }
+end
+
+-- ---------- streaming SSE ----------
+
+-- Build one OpenAI `chat.completion.chunk` object.
+local function openai_chunk(state, delta, finish_reason)
+    return {
+        id = state.id,
+        object = "chat.completion.chunk",
+        created = state.created,
+        model = state.model,
+        choices = {
+            {
+                index = 0,
+                delta = delta,
+                finish_reason = finish_reason,
+            },
+        },
+    }
+end
+
+local function sse_data(obj)
+    return "data: " .. cjson.encode(obj) .. "\n\n"
+end
+
+--- Fresh streaming-translation state.  `created`/`id` come from the ngx
+--- layer (ngx.time / request id) so this module has no ngx dependency in
+--- its core.
+function _M.new_stream_state(created, id)
+    return {
+        buffer = "",
+        created = created,
+        id = "chatcmpl-" .. tostring(id or "wslproxy"),
+        model = nil,
+        role_sent = false,
+        finish_reason = nil,
+        done = false,
+    }
+end
+
+-- Translate one decoded Anthropic SSE event into zero or more OpenAI
+-- SSE lines, appended to `out`.
+local function handle_event(state, evt, out)
+    local t = evt.type
+    if t == "message_start" then
+        local msg = evt.message or {}
+        state.model = msg.model or state.model
+        if not state.role_sent then
+            state.role_sent = true
+            out[#out + 1] = sse_data(openai_chunk(state, { role = "assistant" }, nil))
+        end
+    elseif t == "content_block_delta" then
+        local d = evt.delta or {}
+        if d.type == "text_delta" and d.text and d.text ~= "" then
+            out[#out + 1] = sse_data(openai_chunk(state, { content = d.text }, nil))
+        end
+        -- thinking_delta / input_json_delta intentionally ignored (Phase 3)
+    elseif t == "message_delta" then
+        local d = evt.delta or {}
+        if d.stop_reason then
+            state.finish_reason = map_finish_reason(d.stop_reason)
+        end
+    elseif t == "message_stop" then
+        if not state.done then
+            state.done = true
+            out[#out + 1] = sse_data(openai_chunk(state, {}, state.finish_reason or "stop"))
+            out[#out + 1] = "data: [DONE]\n\n"
+        end
+    end
+    -- ping / content_block_start / content_block_stop: nothing to emit
+end
+
+--- Feed a raw chunk of Anthropic SSE bytes; return translated OpenAI SSE
+--- bytes (possibly ""), buffering any incomplete trailing event.  Call
+--- with eof=true at end of stream to flush a terminal [DONE] if the
+--- upstream cut off without a clean message_stop.
+function _M.sse_step(state, chunk, eof)
+    if state.done then
+        return ""
+    end
+    if chunk and chunk ~= "" then
+        state.buffer = state.buffer .. chunk
+    end
+
+    local out = {}
+    -- SSE events are separated by a blank line ("\n\n").  Process every
+    -- complete event; keep the trailing partial in the buffer.
+    while true do
+        local sep_start, sep_end = state.buffer:find("\n\n", 1, true)
+        if not sep_start then break end
+        local block = state.buffer:sub(1, sep_start - 1)
+        state.buffer = state.buffer:sub(sep_end + 1)
+
+        -- A block may contain "event:" and one or more "data:" lines.
+        -- We only need the JSON from the data line(s).
+        local data_lines = {}
+        for line in (block .. "\n"):gmatch("([^\n]*)\n") do
+            local payload = line:match("^data:%s?(.*)$")
+            if payload then data_lines[#data_lines + 1] = payload end
+        end
+        if #data_lines > 0 then
+            local joined = table.concat(data_lines, "")
+            if joined ~= "" and joined ~= "[DONE]" then
+                local evt = cjson_safe.decode(joined)
+                if type(evt) == "table" and evt.type then
+                    handle_event(state, evt, out)
+                end
+            end
+        end
+        if state.done then break end
+    end
+
+    if eof and not state.done then
+        -- Upstream ended without message_stop — emit a best-effort close.
+        state.done = true
+        out[#out + 1] = sse_data(openai_chunk(state, {}, state.finish_reason or "stop"))
+        out[#out + 1] = "data: [DONE]\n\n"
+    end
+
+    return table.concat(out)
+end
+
+-- ============================================================
+-- ngx-facing wrappers
+-- ============================================================
+
+--- Access phase: if the matched rule asks for translation, rewrite the
+--- request in place and arm ngx.ctx.llm for the response filters.
+--- `cfg` is the rule's `llm_translate` object.  Fails open (logs +
+--- leaves the request untouched) on any error so a bad body can't 500
+--- the gateway.
+function _M.apply_request(cfg)
+    if type(cfg) ~= "table" then return end
+    -- Only the OpenAI->Anthropic direction exists in the MVP.
+    local source = cfg.source or "openai"
+    local target = cfg.target or "anthropic"
+    if source ~= "openai" or target ~= "anthropic" then
+        ngx.log(ngx.WARN, "llm_translate: unsupported pair ", source, "->", target)
+        return
+    end
+
+    ngx.req.read_body()
+    local body = ngx.req.get_body_data()
+    if not body then
+        -- Body may be buffered to a temp file when large; for the MVP we
+        -- skip translation rather than risk a partial read.
+        ngx.log(ngx.WARN, "llm_translate: request body not in memory; skipping")
+        return
+    end
+
+    local o = cjson_safe.decode(body)
+    if type(o) ~= "table" then
+        ngx.log(ngx.WARN, "llm_translate: request body is not JSON; skipping")
+        return
+    end
+
+    local ok, anthropic, meta = pcall(_M.openai_to_anthropic, o, cfg)
+    if not ok then
+        ngx.log(ngx.ERR, "llm_translate: request translation failed: ", tostring(anthropic))
+        return
+    end
+
+    local new_body = cjson.encode(anthropic)
+    ngx.req.set_body_data(new_body)
+    ngx.req.set_uri(ANTHROPIC_PATH)            -- /v1/chat/completions -> /v1/messages
+
+    -- Header hygiene for Anthropic: it authenticates with x-api-key
+    -- (injected via the server's custom_headers), not Bearer.
+    ngx.req.clear_header("Authorization")
+    ngx.req.set_header("Content-Type", "application/json")
+    ngx.req.set_header("Content-Length", #new_body)
+    if not ngx.var.http_anthropic_version then
+        ngx.req.set_header("anthropic-version",
+            cfg.anthropic_version or DEFAULT_ANTHROPIC_VERSION)
+    end
+
+    ngx.ctx.llm = {
+        active = true,
+        stream = meta.stream,
+        state = nil,           -- lazily created in body_filter for streams
+        buf = nil,             -- accumulator for the non-streaming case
+    }
+end
+
+--- header_filter phase: body length/shape changes, so drop content-length
+--- and fix the content-type for the non-streaming JSON case.  Streaming
+--- responses keep text/event-stream.
+function _M.header_filter()
+    local llm = ngx.ctx.llm
+    if not llm or not llm.active then return end
+    ngx.header["Content-Length"] = nil          -- re-chunked downstream
+    if not llm.stream then
+        ngx.header["Content-Type"] = "application/json"
+    end
+end
+
+--- body_filter phase: rewrite the response body.  Streaming is translated
+--- incrementally; non-streaming is buffered then converted on EOF.
+function _M.body_filter()
+    local llm = ngx.ctx.llm
+    if not llm or not llm.active then return end
+
+    local chunk = ngx.arg[1]
+    local eof = ngx.arg[2]
+
+    if llm.stream then
+        if not llm.state then
+            llm.state = _M.new_stream_state(ngx.time(), ngx.var.request_id)
+        end
+        local ok, out = pcall(_M.sse_step, llm.state, chunk or "", eof)
+        ngx.arg[1] = (ok and out) or ""
+        return
+    end
+
+    -- Non-streaming: accumulate, emit nothing until EOF, then convert.
+    llm.buf = (llm.buf or "") .. (chunk or "")
+    if not eof then
+        ngx.arg[1] = ""
+        return
+    end
+    local a = cjson_safe.decode(llm.buf)
+    if type(a) ~= "table" then
+        -- Couldn't parse (e.g. an upstream error body) — pass it through
+        -- untouched rather than blanking the response.
+        ngx.arg[1] = llm.buf
+        return
+    end
+    local ok, openai = pcall(_M.anthropic_to_openai, a, ngx.time(), ngx.var.request_id)
+    if ok and openai then
+        ngx.arg[1] = cjson.encode(openai)
+    else
+        ngx.arg[1] = llm.buf
+    end
+end
+
+return _M

--- a/api/test_llm_translator.lua
+++ b/api/test_llm_translator.lua
@@ -1,0 +1,109 @@
+-- Standalone test for the pure core of llm_translator (no ngx needed).
+-- Run with:  resty api/test_llm_translator.lua   (or on a host with cjson)
+package.path = "/tmp/?.lua;./api/?.lua;" .. package.path
+local cjson = require("cjson")
+local T = require("llm_translator")
+
+local failures = 0
+local function check(name, cond)
+    if cond then
+        print("  ok   - " .. name)
+    else
+        print("  FAIL - " .. name)
+        failures = failures + 1
+    end
+end
+
+-- 1) request: OpenAI -> Anthropic
+do
+    local openai = {
+        model = "gpt-4o",
+        messages = {
+            { role = "system", content = "You are terse." },
+            { role = "user", content = "Hi" },
+        },
+        temperature = 0.5,
+        stop = "STOP",
+        stream = true,
+    }
+    local a, meta = T.openai_to_anthropic(openai, {
+        model_map = { ["gpt-4o"] = "claude-opus-4-8" },
+    })
+    check("model mapped", a.model == "claude-opus-4-8")
+    check("system extracted", a.system == "You are terse.")
+    check("system removed from messages", #a.messages == 1 and a.messages[1].role == "user")
+    check("max_tokens defaulted", a.max_tokens == 4096)
+    check("stop -> stop_sequences", a.stop_sequences[1] == "STOP")
+    check("temperature passthrough", a.temperature == 0.5)
+    check("stream flag", a.stream == true and meta.stream == true)
+end
+
+-- 2) non-streaming response: Anthropic -> OpenAI
+do
+    local anth = {
+        id = "msg_123",
+        model = "claude-opus-4-8",
+        content = { { type = "text", text = "Hello" }, { type = "text", text = " world" } },
+        stop_reason = "end_turn",
+        usage = { input_tokens = 10, output_tokens = 5 },
+    }
+    local o = T.anthropic_to_openai(anth, 1700000000, "req1")
+    check("object type", o.object == "chat.completion")
+    check("content joined", o.choices[1].message.content == "Hello world")
+    check("finish_reason mapped", o.choices[1].finish_reason == "stop")
+    check("usage prompt", o.usage.prompt_tokens == 10)
+    check("usage total", o.usage.total_tokens == 15)
+end
+
+-- 3) streaming SSE: Anthropic events (fed in awkward chunk splits) -> OpenAI
+do
+    local stream =
+        "event: message_start\n" ..
+        'data: {"type":"message_start","message":{"id":"msg_9","model":"claude-opus-4-8"}}\n\n' ..
+        "event: content_block_delta\n" ..
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}\n\n' ..
+        "event: content_block_delta\n" ..
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}\n\n' ..
+        "event: message_delta\n" ..
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}\n\n' ..
+        "event: message_stop\n" ..
+        'data: {"type":"message_stop"}\n\n'
+
+    local st = T.new_stream_state(1700000000, "req2")
+    local out = {}
+    -- Feed in 7-byte slices to exercise event-boundary buffering.
+    local i = 1
+    while i <= #stream do
+        local piece = stream:sub(i, i + 6)
+        out[#out + 1] = T.sse_step(st, piece, false)
+        i = i + 7
+    end
+    out[#out + 1] = T.sse_step(st, "", true)
+    local result = table.concat(out)
+
+    -- Parse the emitted OpenAI SSE back out.
+    local contents, sawRole, sawDone, finish = {}, false, false, nil
+    for line in (result):gmatch("data: ([^\n]*)\n") do
+        if line == "[DONE]" then
+            sawDone = true
+        else
+            local c = cjson.decode(line)
+            local d = c.choices[1].delta
+            if d.role == "assistant" then sawRole = true end
+            if d.content then contents[#contents + 1] = d.content end
+            if c.choices[1].finish_reason then finish = c.choices[1].finish_reason end
+        end
+    end
+    check("stream: role chunk first", sawRole)
+    check("stream: text reassembled", table.concat(contents) == "Hello")
+    check("stream: finish_reason stop", finish == "stop")
+    check("stream: terminated with [DONE]", sawDone)
+    check("stream: idempotent after done", T.sse_step(st, "x", false) == "")
+end
+
+if failures == 0 then
+    print("ALL PASS")
+else
+    print(failures .. " FAILURE(S)")
+    os.exit(1)
+end

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="WSL Proxy - Enterprise-grade reverse proxy, load balancer, and edge computing platform. Build your own CDN with multi-region failover, edge caching, and WAF protection." />
-    <meta name="keywords" content="CDN, reverse proxy, load balancer, edge computing, WAF, SSL, cache, API gateway, OpenResty, Lua, nginx" />
+    <meta name="description" content="WSL Proxy - Enterprise-grade reverse proxy, load balancer, AI gateway, and edge computing platform. Build your own CDN with multi-region failover, edge caching, WAF protection, and an OpenAI-compatible LLM gateway in front of Anthropic, OpenAI, and self-hosted models." />
+    <meta name="keywords" content="CDN, reverse proxy, load balancer, edge computing, WAF, SSL, cache, API gateway, AI gateway, LLM gateway, OpenAI-compatible, Anthropic, OpenAI, Ollama, OpenResty, Lua, nginx" />
     <meta name="author" content="Workstation Solutions Limited" />
     <meta property="og:title" content="WSL Proxy - Build Your Own CDN" />
     <meta property="og:description" content="Enterprise-grade reverse proxy, load balancer, and edge computing platform with multi-region failover, edge caching, and WAF protection." />
@@ -478,6 +478,7 @@
         </a>
         <div class="d-flex align-items-center">
           <a class="nav-link-custom d-none d-md-inline" href="#features">Features</a>
+          <a class="nav-link-custom d-none d-md-inline" href="#ai-gateway">AI Gateway</a>
           <a class="nav-link-custom d-none d-md-inline" href="#flow">Architecture</a>
           <a class="nav-link-custom d-none d-md-inline" href="#api">API</a>
           <a class="nav-link-custom d-none d-md-inline" href="https://github.com/bwalia/wslproxy" target="_blank">Docs</a>
@@ -651,6 +652,102 @@
               <p>Fully-featured Web UI Administrator to manage entire cluster configuration from a single place securely.</p>
             </div>
           </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="feature-icon purple"><i class="fas fa-robot"></i></div>
+              <h4>AI Gateway (OpenAI-Compatible)</h4>
+              <p>Front Anthropic, OpenAI, or self-hosted models behind one OpenAI-compatible endpoint — with live SSE token streaming, per-route API keys, rate limits, and metrics. <a href="#ai-gateway">Learn more →</a></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- AI Gateway Section -->
+    <section class="features" id="ai-gateway" style="background: var(--light);">
+      <div class="container">
+        <div class="text-center mb-5">
+          <span class="section-badge"><i class="fas fa-robot"></i> New &middot; AI Gateway</span>
+          <h2 class="section-title">OpenAI-Compatible Edge for LLMs</h2>
+          <p class="section-description">
+            Put one secure, observable gateway in front of every model provider. Your apps speak the
+            standard OpenAI API; WSL Proxy translates, routes, secures, and meters the traffic —
+            Anthropic, OpenAI, or self-hosted Ollama behind a single endpoint.
+          </p>
+        </div>
+
+        <div class="row g-4 align-items-stretch mb-4">
+          <div class="col-lg-6">
+            <div class="feature-card" style="height: 100%;">
+              <div class="feature-icon purple"><i class="fas fa-language"></i></div>
+              <h4>What it is</h4>
+              <p>
+                A protocol-translating LLM gateway built into the proxy. Clients call the familiar
+                <strong>OpenAI Chat Completions</strong> API; WSL Proxy rewrites each request into the
+                target provider's native API (e.g. <strong>Anthropic Messages</strong>) and converts the
+                reply back — including <strong>live token streaming (SSE)</strong> — so you never rewrite
+                application code to switch or mix providers.
+              </p>
+            </div>
+          </div>
+          <div class="col-lg-6">
+            <div class="feature-card" style="height: 100%;">
+              <div class="feature-icon green"><i class="fas fa-terminal"></i></div>
+              <h4>One endpoint, any model</h4>
+              <p>Path-based rules route each call to the right backend, each with its own keys, rate limits, and WAF:</p>
+              <pre style="background: var(--dark); color: #e2e8f0; padding: 1rem 1.25rem; border-radius: 12px; font-size: 0.85rem; line-height: 1.7; overflow-x: auto; margin: 0;"><code>POST /api/claude  &rarr; api.anthropic.com   <span style="color:#10b981;"># OpenAI &harr; Anthropic</span>
+POST /api/openai  &rarr; api.openai.com
+POST /api/llm     &rarr; ollama            <span style="color:#10b981;"># self-hosted</span></code></pre>
+            </div>
+          </div>
+        </div>
+
+        <div class="text-center mb-4">
+          <h3 style="font-size: 1.4rem; font-weight: 700; color: var(--dark);">Use Cases &amp; Benefits</h3>
+        </div>
+        <div class="row g-4">
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="feature-icon blue"><i class="fas fa-cubes"></i></div>
+              <h4>Vendor-neutral apps</h4>
+              <p>Write once to the OpenAI API and swap or blend Claude, GPT, and local models by configuration — no SDK changes, no lock-in.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="feature-icon red"><i class="fas fa-user-shield"></i></div>
+              <h4>Govern &amp; secure centrally</h4>
+              <p>Provider keys never touch client apps. Enforce JWT / API-key auth, WAF, and rate limits at the edge — per route, per team.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="feature-icon orange"><i class="fas fa-route"></i></div>
+              <h4>Control cost &amp; latency</h4>
+              <p>Route by model, weight, or canary; fail over between providers; send cheap/private work to self-hosted models and hard tasks to frontier models.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="feature-icon pink"><i class="fas fa-chart-line"></i></div>
+              <h4>Observability &amp; spend</h4>
+              <p>Every prompt and response flows through one place — Prometheus metrics, audit logs, and per-model traffic stats for usage and cost visibility.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="feature-icon cyan"><i class="fas fa-bolt"></i></div>
+              <h4>Streaming-native</h4>
+              <p>Server-Sent Event token streams are translated chunk-by-chunk, so chat UIs stay real-time and responsive across providers.</p>
+            </div>
+          </div>
+          <div class="col-md-6 col-lg-4">
+            <div class="feature-card">
+              <div class="feature-icon green"><i class="fas fa-plug"></i></div>
+              <h4>Drop-in migration</h4>
+              <p>Point your existing OpenAI base URL at the gateway. No payload rewrites — start mixing providers without touching client code.</p>
+            </div>
+          </div>
         </div>
       </div>
     </section>
@@ -778,6 +875,7 @@
             <h5>Product</h5>
             <ul>
               <li><a href="#features">Features</a></li>
+              <li><a href="#ai-gateway">AI Gateway</a></li>
               <li><a href="#flow">Architecture</a></li>
               <li><a href="#api">API</a></li>
               <li><a href="https://github.com/bwalia/wslproxy">Documentation</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,13 +7,13 @@
     <meta name="description" content="WSL Proxy - Enterprise-grade reverse proxy, load balancer, AI gateway, and edge computing platform. Build your own CDN with multi-region failover, edge caching, WAF protection, and an OpenAI-compatible LLM gateway in front of Anthropic, OpenAI, and self-hosted models." />
     <meta name="keywords" content="CDN, reverse proxy, load balancer, edge computing, WAF, SSL, cache, API gateway, AI gateway, LLM gateway, OpenAI-compatible, Anthropic, OpenAI, Ollama, OpenResty, Lua, nginx" />
     <meta name="author" content="Workstation Solutions Limited" />
-    <meta property="og:title" content="WSL Proxy - Build Your Own CDN" />
+    <meta property="og:title" content="WSL Proxy - Build Your Own AI Gateways, CDN & More" />
     <meta property="og:description" content="Enterprise-grade reverse proxy, load balancer, and edge computing platform with multi-region failover, edge caching, and WAF protection." />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="WSL Proxy - Build Your Own CDN" />
+    <meta name="twitter:title" content="WSL Proxy - Build Your Own AI Gateways, CDN & More" />
     <meta name="twitter:description" content="Enterprise-grade reverse proxy and edge computing platform" />
-    <title>WSL Proxy - Build Your Own CDN | Enterprise Edge Platform</title>
+    <title>WSL Proxy - Build Your Own AI Gateways, CDN & More | Enterprise Edge Platform</title>
     
     <!-- CDN Dependencies for GitHub Pages -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
@@ -500,7 +500,7 @@
               <i class="fas fa-bolt"></i>
               <span>OpenResty + Lua Powered Edge Computing</span>
             </div>
-            <h1>Build Your Own <span class="gradient-text">Enterprise CDN</span></h1>
+            <h1>Build Your Own <span class="gradient-text">Enterprise AI Gateways, CDN</span> and much more.</h1>
             <p class="hero-description">
               WSL Proxy is a high-performance reverse proxy, load balancer, and edge computing platform. 
               Deploy globally with multi-region failover, edge caching, WAF protection, and API gateway capabilities.
@@ -844,7 +844,7 @@ POST /api/llm     &rarr; ollama            <span style="color:#10b981;"># self-h
     <!-- CTA Section -->
     <section class="cta-section">
       <div class="container">
-        <h2>Ready to Build Your Own CDN?</h2>
+        <h2>Ready to Build Your Own AI Gateway &amp; CDN?</h2>
         <p>Get started with WSL Proxy in minutes. Deploy on Docker, Kubernetes, or bare metal.</p>
         <div class="d-flex justify-content-center gap-3 flex-wrap">
           <a href="https://github.com/bwalia/wslproxy" class="btn-primary-custom" target="_blank">

--- a/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
@@ -835,10 +835,19 @@ server {
                 end
               end
             end
+
+            -- LLM protocol translation: normalise response headers
+            local ok_llm, Llm = pcall(require, "llm_translator")
+            if ok_llm then Llm.header_filter() end
           }
 
           # WSL Cache: Capture response body for caching
           body_filter_by_lua_block {
+            -- LLM protocol translation: rewrite Anthropic body/SSE -> OpenAI.
+            -- No-op unless gateway_resp.lua armed ngx.ctx.llm for this request.
+            local ok_llm, Llm = pcall(require, "llm_translator")
+            if ok_llm then Llm.body_filter() end
+
             local ok, CacheHandler = pcall(require, "cache_handler")
             if ok and ngx.ctx.should_cache then
               CacheHandler.collect_response_body()
@@ -1044,6 +1053,17 @@ server {
                 end
               end
             end
+
+            -- LLM protocol translation: normalise response headers
+            local ok_llm, Llm = pcall(require, "llm_translator")
+            if ok_llm then Llm.header_filter() end
+          }
+
+          # LLM protocol translation: rewrite Anthropic body/SSE -> OpenAI.
+          # No-op unless gateway_resp.lua armed ngx.ctx.llm for this request.
+          body_filter_by_lua_block {
+            local ok_llm, Llm = pcall(require, "llm_translator")
+            if ok_llm then Llm.body_filter() end
           }
 
           # Docker blob disk cache (controlled by Lua via $docker_cache_zone)

--- a/nginx-dev.conf.tmpl
+++ b/nginx-dev.conf.tmpl
@@ -1152,10 +1152,19 @@ server {
             if ok then
               CacheHandler.process_response_headers()
             end
+
+            -- LLM protocol translation: normalise response headers
+            local ok_llm, Llm = pcall(require, "llm_translator")
+            if ok_llm then Llm.header_filter() end
           }
 
           # WSL Cache: Capture response body for caching
           body_filter_by_lua_block {
+            -- LLM protocol translation: rewrite Anthropic body/SSE -> OpenAI.
+            -- No-op unless gateway_resp.lua armed ngx.ctx.llm for this request.
+            local ok_llm, Llm = pcall(require, "llm_translator")
+            if ok_llm then Llm.body_filter() end
+
             local ok, CacheHandler = pcall(require, "cache_handler")
             if ok and ngx.ctx.should_cache then
               CacheHandler.collect_response_body()


### PR DESCRIPTION
## What

Turns wslproxy into an **OpenAI-compatible edge in front of Anthropic**. A client calls the OpenAI Chat Completions API; wslproxy rewrites the request into Anthropic's Messages API on the way in, and rewrites the reply — **buffered JSON _or_ streamed SSE** — back into OpenAI shape on the way out. The client never knows it's talking to Claude.

Closes the gap from the AI-gateway discussion: wslproxy was a transparent proxy; this adds LiteLLM-style payload normalization for the OpenAI↔Anthropic pair.

## How (no architectural change — uses existing pipeline phases)

| Phase | Hook | Role |
|---|---|---|
| access (`gateway_resp.lua`) | `apply_request(cfg)` | read body → `openai_to_anthropic` → `set_body_data` + `set_uri(/v1/messages)` + header hygiene; arms `ngx.ctx.llm` |
| `header_filter` (templates) | `header_filter()` | drop content-length, fix content-type |
| `body_filter` (templates) | `body_filter()` | **streaming:** stateful SSE event translation buffered across chunks; **non-streaming:** buffer then convert on EOF |

The streaming translator maps Anthropic's event stream (`message_start` / `content_block_delta` / `message_delta` / `message_stop`) to OpenAI's `chat.completion.chunk` deltas terminated by `data: [DONE]`, reassembling events that span `body_filter` chunk boundaries via an `ngx.ctx` buffer.

## Activation (per-rule, opt-in)

```json
"response": {
  "code": 305,
  "redirect_uri": "https://api.anthropic.com",
  "llm_translate": {
    "source": "openai", "target": "anthropic",
    "model_map": { "gpt-4o": "claude-opus-4-8" }
  }
}
```
Inject the Anthropic key via the **server's `custom_headers`** (`x-api-key`) — no secret in code. The module sets `anthropic-version` if absent and clears the inbound `Authorization`.

## Tests

`api/test_llm_translator.lua` — 17 assertions over request/response/streaming, including SSE fed in 7-byte slices to exercise event-boundary buffering. **Passes on OpenResty `resty`.**

## Scope / follow-ups

- ✅ Text content, streaming + non-streaming, OpenAI→Anthropic.
- ⏭️ Tool/function calling, multimodal images, reverse direction (Anthropic-in→OpenAI-out), more provider pairs.
- The k3s ingress **helm `files/nginx.conf` is not modified** (separate manual chart) — add the same two filter delegations there if you want translation at that layer.

## Deploy note

The `api/` change ships via a `code` deploy; the **nginx template change needs a full/nginx deploy + reload** (it edits `header_filter`/`body_filter` blocks). All additions are guarded (`ngx.ctx.llm` nil → no-op), so existing traffic is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)