### PR TITLE
ci(prod): write pop0 self-seed to /tmp

### DIFF
--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -420,8 +420,11 @@ jobs:
       # redeploy it (idempotent), instead of decoding an empty GH secret.
       secrets_mode: runner_file
       seed_from_host: true
-      settings_file_path: "/home/bwalia/.secrets/wslproxy/pop0/settings.json"
-      env_file_path: "/home/bwalia/.secrets/wslproxy/pop0/.env"
+      # Seed target on the runner — /tmp is always writable (same place
+      # the old github_secret mode wrote to). The .secrets tree is locked
+      # down and the runner can't mkdir new subdirs there.
+      settings_file_path: "/tmp/wslproxy-pop0/settings.json"
+      env_file_path: "/tmp/wslproxy-pop0/.env"
       health_endpoint: "https://prod-our-v1.wslproxy.com/health"
       health_check_mode: external
       docker_prune: true


### PR DESCRIPTION
Seed step failed on mkdir under the locked .secrets tree; use /tmp instead (writable, same as old github_secret mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)