### PR TITLE
ci(deploy): refuse deploy if settings.env_profile != target_env

### DIFF
--- a/infra/ansible/roles/wslproxy/tasks/deploy_data.yml
+++ b/infra/ansible/roles/wslproxy/tasks/deploy_data.yml
@@ -83,6 +83,24 @@
   when: _use_vault_secrets
   tags: [servers, code]
 
+- name: "Vault: refuse deploy if settings.env_profile != target_env"
+  # See the comment block above the SOPS guard task for the full rationale.
+  ansible.builtin.assert:
+    that:
+      - (_vault_settings.json.data.data.env_profile | default('')) == target_env
+    fail_msg: >-
+      ABORTING DEPLOY — env_profile mismatch.  Vault path
+      secret/data/wslproxy/{{ target_env }}/settings.json contains
+      env_profile='{{ _vault_settings.json.data.data.env_profile | default('<missing>') }}'
+      but the workflow's target_env='{{ target_env }}'.  Writing this file
+      to the target would overwrite the host's profile with the wrong
+      environment's data (rules under data/{rules,servers}/<profile>/
+      are looked up by env_profile at request time).  This is the check
+      that would have prevented the 2026-06-29 prod outage; fix the
+      Vault payload or the workflow before retrying.
+  when: _use_vault_secrets
+  tags: [servers, code]
+
 - name: "Vault: write settings.json to target"
   ansible.builtin.copy:
     content: "{{ _vault_settings.json.data.data | to_nice_json }}"
@@ -156,6 +174,35 @@
   when: _use_sops_secrets
   tags: [servers, code]
 
+- name: "SOPS: refuse deploy if settings.env_profile != target_env"
+  # ENV PROFILE GUARD — prevent the 2026-06-29 outage shape from
+  # recurring.  On that day a workflow ran with target_env=int but
+  # rsynced int's settings.json onto the prod host, flipping
+  # env_profile to 'int' and pointing the gateway at the wrong
+  # rules/servers tree.  The guard reads the file we're about to
+  # write, parses out env_profile, and refuses to continue if it
+  # doesn't match target_env.  Single source of truth — runs in all
+  # three secret-paths (vault / sops / file) before the write.
+  ansible.builtin.assert:
+    that:
+      - ((lookup('community.sops.sops', sops_settings_path) | from_json).env_profile | default('')) == target_env
+    fail_msg: >-
+      ABORTING DEPLOY — env_profile mismatch.  infra/secrets/{{ target_env }}/settings.sops.json
+      decrypts to env_profile='{{ (lookup("community.sops.sops", sops_settings_path) | from_json).env_profile | default("<missing>") }}'
+      but the workflow's target_env='{{ target_env }}'.  Writing this file
+      to the target would overwrite the host's profile with the wrong
+      environment's data (rules under data/{rules,servers}/<profile>/
+      are looked up by env_profile at request time).  This is the check
+      that would have prevented the 2026-06-29 prod outage; fix the
+      encrypted file (sops infra/secrets/{{ target_env }}/settings.sops.json)
+      or the workflow target_env before retrying.
+  vars:
+    sops_settings_path: >-
+      {{ playbook_dir }}/../../infra/secrets/{{ target_env }}/settings.sops.json
+  no_log: true
+  when: _use_sops_secrets
+  tags: [servers, code]
+
 - name: "SOPS: decrypt + write settings.json to target"
   ansible.builtin.copy:
     # Use the `community.sops.sops` lookup to decrypt at task time.
@@ -189,6 +236,24 @@
 # Only runs when NEITHER vault nor sops is enabled.  Reads the
 # settings.json and .env that an earlier workflow step decoded from
 # GitHub Secrets into the runner's filesystem.
+
+- name: "File: refuse deploy if settings.env_profile != target_env"
+  # See the comment block above the SOPS guard task for the full rationale.
+  ansible.builtin.assert:
+    that:
+      - ((lookup('file', local_settings_file_path) | from_json).env_profile | default('')) == target_env
+    fail_msg: >-
+      ABORTING DEPLOY — env_profile mismatch.  The staged settings file
+      at {{ local_settings_file_path }} contains
+      env_profile='{{ (lookup("file", local_settings_file_path) | from_json).env_profile | default("<missing>") }}'
+      but the workflow's target_env='{{ target_env }}'.  Writing this file
+      to the target would overwrite the host's profile with the wrong
+      environment's data (rules under data/{rules,servers}/<profile>/
+      are looked up by env_profile at request time).  This is the check
+      that would have prevented the 2026-06-29 prod outage; fix the
+      staged file or the workflow target_env before retrying.
+  when: not _use_vault_secrets and not _use_sops_secrets
+  tags: [servers, code]
 
 - name: "File: copy settings.json from controller"
   ansible.builtin.copy:


### PR DESCRIPTION
## Summary

Root-cause guard for the 2026-06-29 prod outage.

That day a deploy ran with `target_env=int` but wrote int's `settings.json` (with `env_profile='int'`) onto the prod host. Because the gateway looks up rules by `data/<rules|servers>/<env_profile>/...` at request time, every prod domain instantly fell through to `no_rule` for ~90 minutes until manual recovery.

The failure reduced to one missing check — *the secret we're about to write doesn't agree with the environment we said we were deploying to* — and nothing in the path noticed.

## What this adds

Three new `assert` tasks in [infra/ansible/roles/wslproxy/tasks/deploy_data.yml](infra/ansible/roles/wslproxy/tasks/deploy_data.yml), one per `secrets_mode`, each inserted **before** the write of `/opt/nginx/data/settings.json`:

| Mode | Source of truth | Fails before |
|------|----------------|--------------|
| `vault` | `_vault_settings.json.data.data.env_profile` (already fetched) | "Vault: write settings.json to target" |
| `sops` | `lookup('community.sops.sops', sops_settings_path) \| from_json` (same lookup the write uses) | "SOPS: decrypt + write settings.json to target" |
| `file` (runner_file / github_secret / legacy) | `lookup('file', local_settings_file_path) \| from_json` | "File: copy settings.json from controller" |

Missing `env_profile` is treated as a hard fail — deploying a `settings.json` without one is a footgun (gateway defaults to `prod`).

## Why all three guards live in Ansible (not in the workflow)

- **Single source of truth**: catches *every* path. A workflow guard would miss the Vault path entirely since the secret is fetched inside the playbook.
- **Catches local `ansible-playbook` runs too** — not just GH Actions.
- **Sits next to the write task it protects** — anyone editing one will see the other.

## Scope (deliberately small)

- Only checks `env_profile`. Other fields wrong → loud failures. `env_profile` wrong → silent gateway breakage. That asymmetry is what justifies a guard.
- No emergency override. The right fix is always *edit the secret or fix the workflow*; an override re-enables the exact footgun this guards against.

## Test plan

- [x] YAML lint passes
- [ ] Trigger int deploy with a deliberately-mismatched secret → expect early failure at the assert step
- [ ] Trigger normal int deploy → expect pass-through
- [ ] Same for prod (full deploy + targeted `code` deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)