### PR TITLE
fix(rule_auth): JWT verify always passed — read .verified field, not table truthiness

### DIFF
--- a/api/rule_auth.lua
+++ b/api/rule_auth.lua
@@ -76,8 +76,16 @@ function M.authenticate(rule)
         if not token then return false end
         token = string.gsub(token, "Bearer", "")
         token = trim(ngx.unescape_uri(token))
-        local verified = jwt:verify(passphrase, token)
-        return verified and true or false
+        local jwt_obj = jwt:verify(passphrase, token)
+        -- `jwt:verify` returns a TABLE { verified = bool, reason =
+        -- string, payload = table, ... }.  The TABLE itself is always
+        -- truthy in Lua, so the previous `return verified and true
+        -- or false` always returned true — silently disabling
+        -- signature verification.  Read the `.verified` field
+        -- instead.  Reproduced on prod 2026-06-30:
+        --   curl -H 'x-api-key: literally-anything-here' <url>
+        -- returned 200 from the protected backend.
+        return jwt_obj ~= nil and jwt_obj.verified == true
     end
 
     -- ── Cookie key-value ──
@@ -109,8 +117,16 @@ function M.authenticate(rule)
         -- which client convention they'll see.
         token = string.gsub(tostring(token), "^[Bb]earer%s+", "")
         token = trim(ngx.unescape_uri(token))
-        local verified = jwt:verify(passphrase, token)
-        return verified and true or false
+        local jwt_obj = jwt:verify(passphrase, token)
+        -- `jwt:verify` returns a TABLE { verified = bool, reason =
+        -- string, payload = table, ... }.  The TABLE itself is always
+        -- truthy in Lua, so the previous `return verified and true
+        -- or false` always returned true — silently disabling
+        -- signature verification.  Read the `.verified` field
+        -- instead.  Reproduced on prod 2026-06-30:
+        --   curl -H 'x-api-key: literally-anything-here' <url>
+        -- returned 200 from the protected backend.
+        return jwt_obj ~= nil and jwt_obj.verified == true
     end
 
     -- ── AWS S3 Signature V4 ──


### PR DESCRIPTION
## ⚠️ Security bug

`jwt:verify(passphrase, token)` (lua-resty-jwt) returns a **TABLE** like:
```lua
{ verified = bool, reason = string, payload = table, header = table }
```

The pre-existing code read this as:
```lua
local verified = jwt:verify(passphrase, token)
return verified and true or false
```

In Lua, any non-nil table is truthy.  So `verified` (the **table**) was always truthy, `verified and true` was always `true`, and the function always returned `true` regardless of whether the JWT signature was actually valid.

**Net effect:** every rule configured with `cookie_jwt_token_validation` or `header_jwt_token_validation` was effectively no-auth.  ANY string in the cookie/header passed the check.

### Reproduced on prod (2026-06-30 05:52 UTC)

```bash
$ curl -skI -H 'x-api-key: sddsfdsfds' https://ollama.diytaxreturn.co.uk/
HTTP/2 200        ← random string passed JWT verification ↯
content-length: 17
x-debug-origin-host: ollama.diytaxreturn.co.uk
x-debug-origin-port: 31434
```

The rule was configured to require a JWT signed with a specific HMAC-SHA256 secret.  Any random string was getting through.

### After the patch

```bash
$ curl -skI -H 'x-api-key: sddsfdsfds' https://ollama.diytaxreturn.co.uk/
HTTP/2 403

$ curl -skI https://ollama.diytaxreturn.co.uk/
HTTP/2 403

$ curl -skI -H 'x-api-key: <valid-jwt-signed-with-secret>' https://ollama.diytaxreturn.co.uk/
HTTP/2 200    ← real backend proxied through
```

## The fix

Read the `.verified` field of the return value instead of asking whether the table itself is truthy:

```lua
local jwt_obj = jwt:verify(passphrase, token)
return jwt_obj ~= nil and jwt_obj.verified == true
```

Applied to **both** the cookie JWT and header JWT branches — they had the same bug.

## Bug history

This was **pre-existing** in the codebase BEFORE PR #1088 (my recent header-JWT fail-closed fix).  PR #1088 changed the *fail-open behaviour when the header was missing* — orthogonal to this bug.  The pre-existing `verified and true or false` pattern just never produced a meaningful security property even when the header WAS present.

## Already hotfixed on prod

Applied as a direct hotfix on `187.124.112.155` at 2026-06-30 05:53 UTC to stop the leak immediately.  This PR brings the repo in line so the next deploy doesn't overwrite the hotfix with the buggy version.

Pre-hotfix backup on prod:
```
/usr/local/openresty/nginx/html/api/rule_auth.lua.bak.20260630-055344
```

## Test plan

- [ ] Merge this PR
- [ ] Verify the next deploy doesn't regress the prod hotfix (the prod file should match the patched version in this PR)
- [ ] Confirm `curl -H 'x-api-key: anything' https://ollama.diytaxreturn.co.uk/` returns 403
- [ ] Confirm a valid JWT (signed with the configured secret) returns 200

## Related

- This PR fixes the security half of the issue reported when testing PR #1088 ([wslproxy outage discussion](https://github.com/bwalia/wslproxy/actions/runs/28367654557))
- A follow-up PR will address the UX half (the 403 body is currently the global `nginx.default.no_rule` HTML which browsers meta-refresh to wslproxy.com — confusing for protected APIs)