### PR TITLE
fix(rules/auth): header-JWT validation fails closed + clearer form labels

### DIFF
--- a/api/rule_auth.lua
+++ b/api/rule_auth.lua
@@ -94,8 +94,20 @@ function M.authenticate(rule)
     if token_source == "header_jwt_token_validation" then
         local token = ngx.req.get_headers()[token_value_name]
         if not token then
-            return true  -- no header present → pass (existing behavior)
+            -- Fail-closed: an operator who configured header JWT
+            -- validation means "only requests carrying this header
+            -- should pass."  Earlier versions returned true here on
+            -- missing header — that was a footgun that left a
+            -- supposedly-authenticated endpoint fully open.  Behaviour
+            -- now matches the cookie paths above which already return
+            -- false on missing cookie.
+            return false
         end
+        -- Some clients send "Bearer <jwt>"; the cookie path strips
+        -- this and the header path didn't.  Strip it here too so an
+        -- operator who configures Header JWT doesn't have to know
+        -- which client convention they'll see.
+        token = string.gsub(tostring(token), "^[Bb]earer%s+", "")
         token = trim(ngx.unescape_uri(token))
         local verified = jwt:verify(passphrase, token)
         return verified and true or false

--- a/openresty-admin-next/src/app/(dashboard)/rules/[id]/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/rules/[id]/page.tsx
@@ -367,6 +367,65 @@ export default function RuleDetailPage() {
   const showTokenFields = !!form.jwt_token_validation_value;
   const showS3Fields = isS3 && !!form.jwt_token_validation_key;
 
+  // Field labels + hints adapt to the chosen validation type so the
+  // operator sees field semantics that match the mode they picked.
+  // Without this, "Token Value" / "Token Secret Key" was ambiguous —
+  // an operator might paste their raw API key into "Token Secret Key"
+  // expecting clients to send THAT, when actually the field is a JWT
+  // SIGNING SECRET and clients must send JWTs signed with it.
+  const validationFieldLabels = useMemo<{
+    valueLabel: string;
+    valueHint: string;
+    keyLabel: string;
+    keyHint: string;
+  }>(() => {
+    switch (form.jwt_token_validation) {
+      case "header_jwt_token_validation":
+        return {
+          valueLabel: "HTTP Header Name",
+          valueHint:
+            "Name of the request header that carries the JWT (e.g. \"x-api-key\", \"Authorization\"). Clients must send the JWT as this header's value.",
+          keyLabel: "JWT Signing Secret",
+          keyHint:
+            "Secret used to sign the JWT (HS256). Clients sign their tokens with this same value; wslproxy verifies the signature on each request. Treat like a password — anyone who has it can mint valid tokens.",
+        };
+      case "cookie_jwt_token_validation":
+        return {
+          valueLabel: "Cookie Name",
+          valueHint:
+            "Name of the cookie that carries the JWT (e.g. \"session\", \"auth_token\"). Clients must set this cookie with a JWT as its value.",
+          keyLabel: "JWT Signing Secret",
+          keyHint:
+            "Secret used to sign the JWT (HS256). Same secret used by whoever issues the cookie. Treat like a password.",
+        };
+      case "cookie_key_value":
+        return {
+          valueLabel: "Cookie Name",
+          valueHint:
+            "Name of the cookie to check. wslproxy compares the cookie's value to the \"Expected Value\" below — no JWT involved, just plain string equality.",
+          keyLabel: "Expected Cookie Value",
+          keyHint:
+            "Plain string the cookie must contain to pass. Less secure than JWT (no expiry, no per-client identity); use only for simple gating.",
+        };
+      case "amazon_s3_signed_header_validation":
+        return {
+          valueLabel: "S3 Bucket Name",
+          valueHint:
+            "Name of the S3 bucket this rule proxies to. wslproxy signs the outgoing request with AWS Signature V4 so S3 accepts it.",
+          keyLabel: "S3 Object Path / Prefix",
+          keyHint:
+            "Path or prefix inside the bucket the rule should access. Combined with the AWS access/secret keys below.",
+        };
+      default:
+        return {
+          valueLabel: "Token Value",
+          valueHint: "",
+          keyLabel: "Token Secret Key",
+          keyHint: "",
+        };
+    }
+  }, [form.jwt_token_validation]);
+
   const redirectLabel = useMemo(() => {
     if (form.code === 305) return "Proxy Pass URL";
     if (form.code === 301 || form.code === 302) return "Redirect URL";
@@ -745,13 +804,15 @@ export default function RuleDetailPage() {
             {form.jwt_token_validation !== "equals" && (
               <>
                 <Input
-                  label={isS3 ? "Bucket Name" : "Token Value"}
+                  label={validationFieldLabels.valueLabel}
+                  hint={validationFieldLabels.valueHint}
                   value={form.jwt_token_validation_value}
                   onChange={(e) => set("jwt_token_validation_value", e.target.value)}
                 />
                 {showTokenFields && (
                   <Input
-                    label={isS3 ? "Bucket File Paths" : "Token Secret Key"}
+                    label={validationFieldLabels.keyLabel}
+                    hint={validationFieldLabels.keyHint}
                     type={isS3 ? "text" : "password"}
                     value={form.jwt_token_validation_key}
                     onChange={(e) => set("jwt_token_validation_key", e.target.value)}


### PR DESCRIPTION
## Summary

Closes a **fail-open footgun** in per-rule header JWT validation, and relabels the rules form so operators can tell what to type in each field without reading the Lua source.

Verified live on prod `187.124.112.155`: the URL `https://ollama.diytaxreturn.co.uk/` with a `header_jwt_token_validation` rule attached was returning HTTP 200 to **any** request, including requests with no `x-api-key` header at all.

## The bug

`api/rule_auth.lua` line 97:

```lua
if not token then
    return true  -- no header present → pass (existing behavior)
end
```

The comment says "existing behavior" — this was a deliberate fail-open that turned every "header JWT-protected" rule into an honour-system check.  Any client that omitted the header got through.

The cookie paths above were already fail-closed (`if not cookie_header then return false end`).  Only the header path was inconsistent + insecure.

## Reproduction (before fix)

```
$ curl -kI https://ollama.diytaxreturn.co.uk/
HTTP/2 200            ← rule says "header JWT required", but missing header still passes
```

## The fix — backend

In `api/rule_auth.lua`:

1. **Missing header → fail-closed** (return false).  Matches the cookie paths.
2. **Strip `Bearer ` prefix** before verifying — the cookie path already does this; the header path didn't.  Clients sending `Authorization: Bearer <jwt>` now work the same as clients sending the raw token.

## The fix — frontend

`openresty-admin-next/src/app/(dashboard)/rules/[id]/page.tsx` — the rules form had:

```jsx
<Input label="Token Value" ... />
<Input label="Token Secret Key" ... />
```

These labels were misleading for Header-JWT mode: "Token Value" is actually the **header name** (e.g. `x-api-key`), and "Token Secret Key" is the **JWT signing secret** (not an API key the client sends).

Replaced with mode-aware labels + hint text per validation type:

| Mode | Field 1 | Field 2 |
|---|---|---|
| Header JWT | "HTTP Header Name" | "JWT Signing Secret" |
| Cookie JWT | "Cookie Name" | "JWT Signing Secret" |
| Cookie key=value | "Cookie Name" | "Expected Cookie Value" |
| Amazon S3 Signed | "S3 Bucket Name" | "S3 Object Path / Prefix" |

Each field gets a one-sentence hint explaining what to type, surfaced via `Input`'s existing `hint` prop (already supported, just not used here).

## ⚠ Behaviour change

Any rule configured with `header_jwt_token_validation` that was **relying** on the fail-open (i.e. accepting requests without the header) will start **rejecting** those requests after this ships.  For most operators this is the bug fix they actually wanted; for the rare case someone was deliberately exploiting fail-open, switch the rule's validation type back to "equals" (no auth).

## Verified

- ✅ `luac -p api/rule_auth.lua` — clean
- ✅ `npx tsc --noEmit` — no errors
- ✅ `npx next build` — completes through full route manifest

## Test plan after merge + deploy

```
# without header → should now be 403 (or whatever the no_rule default is)
curl -kI https://ollama.diytaxreturn.co.uk/

# with valid JWT signed with the configured secret → still 200
JWT=$(generate-jwt-with-secret)
curl -kI -H "x-api-key: $JWT" https://ollama.diytaxreturn.co.uk/

# with Bearer prefix → now also works
curl -kI -H "x-api-key: Bearer $JWT" https://ollama.diytaxreturn.co.uk/
```