### PR TITLE
feat(mcp): MCP gateway — govern traffic to external MCP servers

### DIFF
--- a/api/gateway_resp.lua
+++ b/api/gateway_resp.lua
@@ -298,6 +298,21 @@ elseif selectedRule.statusCode == 305 then
         end
     end
 
+    -- MCP gateway: govern JSON-RPC traffic to an upstream MCP server
+    -- (tool/method allow-deny, rate limit, audit, auth bridging).  May
+    -- finalise the request with a JSON-RPC error on a denied tools/call;
+    -- otherwise it arms ngx.ctx.mcp_gateway and proxying continues.
+    local mcp_cfg = selectedRule.rule_data and selectedRule.rule_data.response
+        and selectedRule.rule_data.response.mcp_gateway
+    if mcp_cfg and mcp_cfg.enabled then
+        local ok_mcp, McpGateway = pcall(require, "mcp_gateway")
+        if ok_mcp then
+            McpGateway.enforce(mcp_cfg)
+        else
+            ngx.log(ngx.ERR, "mcp_gateway: module load failed: ", tostring(McpGateway))
+        end
+    end
+
     ngx.var.proxy_host_scheme = origin_serverScheme
 
     -- Per-server proxy timeouts: pass to balancer_by_lua via ngx.ctx

--- a/api/mcp_gateway.lua
+++ b/api/mcp_gateway.lua
@@ -1,0 +1,212 @@
+-- MCP Gateway for WSLProxy
+--
+-- Turns wslproxy into a governed front door in front of *external* MCP
+-- (Model Context Protocol) servers — filesystem, GitHub, Slack, internal
+-- tools, etc.  Clients connect to wslproxy; wslproxy inspects the
+-- JSON-RPC traffic and enforces policy before proxying upstream.
+--
+-- NOTE: this is the gateway (proxy to OTHER MCP servers).  It is distinct
+-- from api/mcp/ which is wslproxy's own MCP *server* (manage the gateway
+-- itself).  They don't share code.
+--
+-- MCP rides JSON-RPC 2.0 over Streamable HTTP.  Governance is entirely
+-- request-side — inspect the `tools/call` on the way in, allow -> proxy,
+-- deny -> return a JSON-RPC error without ever reaching the upstream.
+-- No response rewriting, so no nginx template changes are required.
+--
+-- Capabilities (Phase 1 MVP):
+--   * Auth bridging   — strip the client's inbound credential; the
+--                       upstream MCP server's credential is injected via
+--                       the server's custom_headers (secrets stay server-side).
+--   * Tool/method allow-deny — block disallowed tools or JSON-RPC methods.
+--   * Audit           — log every tools/call to the audit trail.
+--   * Rate limiting   — per-client, optionally per-tool, via wsl_cache.
+--
+-- Activation is per-rule.  A rule's response carries:
+--   "mcp_gateway": {
+--     "enabled": true,
+--     "strip_client_auth": true,
+--     "tools":   { "mode": "deny", "list": ["delete_file","exec"] },
+--     "methods": { "deny": ["resources/write"] },
+--     "audit":   true,
+--     "rate_limit": { "window": 60, "max": 120, "per_tool": { "search": 20 } }
+--   }
+--
+-- Follow-ups (not in MVP): filter `tools/list` responses to the allowed
+-- set (response-side), multi-upstream federation, per-subject identity
+-- from JWT instead of remote_addr.
+
+local _M = {}
+
+local cjson = Cjson or require("cjson")
+local cjson_safe = require("cjson.safe")
+local _audit_ok, AuditLogger = pcall(require, "audit_logger")
+
+-- ============================================================
+-- Pure policy core (no ngx) — unit-testable
+-- ============================================================
+
+-- A decoded JSON-RPC batch is an array (has [1]); a single call is an
+-- object (has .jsonrpc/.method).  cheap, allocation-free check.
+function _M.is_batch(rpc)
+    return type(rpc) == "table" and rpc[1] ~= nil
+end
+
+local function list_contains(list, value)
+    if type(list) ~= "table" or value == nil then return false end
+    for _, v in ipairs(list) do
+        if v == value then return true end
+    end
+    return false
+end
+
+--- Is `tool` permitted by the policy?
+---   mode "allow" -> only names in `list` pass (allowlist)
+---   mode "deny"  -> names in `list` are blocked (denylist); default
+---   no tools block at all -> everything passes
+function _M.tool_allowed(cfg, tool)
+    local t = cfg and cfg.tools
+    if type(t) ~= "table" or type(t.list) ~= "table" or #t.list == 0 then
+        return true
+    end
+    if t.mode == "allow" then
+        return list_contains(t.list, tool)
+    end
+    -- default: denylist
+    return not list_contains(t.list, tool)
+end
+
+--- Is a JSON-RPC `method` explicitly denied?
+function _M.method_denied(cfg, method)
+    local m = cfg and cfg.methods
+    if type(m) ~= "table" then return false end
+    return list_contains(m.deny, method)
+end
+
+--- Pure decision for one JSON-RPC call.  Rate limiting is stateful and
+--- handled separately in the ngx layer.
+--- Returns { allow = true, method, tool } OR
+---         { allow = false, code, message }.
+function _M.decision(cfg, call)
+    if type(call) ~= "table" then
+        return { allow = true }       -- not a JSON-RPC object; pass through
+    end
+    local method = call.method
+    if type(method) == "string" and _M.method_denied(cfg, method) then
+        return {
+            allow = false, code = -32601,
+            message = "MCP gateway: method '" .. method .. "' is not allowed by policy",
+        }
+    end
+    if method == "tools/call" then
+        local tool = call.params and call.params.name
+        if not _M.tool_allowed(cfg, tool) then
+            return {
+                allow = false, code = -32000,
+                message = "MCP gateway: tool '" .. tostring(tool) ..
+                    "' is not allowed by policy",
+            }
+        end
+        return { allow = true, method = method, tool = tool }
+    end
+    return { allow = true, method = method }
+end
+
+-- ============================================================
+-- ngx-facing wrappers
+-- ============================================================
+
+-- Per-client (optionally per-tool) sliding window via the shared dict.
+-- Returns true to allow, false to reject.  Fails open on any infra issue.
+local function rate_ok(cfg, tool)
+    local rl = cfg.rate_limit
+    if type(rl) ~= "table" then return true end
+    local dict = ngx.shared.wsl_cache
+    if not dict then return true end
+    local max = rl.per_tool and tool and tonumber(rl.per_tool[tool]) or tonumber(rl.max)
+    if not max then return true end           -- no limit configured for this tool
+    local window = tonumber(rl.window) or 60
+    local client = ngx.var.remote_addr or "0.0.0.0"
+    local key = "mcpgw:" .. (tool or "_") .. ":" .. client
+    local cur, err = dict:incr(key, 1, 0, window)
+    if err then
+        ngx.log(ngx.WARN, "mcp_gateway: rate counter error: ", err)
+        return true                            -- fail-open
+    end
+    return not (cur and cur > max)
+end
+
+-- Send a JSON-RPC error response and end the request without proxying.
+local function reject(id, code, message)
+    ngx.status = ngx.HTTP_OK                   -- MCP surfaces errors in the JSON-RPC body
+    ngx.header["Content-Type"] = "application/json"
+    ngx.header["X-MCP-Gateway"] = "deny"
+    ngx.say(cjson.encode({
+        jsonrpc = "2.0",
+        id = id,
+        error = { code = code or -32000, message = message or "denied by MCP gateway policy" },
+    }))
+    return ngx.exit(ngx.HTTP_OK)
+end
+
+local function audit_call(cfg, call)
+    if not cfg.audit or not _audit_ok or not AuditLogger then return end
+    local tool = call.params and call.params.name
+    pcall(AuditLogger.log, "mcp_tool_call", ngx.var.remote_addr or "unknown",
+        "mcp", tool or "?", {
+            method = call.method,
+            client = ngx.var.remote_addr,
+            request_id = ngx.var.request_id,
+        })
+end
+
+--- Access-phase entry point.  Inspect the JSON-RPC request and enforce
+--- policy.  Either returns (allowed — caller continues to proxy) or
+--- finalises the request with a JSON-RPC error (denied / rate-limited).
+--- Fails OPEN on anything it can't inspect (non-POST, unbuffered body,
+--- non-JSON) so the gateway never breaks legitimate traffic it can't
+--- reason about — governance applies to recognised tools/call only.
+function _M.enforce(cfg)
+    if type(cfg) ~= "table" or cfg.enabled == false then return end
+
+    -- SSE GET (the server->client stream) and other non-body methods just
+    -- proxy through; there's no tools/call to inspect.
+    if ngx.req.get_method() ~= "POST" then return end
+
+    ngx.req.read_body()
+    local body = ngx.req.get_body_data()
+    if not body or body == "" then
+        -- Body buffered to a temp file (large) — can't inspect cheaply.
+        ngx.log(ngx.WARN, "mcp_gateway: request body not in memory; passing through")
+        return
+    end
+
+    local rpc = cjson_safe.decode(body)
+    if type(rpc) ~= "table" then return end    -- not JSON-RPC
+
+    local calls = _M.is_batch(rpc) and rpc or { rpc }
+    for _, call in ipairs(calls) do
+        local d = _M.decision(cfg, call)
+        if not d.allow then
+            return reject(call.id, d.code, d.message)
+        end
+        if call.method == "tools/call" then
+            local tool = call.params and call.params.name
+            if not rate_ok(cfg, tool) then
+                return reject(call.id, -32000,
+                    "MCP gateway: rate limit exceeded for tool '" .. tostring(tool) .. "'")
+            end
+            audit_call(cfg, call)
+        end
+    end
+
+    -- Allowed.  Auth bridging: drop the client's credential so it is not
+    -- forwarded upstream — the upstream MCP server's own credential is
+    -- injected by the server's custom_headers.
+    if cfg.strip_client_auth then
+        ngx.req.clear_header("Authorization")
+    end
+    ngx.ctx.mcp_gateway = { active = true }
+end
+
+return _M

--- a/api/test_mcp_gateway.lua
+++ b/api/test_mcp_gateway.lua
@@ -1,0 +1,72 @@
+-- Standalone test for the pure policy core of mcp_gateway (no ngx).
+-- Run with:  resty api/test_mcp_gateway.lua
+package.path = "/tmp/?.lua;./api/?.lua;" .. package.path
+local M = require("mcp_gateway")
+
+local failures = 0
+local function check(name, cond)
+    print((cond and "  ok   - " or "  FAIL - ") .. name)
+    if not cond then failures = failures + 1 end
+end
+
+-- tool_allowed: denylist (default)
+do
+    local cfg = { tools = { mode = "deny", list = { "delete_file", "exec" } } }
+    check("denylist blocks listed", M.tool_allowed(cfg, "delete_file") == false)
+    check("denylist allows others", M.tool_allowed(cfg, "read_file") == true)
+end
+
+-- tool_allowed: allowlist
+do
+    local cfg = { tools = { mode = "allow", list = { "read_file", "list_dir" } } }
+    check("allowlist passes listed", M.tool_allowed(cfg, "read_file") == true)
+    check("allowlist blocks others", M.tool_allowed(cfg, "delete_file") == false)
+end
+
+-- tool_allowed: no policy -> all pass
+do
+    check("no tools block -> allow all", M.tool_allowed({}, "anything") == true)
+end
+
+-- method_denied
+do
+    local cfg = { methods = { deny = { "resources/write" } } }
+    check("method denied", M.method_denied(cfg, "resources/write") == true)
+    check("method allowed", M.method_denied(cfg, "tools/list") == false)
+end
+
+-- decision: denied tool
+do
+    local cfg = { tools = { mode = "deny", list = { "exec" } } }
+    local d = M.decision(cfg, { jsonrpc = "2.0", id = 7, method = "tools/call",
+                                params = { name = "exec", arguments = {} } })
+    check("decision blocks denied tool", d.allow == false and d.code == -32000)
+end
+
+-- decision: allowed tool
+do
+    local cfg = { tools = { mode = "deny", list = { "exec" } } }
+    local d = M.decision(cfg, { method = "tools/call", params = { name = "read_file" } })
+    check("decision allows ok tool", d.allow == true and d.tool == "read_file")
+end
+
+-- decision: denied method
+do
+    local cfg = { methods = { deny = { "resources/write" } } }
+    local d = M.decision(cfg, { method = "resources/write" })
+    check("decision blocks denied method", d.allow == false and d.code == -32601)
+end
+
+-- decision: non-tools method passes
+do
+    local d = M.decision({}, { method = "tools/list" })
+    check("decision allows tools/list", d.allow == true)
+end
+
+-- batch detection
+do
+    check("batch detected", M.is_batch({ { method = "x" }, { method = "y" } }) == true)
+    check("single not batch", M.is_batch({ method = "x" }) == false)
+end
+
+if failures == 0 then print("ALL PASS") else print(failures .. " FAILURE(S)"); os.exit(1) end

--- a/docs/mcp-gateway.md
+++ b/docs/mcp-gateway.md
@@ -1,0 +1,100 @@
+# MCP Gateway
+
+Use WSLProxy as a **governed front door in front of external MCP (Model
+Context Protocol) servers** — filesystem, GitHub, Slack, internal tools.
+Clients connect to WSLProxy; WSLProxy inspects the JSON-RPC traffic and
+enforces policy before proxying upstream.
+
+> **Not the same as [the MCP _server_](../api/mcp/README.md).** That exposes
+> WSLProxy's *own* management surface as MCP. This is the inverse: WSLProxy
+> as a gateway *in front of other* MCP servers.
+
+MCP rides JSON-RPC 2.0 over Streamable HTTP, which WSLProxy already
+reverse-proxies. The gateway adds MCP-aware **governance**, entirely
+request-side (inspect `tools/call` on the way in). No response rewriting,
+so enabling it is just a rule change — no nginx reload-template churn.
+
+## Capabilities (Phase 1)
+
+| Capability | What it does |
+|---|---|
+| **Auth bridging** | Strip the client's inbound credential; the upstream MCP server's credential is injected via the server's `custom_headers`. Secrets stay server-side — clients never hold backend tokens. |
+| **Tool / method allow-deny** | Block disallowed tool names (`tools/call`) or JSON-RPC methods. Allowlist or denylist. |
+| **Audit** | Every `tools/call` logged to `data/audit/YYYY-MM/DD.json` (`action: mcp_tool_call`). |
+| **Rate limiting** | Per-client, optionally per-tool, sliding window via the `wsl_cache` shared dict. |
+
+## Setup
+
+### 1. Inject the upstream MCP server's credential (server `custom_headers`)
+
+On the gateway **server**, add the upstream's auth header so it's applied to
+every proxied request:
+
+```json
+"custom_headers": [
+  { "header_key": "Authorization", "header_value": "Bearer <UPSTREAM_MCP_TOKEN>" }
+]
+```
+
+### 2. Add an `mcp_gateway` policy to the routing **rule**
+
+The rule proxies (code `305`) to the upstream MCP server and carries the policy:
+
+```json
+"response": {
+  "code": 305,
+  "redirect_uri": "https://upstream-mcp.internal:8080",
+  "mcp_gateway": {
+    "enabled": true,
+    "strip_client_auth": true,
+    "tools":   { "mode": "deny", "list": ["delete_file", "exec"] },
+    "methods": { "deny": ["resources/write"] },
+    "audit":   true,
+    "rate_limit": { "window": 60, "max": 120, "per_tool": { "search": 20 } }
+  }
+}
+```
+
+- `tools.mode`: `"allow"` (only listed tools pass) or `"deny"` (listed tools blocked; default).
+- `methods.deny`: optional JSON-RPC method denylist (e.g. block all writes).
+- `rate_limit`: `max` is the per-client default; `per_tool` overrides specific tools. `window` in seconds.
+- `strip_client_auth`: drop the client's `Authorization` before proxying (used with step 1's `custom_headers`).
+
+A denied or rate-limited call is answered with a standard **JSON-RPC error**
+and never reaches the upstream.
+
+## Verify (direct HTTP)
+
+```sh
+GW=https://your-gateway.example.com/mcp/jsonrpc
+
+# Allowed tool -> reaches upstream
+curl -s $GW -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"read_file","arguments":{"path":"/etc/hostname"}}}'
+
+# Denied tool -> JSON-RPC error, upstream never hit (response has X-MCP-Gateway: deny)
+curl -s $GW -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delete_file","arguments":{"path":"/"}}}'
+# => {"jsonrpc":"2.0","id":2,"error":{"code":-32000,"message":"MCP gateway: tool 'delete_file' is not allowed by policy"}}
+```
+
+Point any MCP client (Claude Desktop/Code, Cursor, …) at the gateway URL
+instead of the upstream — the protocol is unchanged; only the policy is added.
+
+## Behaviour & safety
+
+- **Fails open on what it can't inspect** — non-POST requests (e.g. the SSE
+  GET stream), bodies buffered to disk, or non-JSON-RPC payloads pass through
+  untouched. Governance applies to recognised `tools/call`/methods only.
+- **Fails open on infra issues** — missing shared dict / audit module degrade
+  gracefully rather than breaking traffic.
+- Errors use HTTP `200` with a JSON-RPC `error` body, the convention MCP
+  clients expect.
+
+## Roadmap (not in Phase 1)
+
+- Filter `tools/list` responses to the allowed set (response-side) so denied
+  tools don't even appear in a client's catalogue.
+- Multi-upstream **federation** — aggregate several MCP servers' tool
+  catalogues under one endpoint with namespacing and per-tool dispatch.
+- Per-subject identity (from JWT) for rate-limit/audit instead of client IP.


### PR DESCRIPTION
## What

WSLProxy as a **governed front door in front of external MCP (Model Context Protocol) servers** — filesystem, GitHub, Slack, internal tools. Clients connect to WSLProxy; it inspects the JSON-RPC traffic and enforces policy before proxying upstream.

> Distinct from [`api/mcp/`](../api/mcp/README.md), which is WSLProxy's own MCP *server* (manage the gateway). This is the inverse — a gateway in front of *other* MCP servers. Sibling of the AI gateway (#1082).

## Why request-side only

MCP rides JSON-RPC 2.0 over Streamable HTTP, already reverse-proxied. Governance happens entirely in the **access phase** (inspect `tools/call`, allow→proxy / deny→JSON-RPC error). **No response rewriting → no nginx template change** → ships via a plain `code` deploy.

## Capabilities (Phase 1)

| Capability | How |
|---|---|
| **Auth bridging** | `strip_client_auth` drops the client credential; upstream cred injected via the server's `custom_headers` |
| **Tool/method allow-deny** | allowlist or denylist on tool names + JSON-RPC methods |
| **Audit** | every `tools/call` → `audit_logger` (`action: mcp_tool_call`) |
| **Rate limiting** | per-client, optionally per-tool, via `wsl_cache` |

## Config (per rule)

```json
"response": {
  "code": 305, "redirect_uri": "https://upstream-mcp.internal:8080",
  "mcp_gateway": {
    "enabled": true, "strip_client_auth": true,
    "tools":   { "mode": "deny", "list": ["delete_file","exec"] },
    "methods": { "deny": ["resources/write"] },
    "audit":   true,
    "rate_limit": { "window": 60, "max": 120, "per_tool": { "search": 20 } }
  }
}
```

## Tests + live validation

- `api/test_mcp_gateway.lua` — **13 policy assertions, pass on resty**.
- **Live on a mock MCP server through real nginx:** allowed tool reached the upstream; denied tool blocked with `X-MCP-Gateway: deny` (upstream never hit); per-tool rate limit tripped on the 3rd call.

## Safety

Fails **open** on what it can't inspect (non-POST/SSE GET, disk-buffered bodies, non-JSON-RPC) and on infra issues (missing shared dict/audit). Errors are HTTP 200 + JSON-RPC `error` body (MCP convention). Per-rule opt-in — no effect on existing traffic.

## Roadmap (follow-ups)

`tools/list` response filtering · multi-upstream federation (catalog merge + dispatch) · JWT-subject identity for rate-limit/audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)