### PR TITLE
ci(nightly): deploy int via Vault secrets mode to fix failing assertion

### DIFF
--- a/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
@@ -145,7 +145,12 @@ jobs:
       host_ip: "192.168.1.193"
       ssh_user: bwalia
       connection_mode: local
-      secrets_mode: github_secret
+      # The int host (192.168.1.193) sets vault_secrets_enabled: true in its
+      # host_vars, so deploy_data.yml asserts VAULT_ADDR/VAULT_TOKEN are
+      # exported. Use Vault mode (matching the delivery/promotion pipelines)
+      # so the "Export Vault credentials" step runs and exports them — in
+      # github_secret mode that step is skipped and the assertion fails.
+      secrets_mode: vault
       health_endpoint: "http://localhost:8080/health"
       health_check_mode: local
       docker_prune: true
@@ -154,6 +159,10 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+      # Kept so an emergency rollback to secrets_mode: github_secret is a
+      # one-line revert — no secrets need to be re-added.
       SETTINGS_SECRET: ${{ secrets.DOT_WSLPROXY_SETTINGS_INT }}
       ENV_CREDS_SECRET: ${{ secrets.DOT_WSLPROXY_ENV_CREDS_INT }}
 


### PR DESCRIPTION
## Problem

The **Nightly Integration Pipeline** failed at **Stage 2: Deploy Int** ([run 27999746083](https://github.com/bwalia/wslproxy/actions/runs/27999746083)) in the *Run Ansible Playbook* step:

```
TASK [wslproxy : Vault: assert env vars and target_env are set]
fatal: [192.168.1.193]: FAILED!
  assertion: "lookup('env', 'VAULT_TOKEN') | length > 0"
  msg: "vault_secrets_enabled=true requires VAULT_TOKEN and VAULT_ADDR to be exported..."
```

## Root cause

Configuration mismatch between the inventory and the nightly pipeline:

1. The int host `192.168.1.193` sets `vault_secrets_enabled: true` in `infra/ansible/host_vars/192.168.1.193/vars.yaml`.
2. With that flag, `roles/wslproxy/tasks/deploy_data.yml` asserts `VAULT_ADDR`/`VAULT_TOKEN` are exported in the environment.
3. But the nightly pipeline deployed int with `secrets_mode: github_secret`. In that mode the reusable `deploy-environment.yml`'s "Export Vault credentials" step is **skipped** (`if: secrets_mode == 'vault'`), and the nightly job never passed `VAULT_ADDR`/`VAULT_TOKEN` to the reusable workflow at all.
4. Result: `lookup('env','VAULT_TOKEN')` is empty → assertion fails → playbook exits 2 → nightly stops.

The delivery and promotion pipelines don't hit this because they already deploy int with `secrets_mode: vault` and pass the Vault secrets. The nightly pipeline simply wasn't updated when int moved to Vault mode.

## Fix

Make the nightly `deploy-int` job mirror the delivery/promotion pipelines:

- `secrets_mode: github_secret` → `secrets_mode: vault`
- Pass `VAULT_ADDR` / `VAULT_TOKEN` to the reusable workflow (kept `SETTINGS_SECRET`/`ENV_CREDS_SECRET` so an emergency rollback to `github_secret` mode is a one-line revert).

## Verification

Triggered the pipeline from this branch ([run 28009280346](https://github.com/bwalia/wslproxy/actions/runs/28009280346)):

- ✅ `Export Vault credentials` step now runs (was skipped before)
- ✅ `Vault: assert env vars and target_env are set` → "All assertions passed"
- ✅ `Vault: fetch settings.json` + `write settings.json` succeed

The reported assertion failure is resolved.

## Known follow-up (out of scope for this PR)

The branch run then fails one task later at `Vault: fetch env file` because the Vault secret `secret/data/wslproxy/int/env` returns non-200 (missing/regressed since it last worked in the promotion run on 2026-06-21). This is a **separate Vault data issue** that affects all vault-mode int deploys (promotion/delivery/nightly), not a workflow defect — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)