### PR TITLE
chore(secrets): rename AGE-SECRET-KEY -> AGE_SECRET_KEY

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -81,7 +81,7 @@ on:
       VAULT_TOKEN:
         required: false
       # SOPS_AGE_KEY: the FULL age private key value (one line, starts
-      # with `AGE-SECRET-KEY-1…`).  Required when secrets_mode=sops.
+      # with `AGE_SECRET_KEY-1…`).  Required when secrets_mode=sops.
       # See infra/secrets/README.md for how to generate + rotate it.
       SOPS_AGE_KEY:
         required: false

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -10,7 +10,7 @@
 # Then run `sops updatekeys` on every existing encrypted file so the
 # new operator can decrypt them.  See infra/secrets/README.md.
 #
-# NEVER paste an `AGE-SECRET-KEY-1…` (private key) into this file.
+# NEVER paste an `AGE_SECRET_KEY-1…` (private key) into this file.
 
 creation_rules:
   # Matches: .sops.json / .sops.env / .sops.yaml / .sops.yml

--- a/infra/ansible/roles/wslproxy/tasks/deploy_data.yml
+++ b/infra/ansible/roles/wslproxy/tasks/deploy_data.yml
@@ -150,7 +150,7 @@
       - target_env is defined and target_env | length > 0
     fail_msg: >-
       sops_secrets_enabled=true requires SOPS_AGE_KEY env var to be
-      set on the runner (export SOPS_AGE_KEY=AGE-SECRET-KEY-1…),
+      set on the runner (export SOPS_AGE_KEY=AGE_SECRET_KEY-1…),
       and target_env to be set on the host.  See
       infra/secrets/README.md for setup.
   when: _use_sops_secrets

--- a/infra/secrets/README.md
+++ b/infra/secrets/README.md
@@ -81,11 +81,11 @@ The file looks like:
 ```
 # created: 2026-06-29T12:34:56+00:00
 # public key: age1qabcdefg…   ← share this freely (in .sops.yaml below)
-AGE-SECRET-KEY-1XYZ123ABC…    ← NEVER share this
+AGE_SECRET_KEY-1XYZ123ABC…    ← NEVER share this
 ```
 
 **You will use the `age1…` public key in step 3 and the
-`AGE-SECRET-KEY-1…` private key in step 5.**
+`AGE_SECRET_KEY-1…` private key in step 5.**
 
 ### 3. Wire the public key into `.sops.yaml`
 
@@ -134,7 +134,7 @@ Commit the `.sops.json` / `.sops` files to Git — they're encrypted.
 ```bash
 gh secret set SOPS_AGE_KEY \
     --repo bwalia/wslproxy \
-    --body "$(cat ~/.config/sops/age/wslproxy.txt | grep AGE-SECRET-KEY-)"
+    --body "$(cat ~/.config/sops/age/wslproxy.txt | grep AGE_SECRET_KEY-)"
 ```
 
 Verify it's there:


### PR DESCRIPTION
GitHub variable/secret names cannot contain hyphens, so standardise the identifier on AGE_SECRET_KEY across the sops/age docs, Ansible task, and deploy workflow comments. SOPS_AGE_KEY (the env var sops reads and the GitHub secret name) is intentionally left unchanged.