### PR TITLE
ci: skip int stage in BOTH pipelines when self-hosted runner is offline

### DIFF
--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -155,10 +155,95 @@ jobs:
               '{channel: "github-updates", username: "GitHub Actions", text: (":x: *Stage 1 FAILED: Build & Validate*\nConfig validation errors found — pipeline stopped.\n*Branch:* \($branch) | *Commit:* `\($commit)`\n*Triggered by:* \($actor) (\($event))\n*Logs:* \($logs)")}')"
 
   # ──────────────────────────────────────────────────────
+  # Stage 1.5: Probe the int self-hosted runner.
+  #
+  # The int deploy + smoke-test BOTH run ON the int host itself
+  # (`runs-on: [self-hosted, Linux, int]`).  If the host is powered
+  # off or unreachable, those jobs sit in GitHub's "queued" state
+  # forever — the pipeline is stuck rather than failing, so manual
+  # intervention is required before test/prod can run.
+  #
+  # This job runs on a GitHub-hosted ubuntu-latest runner (always
+  # available) and asks the GitHub API whether any self-hosted
+  # runner labeled `int` is currently `online`.  If none are,
+  # deploy-int + test-int skip, and downstream stages (deploy-test,
+  # deploy-prod-*) still run because they already use
+  # `always() && !failure() && !cancelled()` guards.
+  #
+  # Fail-safe default: if the API call itself fails (token
+  # permissions, transient network), we ASSUME ONLINE and proceed
+  # as today — better to queue and time out than to silently skip
+  # a real deploy when the runner is actually fine.
+  # ──────────────────────────────────────────────────────
+  preflight-int:
+    name: "Stage 1.5: Probe Int Runner"
+    needs: [build-validate]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read   # required to list self-hosted runners
+    outputs:
+      runner_online: ${{ steps.probe.outputs.online }}
+    steps:
+      - name: Check if int self-hosted runner is online
+        id: probe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          # Default to "online" so an API failure does NOT skip the
+          # real deploy.  Only flip to false on a successful query
+          # that returns zero online int runners.
+          ONLINE=true
+          REASON="(fail-safe default — API not queried)"
+          if API_OUT=$(gh api "/repos/${{ github.repository }}/actions/runners" 2>&1); then
+            ONLINE_COUNT=$(printf '%s' "$API_OUT" | jq '
+              [ .runners[]
+                | select(any(.labels[]; .name == "int"))
+                | select(.status == "online")
+              ] | length
+            ')
+            if [ "${ONLINE_COUNT:-0}" -gt 0 ]; then
+              ONLINE=true
+              REASON="$ONLINE_COUNT online int runner(s) found"
+            else
+              ONLINE=false
+              REASON="no online int runner — skipping deploy-int + test-int"
+            fi
+          else
+            # API call failed.  Most likely cause: GITHUB_TOKEN
+            # doesn't have admin scope for repo-level self-hosted
+            # runners.  Log the response so an operator can see why,
+            # but proceed normally.
+            REASON="API query failed; assuming runner online. Response: $(printf '%s' "$API_OUT" | head -c 200)"
+          fi
+          echo "Decision: online=$ONLINE — $REASON"
+          if [ "$ONLINE" = "false" ]; then
+            echo "::warning::Int runner offline — deploy-int + test-int will be skipped. Pipeline will continue to test stage. Reason: $REASON"
+          else
+            echo "::notice::Int runner check passed — $REASON"
+          fi
+          echo "online=$ONLINE" >> "$GITHUB_OUTPUT"
+
+      - name: Slack notify - Int skipped (runner offline)
+        if: steps.probe.outputs.online == 'false'
+        continue-on-error: true
+        shell: bash
+        run: |
+          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n \
+              --arg branch "${{ github.ref_name }}" \
+              --arg commit "${{ github.sha }}" \
+              --arg actor "${{ github.actor }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":warning: *Stage 2 SKIPPED: Int (192.168.1.193)*\nInt self-hosted runner is offline — deploy + smoke-test skipped, pipeline continuing to test stage.\n*Branch:* \($branch) | *Commit:* `\($commit)`\n*Triggered by:* \($actor)\n*Logs:* \($logs)")}')"
+
+  # ──────────────────────────────────────────────────────
   # Stage 2: Deploy Int (192.168.1.193)
   # ──────────────────────────────────────────────────────
   deploy-int:
-    needs: [build-validate]
+    needs: [build-validate, preflight-int]
+    if: needs.preflight-int.outputs.runner_online == 'true'
     uses: ./.github/workflows/deploy-environment.yml
     with:
       env_name: int
@@ -193,7 +278,14 @@ jobs:
   test-int:
     name: "Stage 3: Smoke Test Int"
     runs-on: [self-hosted, Linux, int]
-    needs: [deploy-int]
+    needs: [deploy-int, preflight-int]
+    # Only smoke-test when the int runner was actually online AND
+    # deploy-int succeeded.  Without the preflight gate this job
+    # would also queue forever waiting for the offline int runner.
+    if: |
+      always() && !failure() && !cancelled() &&
+      needs.preflight-int.outputs.runner_online == 'true' &&
+      needs.deploy-int.result == 'success'
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
@@ -59,7 +59,12 @@ jobs:
   # ──────────────────────────────────────────────────────
   validate:
     name: "Validate Configs (main)"
-    runs-on: [self-hosted, Linux, int]
+    # Was [self-hosted, Linux, int] — but this job only runs git
+    # checkout + `python -m json.tool` over data/, neither of which
+    # needs the int runner.  Moving to ubuntu-latest means the
+    # promotion pipeline no longer gets STUCK AT STAGE 1 when int
+    # is offline (which is what happened on run 28359601509).
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -105,10 +110,72 @@ jobs:
               '{channel: "github-updates", username: "GitHub Actions", text: (":x: *Promotion Pipeline: Validation FAILED*\nConfig validation errors on main — promotion stopped.\n*Triggered by:* \($actor)\n*Logs:* \($logs)")}')"
 
   # ──────────────────────────────────────────────────────
-  # Stage 2: Deploy to Int (always runs)
+  # Stage 1.5: Probe the int self-hosted runner.
+  # Same pattern as the delivery pipeline — see that file for the
+  # rationale.  Runs on ubuntu-latest (always available); falls back
+  # to "assume online" on API failure so a permissions hiccup never
+  # silently skips a real deploy.
+  # ──────────────────────────────────────────────────────
+  preflight-int:
+    name: "Stage 1.5: Probe Int Runner"
+    needs: [validate]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    outputs:
+      runner_online: ${{ steps.probe.outputs.online }}
+    steps:
+      - name: Check if int self-hosted runner is online
+        id: probe
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          ONLINE=true
+          REASON="(fail-safe default — API not queried)"
+          if API_OUT=$(gh api "/repos/${{ github.repository }}/actions/runners" 2>&1); then
+            ONLINE_COUNT=$(printf '%s' "$API_OUT" | jq '
+              [ .runners[]
+                | select(any(.labels[]; .name == "int"))
+                | select(.status == "online")
+              ] | length
+            ')
+            if [ "${ONLINE_COUNT:-0}" -gt 0 ]; then
+              ONLINE=true
+              REASON="$ONLINE_COUNT online int runner(s) found"
+            else
+              ONLINE=false
+              REASON="no online int runner — skipping deploy-int + smoke-test-int"
+            fi
+          else
+            REASON="API query failed; assuming runner online. Response: $(printf '%s' "$API_OUT" | head -c 200)"
+          fi
+          echo "Decision: online=$ONLINE — $REASON"
+          if [ "$ONLINE" = "false" ]; then
+            echo "::warning::Int runner offline — deploy-int + smoke-test-int will be skipped. Pipeline will continue to test stage. Reason: $REASON"
+          else
+            echo "::notice::Int runner check passed — $REASON"
+          fi
+          echo "online=$ONLINE" >> "$GITHUB_OUTPUT"
+
+      - name: Slack notify - Int skipped (runner offline)
+        if: steps.probe.outputs.online == 'false'
+        continue-on-error: true
+        shell: bash
+        run: |
+          curl -sf -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n \
+              --arg actor "${{ github.actor }}" \
+              --arg logs "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{channel: "github-updates", username: "GitHub Actions", text: (":warning: *Promotion Pipeline — Int (192.168.1.193) SKIPPED*\nInt self-hosted runner is offline; deploy + smoke-test skipped, promotion continuing to test.\n*Triggered by:* \($actor)\n*Logs:* \($logs)")}')"
+
+  # ──────────────────────────────────────────────────────
+  # Stage 2: Deploy to Int (skipped when int runner is offline)
   # ──────────────────────────────────────────────────────
   deploy-int:
-    needs: [validate]
+    needs: [validate, preflight-int]
+    if: needs.preflight-int.outputs.runner_online == 'true'
     uses: ./.github/workflows/deploy-environment.yml
     with:
       env_name: int
@@ -142,10 +209,17 @@ jobs:
   # ──────────────────────────────────────────────────────
   # Stage 3: Smoke Test Int
   # ──────────────────────────────────────────────────────
+  # Skipped automatically when preflight-int says the runner is
+  # offline (otherwise this job would also queue forever waiting
+  # for the same offline runner).
   smoke-test-int:
     name: "Smoke Test Int"
     runs-on: [self-hosted, Linux, int]
-    needs: [deploy-int]
+    needs: [deploy-int, preflight-int]
+    if: |
+      always() && !failure() && !cancelled() &&
+      needs.preflight-int.outputs.runner_online == 'true' &&
+      needs.deploy-int.result == 'success'
     timeout-minutes: 10
 
     steps:
@@ -208,9 +282,15 @@ jobs:
   # ──────────────────────────────────────────────────────
   deploy-test:
     needs: [smoke-test-int]
+    # `always() && !failure() && !cancelled()` lets test run when
+    # smoke-test-int was SKIPPED (because the int runner was
+    # offline) but NOT when it actually failed.  Without this, a
+    # skipped int would cascade-skip test too — defeating the
+    # whole point of the preflight gate above.
     if: >
-      github.event_name != 'workflow_dispatch' ||
-      github.event.inputs.TARGET_ENV == 'test'
+      always() && !failure() && !cancelled() &&
+      (github.event_name != 'workflow_dispatch' ||
+       github.event.inputs.TARGET_ENV == 'test')
     uses: ./.github/workflows/deploy-environment.yml
     with:
       env_name: test


### PR DESCRIPTION
## Summary

Triggered by **two stuck runs in a row** while the int host (192.168.1.193) was off:

- [Delivery pipeline run 28359829849](https://github.com/bwalia/wslproxy/actions/runs/28359829849) — stuck at stage 2 (`Deploy Int`)
- [Promotion pipeline run 28359601509](https://github.com/bwalia/wslproxy/actions/runs/28359601509) — stuck at stage 1 (`Validate Configs (main)` because it ran on `[self-hosted, Linux, int]`)

Same underlying root cause: jobs running on the int self-hosted runner queue forever when the host is down.

## What this PR does

### Both pipelines: new `preflight-int` job (Stage 1.5)

A small ubuntu-latest job that:
1. Asks the GitHub API whether any self-hosted runner labelled `int` is currently `online`.
2. Outputs `runner_online: true|false`.
3. Slack-notifies on skip with a `:warning:` message.
4. **Fail-safe default = online** if the API call fails (e.g. `GITHUB_TOKEN` lacks scope) — better to queue and time out than silently skip a real deploy.

Then `deploy-int` and the smoke-test (test-int / smoke-test-int) are gated by `if: needs.preflight-int.outputs.runner_online == 'true'`.

### Promotion pipeline only: `validate` moved off the int runner

The `validate` job was `runs-on: [self-hosted, Linux, int]` even though all it does is `python -m json.tool` over `data/`.  Nothing in it needs the int host.  Moved to `ubuntu-latest` so the pipeline doesn't stick at stage 1 when int is down.

### Both pipelines: downstream `deploy-test` widened

Already widened on the delivery pipeline (existing CLAUDE.md §9 rule).  Added the same `always() && !failure() && !cancelled() &&` guard on the promotion pipeline's `deploy-test` so a SKIPPED int doesn't cascade-skip test.

## Behaviour matrix

| Int host state | Old behaviour | New behaviour |
|---|---|---|
| Online | Deploys int → smoke-test → promote to test | **Same** — no change |
| **Offline** | **Pipeline stuck in queue forever** (manual cancel required before test/prod can run) | **Int jobs skip cleanly, pipeline jumps to test stage, Slack notification** |
| API query fails | n/a | Fail-safe: assumes online, behaves like today |

## Files changed

- `.github/workflows/deploy-wslproxy-delivery-pipeline.yml` — preflight + gates
- `.github/workflows/deploy-wslproxy-promotion-pipeline.yml` — preflight + gates + validate moved to ubuntu-latest

## Permissions

Each preflight declares `actions: read` to list runners.  Whether the default `GITHUB_TOKEN` can read repo-runners depends on **Settings → Actions → General → Workflow permissions**:

- "Read and write permissions" → API call succeeds, runner detection works
- "Read repository contents and packages permissions" → API call fails → fail-safe kicks in (behaves like today)

Either setting is safe.

## Test plan

- **Happy path** (int online): trigger either pipeline → preflight reports online → int stage runs as today.
- **Skip path** (int offline): power off int, trigger either pipeline → preflight reports offline → Slack warning → both pipelines jump to test stage.
- **API failure path**: log shows "API query failed; assuming runner online" → behaves like today.