### PR TITLE
ci: reclaim self-hosted runner workspace before Smoke Test checkout

### DIFF
--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -287,6 +287,19 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # actions/checkout's git-clean cannot unlink root-owned build
+      # artifacts left in the persistent self-hosted workspace (e.g.
+      # openresty-admin-next/.next/BUILD_ID created by a prior root/sudo
+      # Next.js build), which fails the Checkout step with EACCES and
+      # blocks promotion. Reclaim ownership before checkout runs.
+      - name: Pre-checkout cleanup (reclaim runner workspace)
+        run: |
+          if [ -n "$GITHUB_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
+            sudo rm -rf "$GITHUB_WORKSPACE/openresty-admin-next/.next" 2>/dev/null || true
+          fi
+        shell: bash
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
@@ -169,6 +169,19 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      # actions/checkout's git-clean cannot unlink root-owned build
+      # artifacts left in the persistent self-hosted workspace (e.g.
+      # openresty-admin-next/.next/BUILD_ID created by a prior root/sudo
+      # Next.js build), which fails the Checkout step with EACCES and
+      # blocks promotion. Reclaim ownership before checkout runs.
+      - name: Pre-checkout cleanup (reclaim runner workspace)
+        run: |
+          if [ -n "$GITHUB_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
+            sudo rm -rf "$GITHUB_WORKSPACE/openresty-admin-next/.next" 2>/dev/null || true
+          fi
+        shell: bash
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
@@ -222,6 +222,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # actions/checkout's git-clean cannot unlink root-owned build
+      # artifacts left in the persistent self-hosted workspace (e.g.
+      # openresty-admin-next/.next/BUILD_ID created by a prior root/sudo
+      # Next.js build), which fails the Checkout step with EACCES and
+      # blocks promotion. Reclaim ownership before checkout runs.
+      - name: Pre-checkout cleanup (reclaim runner workspace)
+        run: |
+          if [ -n "$GITHUB_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE" ]; then
+            sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
+            sudo rm -rf "$GITHUB_WORKSPACE/openresty-admin-next/.next" 2>/dev/null || true
+          fi
+        shell: bash
+
       - name: Checkout main
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Problem

Recent promotion/delivery pipeline runs go **red at the Smoke Test Int checkout step**, even though the SOPS int deploy succeeds:

```
Stage 3: Smoke Test Int → Checkout
✗ EACCES: permission denied, unlink
  '.../openresty-admin-next/.next/BUILD_ID'
```

The Smoke Test Int jobs run on the **persistent self-hosted int runner**, which retains the `deploy-int` Next.js build under `openresty-admin-next/.next`. When `BUILD_ID` is root-owned, `actions/checkout`'s git-clean can't unlink it → Checkout exits 1 → promotion to test/prod is gated even though int deployed fine.

This is **unrelated to the SOPS secrets migration** — SOPS decrypt + write tasks pass with `PLAY RECAP failed=0`. It's purely a runner-workspace ownership problem blocking the gate.

## Fix

Add a pre-checkout step to the self-hosted Smoke Test Int job in all three pipelines (delivery, promotion, nightly) that reclaims workspace ownership and drops the stale `.next` dir before `actions/checkout` runs:

```yaml
- name: Pre-checkout cleanup (reclaim runner workspace)
  run: |
    if [ -n "$GITHUB_WORKSPACE" ] && [ -d "$GITHUB_WORKSPACE" ]; then
      sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" 2>/dev/null || true
      sudo rm -rf "$GITHUB_WORKSPACE/openresty-admin-next/.next" 2>/dev/null || true
    fi
  shell: bash
```

Resilient (`|| true`); the runner already has passwordless sudo (deploy steps use it). All three workflows validated as well-formed YAML.

## Follow-up (not in this PR)
The artifact is root-owned because the `deploy-int` Next.js build leaves it that way in the shared workspace. This PR fixes the symptom robustly; a future change could stop that build running as root so it never creates root-owned artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)