### PR TITLE
fix(ci): render Slack notifications with real newlines (all workflows)

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -558,8 +558,15 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":white_check_mark: *WSLProxy ${{ inputs.env_label }} — Success*\n*Mode:* ${{ inputs.deploy_mode }} | *Host:* ${{ inputs.host_ip }}\n*Branch:* ${{ github.ref_name }} | *Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.actor }} (${{ github.event_name }})" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg envlabel "${{ inputs.env_label }}" \
+              --arg mode "${{ inputs.deploy_mode }}" \
+              --arg host "${{ inputs.host_ip }}" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg event "${{ github.event_name }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":white_check_mark: *WSLProxy \($envlabel) — Success*\n*Mode:* \($mode) | *Host:* \($host)\n*Branch:* \($branch) | *Commit:* `\($commit)`\n*Triggered by:* \($actor) (\($event))")}')"
 
       - name: Slack notify - deploy failed
         if: failure()
@@ -568,5 +575,14 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":x: *Stage ${{ inputs.stage_number }} FAILED: ${{ inputs.env_label }}*\nDeploy or health check failed — pipeline stopped.\n*Mode:* ${{ inputs.deploy_mode }} | *Host:* ${{ inputs.host_ip }}\n*Branch:* ${{ github.ref_name }} | *Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.actor }} (${{ github.event_name }})\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg stage "${{ inputs.stage_number }}" \
+              --arg envlabel "${{ inputs.env_label }}" \
+              --arg mode "${{ inputs.deploy_mode }}" \
+              --arg host "${{ inputs.host_ip }}" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg event "${{ github.event_name }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":x: *Stage \($stage) FAILED: \($envlabel)*\nDeploy or health check failed — pipeline stopped.\n*Mode:* \($mode) | *Host:* \($host)\n*Branch:* \($branch) | *Commit:* `\($commit)`\n*Triggered by:* \($actor) (\($event))\n*Logs:* \($logs)")}')"

--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -146,8 +146,13 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":x: *Stage 1 FAILED: Build & Validate*\nConfig validation errors found — pipeline stopped.\n*Branch:* ${{ github.ref_name }} | *Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.actor }} (${{ github.event_name }})\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg event "${{ github.event_name }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":x: *Stage 1 FAILED: Build & Validate*\nConfig validation errors found — pipeline stopped.\n*Branch:* \($branch) | *Commit:* `\($commit)`\n*Triggered by:* \($actor) (\($event))\n*Logs:* \($logs)")}')"
 
   # ──────────────────────────────────────────────────────
   # Stage 2: Deploy Int (192.168.1.193)
@@ -248,8 +253,13 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":x: *Stage 3 FAILED: Smoke Test Int*\nHealth check or API endpoint tests failed — pipeline stopped before test environment.\n*Branch:* ${{ github.ref_name }} | *Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.actor }} (${{ github.event_name }})\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg event "${{ github.event_name }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":x: *Stage 3 FAILED: Smoke Test Int*\nHealth check or API endpoint tests failed — pipeline stopped before test environment.\n*Branch:* \($branch) | *Commit:* `\($commit)`\n*Triggered by:* \($actor) (\($event))\n*Logs:* \($logs)")}')"
 
   # ──────────────────────────────────────────────────────
   # Stage 4: Deploy Test (192.168.1.140)

--- a/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
@@ -128,8 +128,10 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":x: *Nightly Pipeline: Validation FAILED*\nConfig or template errors on \`${{ env.NIGHTLY_BRANCH }}\` — nightly stopped.\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions (Nightly)", text: $text}')"
+            -d "$(jq -n \
+              --arg branch "${{ env.NIGHTLY_BRANCH }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions (Nightly)", text: (":x: *Nightly Pipeline: Validation FAILED*\nConfig or template errors on `\($branch)` — nightly stopped.\n*Logs:* \($logs)")}')"
 
   # ──────────────────────────────────────────────────────
   # Stage 2: Deploy to Int (192.168.1.193)
@@ -245,8 +247,11 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":x: *Nightly Pipeline: Smoke Test FAILED on Int*\nHealth check or API tests failed — nightly stopped before Test environment.\n*Branch:* \`${{ env.NIGHTLY_BRANCH }}\` | *Mode:* ${{ env.NIGHTLY_DEPLOY_MODE }}\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions (Nightly)", text: $text}')"
+            -d "$(jq -n \
+              --arg branch "${{ env.NIGHTLY_BRANCH }}" \
+              --arg mode "${{ env.NIGHTLY_DEPLOY_MODE }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions (Nightly)", text: (":x: *Nightly Pipeline: Smoke Test FAILED on Int*\nHealth check or API tests failed — nightly stopped before Test environment.\n*Branch:* `\($branch)` | *Mode:* \($mode)\n*Logs:* \($logs)")}')"
 
   # ──────────────────────────────────────────────────────
   # Stage 4: Deploy to Test (192.168.1.140) — automatic
@@ -324,8 +329,12 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":white_check_mark: *Nightly Integration Pipeline PASSED*\nAll stages succeeded — \`${{ env.NIGHTLY_BRANCH }}\` deployed through Int and Test.\n*Mode:* ${{ env.NIGHTLY_DEPLOY_MODE }} | *Commit:* \`${{ github.sha }}\`\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions (Nightly)", text: $text}')"
+            -d "$(jq -n \
+              --arg branch "${{ env.NIGHTLY_BRANCH }}" \
+              --arg mode "${{ env.NIGHTLY_DEPLOY_MODE }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions (Nightly)", text: (":white_check_mark: *Nightly Integration Pipeline PASSED*\nAll stages succeeded — `\($branch)` deployed through Int and Test.\n*Mode:* \($mode) | *Commit:* `\($commit)`\n*Logs:* \($logs)")}')"
 
       - name: Slack notify - Nightly failed
         if: >
@@ -338,8 +347,15 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":x: *Nightly Integration Pipeline FAILED*\nValidate: ${{ needs.validate.result }} | Int: ${{ needs.deploy-int.result }} | Smoke: ${{ needs.smoke-test-int.result }} | Test: ${{ needs.deploy-test.result }}\n*Branch:* \`${{ env.NIGHTLY_BRANCH }}\` | *Mode:* ${{ env.NIGHTLY_DEPLOY_MODE }}\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions (Nightly)", text: $text}')"
+            -d "$(jq -n \
+              --arg validate "${{ needs.validate.result }}" \
+              --arg int "${{ needs.deploy-int.result }}" \
+              --arg smoke "${{ needs.smoke-test-int.result }}" \
+              --arg test "${{ needs.deploy-test.result }}" \
+              --arg branch "${{ env.NIGHTLY_BRANCH }}" \
+              --arg mode "${{ env.NIGHTLY_DEPLOY_MODE }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions (Nightly)", text: (":x: *Nightly Integration Pipeline FAILED*\nValidate: \($validate) | Int: \($int) | Smoke: \($smoke) | Test: \($test)\n*Branch:* `\($branch)` | *Mode:* \($mode)\n*Logs:* \($logs)")}')"
 
       - name: Fail pipeline if any stage failed
         if: >

--- a/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
@@ -99,8 +99,10 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":x: *Promotion Pipeline: Validation FAILED*\nConfig validation errors on main — promotion stopped.\n*Triggered by:* ${{ github.actor }}\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg actor "${{ github.actor }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":x: *Promotion Pipeline: Validation FAILED*\nConfig validation errors on main — promotion stopped.\n*Triggered by:* \($actor)\n*Logs:* \($logs)")}')"
 
   # ──────────────────────────────────────────────────────
   # Stage 2: Deploy to Int (always runs)
@@ -194,8 +196,10 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text ":x: *Promotion Pipeline: Smoke Test FAILED on Int*\nPromotion stopped before test environment.\n*Triggered by:* ${{ github.actor }}\n*Logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg actor "${{ github.actor }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":x: *Promotion Pipeline: Smoke Test FAILED on Int*\nPromotion stopped before test environment.\n*Triggered by:* \($actor)\n*Logs:* \($logs)")}')"
 
   # ──────────────────────────────────────────────────────
   # Stage 4: Deploy to Test (final stage in this pipeline —

--- a/.github/workflows/e2e-admin-ui-login.yml
+++ b/.github/workflows/e2e-admin-ui-login.yml
@@ -246,8 +246,17 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text "WSL Proxy Admin UI Login tests passed :white_check_mark:\n*Environment:* ${{ matrix.environment }}\n*Tests:* ${{ steps.results.outputs.passed }}/${{ steps.results.outputs.total }} passed (${{ steps.results.outputs.skipped }} skipped)\n*Target:* ${{ matrix.url }}\n*Branch:* ${{ github.ref_name }}\n*Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.event_name }} (${{ github.actor }})" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg env "${{ matrix.environment }}" \
+              --arg passed "${{ steps.results.outputs.passed }}" \
+              --arg total "${{ steps.results.outputs.total }}" \
+              --arg skipped "${{ steps.results.outputs.skipped }}" \
+              --arg url "${{ matrix.url }}" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg event "${{ github.event_name }}" \
+              --arg actor "${{ github.actor }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":white_check_mark: *WSL Proxy — Admin UI login is working*\nThe automated login tests just ran against the *\($env)* environment and everything passed, so admins can sign in normally.\n\n*What we checked:* \($passed) of \($total) login tests passed (\($skipped) skipped)\n*Where:* \($url)\n*From code:* branch `\($branch)` at commit `\($commit)`\n*Started by:* \($event) (\($actor))")}')"
 
       - name: Slack notification - Login Tests Failed
         if: failure()
@@ -256,5 +265,16 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text "WSL Proxy Admin UI Login tests FAILED :x:\n*Environment:* ${{ matrix.environment }}\n*Tests:* ${{ steps.results.outputs.failed }} failed, ${{ steps.results.outputs.passed }} passed out of ${{ steps.results.outputs.total }} (${{ steps.results.outputs.skipped }} skipped)\n*Target:* ${{ matrix.url }}\n*Branch:* ${{ github.ref_name }}\n*Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.event_name }} (${{ github.actor }})\n*Screenshots & Traces:* Download from workflow artifacts\n*Workflow logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg env "${{ matrix.environment }}" \
+              --arg failed "${{ steps.results.outputs.failed }}" \
+              --arg passed "${{ steps.results.outputs.passed }}" \
+              --arg total "${{ steps.results.outputs.total }}" \
+              --arg skipped "${{ steps.results.outputs.skipped }}" \
+              --arg url "${{ matrix.url }}" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg event "${{ github.event_name }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":x: *WSL Proxy — Admin UI login may be broken*\nThe automated login tests just ran against the *\($env)* environment and some of them failed, so admins might not be able to sign in. Please take a look.\n\n*What we found:* \($failed) failed and \($passed) passed out of \($total) login tests (\($skipped) skipped)\n*Where:* \($url)\n*From code:* branch `\($branch)` at commit `\($commit)`\n*Started by:* \($event) (\($actor))\n*To debug:* screenshots and traces are attached to the workflow artifacts\n*Full logs:* \($logs)")}')"

--- a/.github/workflows/e2e-create-server.yml
+++ b/.github/workflows/e2e-create-server.yml
@@ -195,8 +195,16 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text "WSL Proxy Create Server test passed :white_check_mark:\n*Profile:* ${PROFILE}\n*Tests:* ${{ steps.results.outputs.passed }}/${{ steps.results.outputs.total }} passed\n*Target:* ${TARGET_URL}/servers\n*Note:* A new test server was created and is visible on the servers list.\n*Branch:* ${{ github.ref_name }}\n*Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.event_name }} (${{ github.actor }})" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg profile "$PROFILE" \
+              --arg passed "${{ steps.results.outputs.passed }}" \
+              --arg total "${{ steps.results.outputs.total }}" \
+              --arg target "$TARGET_URL" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg event "${{ github.event_name }}" \
+              --arg actor "${{ github.actor }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: ("WSL Proxy Create Server test passed :white_check_mark:\n*Profile:* \($profile)\n*Tests:* \($passed)/\($total) passed\n*Target:* \($target)/servers\n*Note:* A new test server was created and is visible on the servers list.\n*Branch:* \($branch)\n*Commit:* `\($commit)`\n*Triggered by:* \($event) (\($actor))")}')"
 
       - name: Slack notification - Create Server Failed
         if: failure()
@@ -205,5 +213,15 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text "WSL Proxy Create Server test FAILED :x:\n*Profile:* ${PROFILE}\n*Tests:* ${{ steps.results.outputs.failed }} failed, ${{ steps.results.outputs.passed }} passed out of ${{ steps.results.outputs.total }}\n*Target:* ${TARGET_URL}/servers\n*Branch:* ${{ github.ref_name }}\n*Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.event_name }} (${{ github.actor }})\n*Screenshots & Traces:* Download from workflow artifacts\n*Workflow logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg profile "$PROFILE" \
+              --arg failed "${{ steps.results.outputs.failed }}" \
+              --arg passed "${{ steps.results.outputs.passed }}" \
+              --arg total "${{ steps.results.outputs.total }}" \
+              --arg target "$TARGET_URL" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg event "${{ github.event_name }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: ("WSL Proxy Create Server test FAILED :x:\n*Profile:* \($profile)\n*Tests:* \($failed) failed, \($passed) passed out of \($total)\n*Target:* \($target)/servers\n*Branch:* \($branch)\n*Commit:* `\($commit)`\n*Triggered by:* \($event) (\($actor))\n*Screenshots & Traces:* Download from workflow artifacts\n*Workflow logs:* \($logs)")}')"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -184,8 +184,17 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text "WSL Proxy E2E Tests passed :white_check_mark:\n*Environment:* ${{ matrix.environment }}\n*Tests:* ${{ steps.results.outputs.passed }}/${{ steps.results.outputs.total }} passed (${{ steps.results.outputs.skipped }} skipped)\n*Target:* ${{ steps.creds.outputs.gateway_url || steps.env_config.outputs.base_url }}\n*Branch:* ${{ github.ref_name }}\n*Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.event_name }} (${{ github.actor }})" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg env "${{ matrix.environment }}" \
+              --arg passed "${{ steps.results.outputs.passed }}" \
+              --arg total "${{ steps.results.outputs.total }}" \
+              --arg skipped "${{ steps.results.outputs.skipped }}" \
+              --arg target "${{ steps.creds.outputs.gateway_url || steps.env_config.outputs.base_url }}" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg event "${{ github.event_name }}" \
+              --arg actor "${{ github.actor }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: ("WSL Proxy E2E Tests passed :white_check_mark:\n*Environment:* \($env)\n*Tests:* \($passed)/\($total) passed (\($skipped) skipped)\n*Target:* \($target)\n*Branch:* \($branch)\n*Commit:* `\($commit)`\n*Triggered by:* \($event) (\($actor))")}')"
 
       - name: Slack notification - Tests Failed
         if: failure()
@@ -194,8 +203,19 @@ jobs:
         run: |
           curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
             -H 'Content-Type: application/json' \
-            -d "$(jq -n --arg text "WSL Proxy E2E Tests FAILED :x:\n*Environment:* ${{ matrix.environment }}\n*Tests:* ${{ steps.results.outputs.failed }} failed, ${{ steps.results.outputs.passed }} passed out of ${{ steps.results.outputs.total }} (${{ steps.results.outputs.skipped }} skipped)\n*Target:* ${{ steps.creds.outputs.gateway_url || steps.env_config.outputs.base_url }}\n*Branch:* ${{ github.ref_name }}\n*Commit:* \`${{ github.sha }}\`\n*Triggered by:* ${{ github.event_name }} (${{ github.actor }})\n*Screenshots & Traces:* Download from workflow artifacts\n*Workflow logs:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-              '{channel: "github-updates", username: "GitHub Actions", text: $text}')"
+            -d "$(jq -n \
+              --arg env "${{ matrix.environment }}" \
+              --arg failed "${{ steps.results.outputs.failed }}" \
+              --arg passed "${{ steps.results.outputs.passed }}" \
+              --arg total "${{ steps.results.outputs.total }}" \
+              --arg skipped "${{ steps.results.outputs.skipped }}" \
+              --arg target "${{ steps.creds.outputs.gateway_url || steps.env_config.outputs.base_url }}" \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg event "${{ github.event_name }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: ("WSL Proxy E2E Tests FAILED :x:\n*Environment:* \($env)\n*Tests:* \($failed) failed, \($passed) passed out of \($total) (\($skipped) skipped)\n*Target:* \($target)\n*Branch:* \($branch)\n*Commit:* `\($commit)`\n*Triggered by:* \($event) (\($actor))\n*Screenshots & Traces:* Download from workflow artifacts\n*Workflow logs:* \($logs)")}')"
 
       - name: Upload screenshot to Slack
         if: failure() && env.SLACK_BOT_TOKEN != ''


### PR DESCRIPTION
## What

Slack notifications across the CI workflows were showing the literal text `\n` between every line instead of actual line breaks. This fixes **all 16 messages** in **7 workflow files**.

## Why

Each message was passed to `jq` via `--arg text "...\n..."`. With `--arg`, jq treats the value as literal characters, so `\n` gets serialized as `\\n` in the JSON body — Slack then displays it as the text `\n`.

```
$ jq -n --arg text "line1\nline2" '{text:$text}'
{ "text": "line1\\nline2" }     # ← literal backslash-n, shows as \n in Slack
```

## Fix

Move each message template **into the jq filter** (where `\n` is a real newline) and pass the dynamic `${{ }}` / shell values through `--arg` with `\(...)` interpolation. The interpolation also safely escapes dynamic values (e.g. an actor name containing quotes) so they can't break the JSON.

```
$ jq -n '{text:"line1\nline2"}'
{ "text": "line1\nline2" }      # ← real newline, renders as a line break in Slack
```

For the **admin-login** workflow the wording was also rewritten into plainer language; the other workflows keep their existing wording (newline rendering only).

## Files covered (16 messages)

| File | Messages |
|------|----------|
| `e2e-admin-ui-login.yml` | passed + failed (reworded) |
| `e2e-tests.yml` | passed + failed |
| `e2e-create-server.yml` | passed + failed |
| `deploy-environment.yml` | success + failure |
| `deploy-wslproxy-delivery-pipeline.yml` | Stage 1 + Stage 3 failures |
| `deploy-wslproxy-nightly-pipeline.yml` | validation, smoke, passed, failed |
| `deploy-wslproxy-promotion-pipeline.yml` | validation + smoke failures |

## Notes

- `label` is a **reserved jq keyword**, so an initial `--arg label` failed to compile — renamed to `envlabel`. Every other arg name was checked against jq keywords (no other collisions).

## Verification

- No `jq -n --arg text` pattern remains in any workflow.
- All 16 jq filters compile-checked with sample args → **0 failures**.
- All 7 YAML files parse cleanly.
- Sample renders confirm real line breaks and literal backticks (e.g. `` *Commit:* `abc123` ``), no `\n` text.

### Rendered result (admin-login, passed)
```
:white_check_mark: *WSL Proxy — Admin UI login is working*
The automated login tests just ran against the *prod* environment and everything passed, so admins can sign in normally.

*What we checked:* 6 of 6 login tests passed (0 skipped)
*Where:* https://prod-our.wslproxy.com
*From code:* branch `main` at commit `635ee29…`
*Started by:* schedule (Harcharan-web)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)