### PR TITLE
ci(deploy): snapshot + rollback /opt/nginx/conf.d on validation failure

### DIFF
--- a/infra/ansible/roles/wslproxy/tasks/finalize.yml
+++ b/infra/ansible/roles/wslproxy/tasks/finalize.yml
@@ -145,6 +145,63 @@
   when: nginx_preflight is defined
   tags: [nginx, code, dashboard, servers]
 
+# ── ATOMIC GUARD: rollback conf.d on pre-flight failure ───────────────────
+#
+# Paired with the snapshot taken at the top of nginx_config.yml.  If
+# the pre-flight openresty -t fails, swap conf.d/ back to the
+# pre-deploy snapshot and abort BEFORE the restart task — otherwise
+# systemd's openresty restart fails, workers die, and the host is
+# down until manual recovery.  The failed conf.d/ is preserved (just
+# renamed) so operators can compare against the snapshot and figure
+# out what the templates rendered wrong.
+#
+# Only acts when the snapshot exists (i.e. nginx_config.yml ran in
+# this play — partial deploys with --tags servers may skip it, in
+# which case there's nothing to roll back to and we fall through to
+# the existing error-display behaviour).
+- name: "Atomic guard: roll back conf.d/ if pre-flight failed"
+  ansible.builtin.shell: |
+    set -euo pipefail
+    SNAPSHOT=/opt/nginx/conf.d.predeploy
+    if [ ! -d "$SNAPSHOT" ]; then
+      echo "no-snapshot"
+      exit 0
+    fi
+    FAILED=/opt/nginx/conf.d.failed-{{ ansible_date_time.iso8601_basic_short }}
+    rm -rf "$FAILED"
+    mv /opt/nginx/conf.d "$FAILED"
+    mv "$SNAPSHOT" /opt/nginx/conf.d
+    echo "rolled-back-to:$SNAPSHOT  failed-preserved-at:$FAILED"
+  register: _confd_rollback
+  changed_when: "'rolled-back-to' in _confd_rollback.stdout"
+  when: nginx_preflight is defined and nginx_preflight.rc != 0
+  tags: [nginx, code, dashboard, servers]
+
+- name: "Atomic guard: abort deploy after rollback"
+  ansible.builtin.fail:
+    msg: |
+      ABORTING DEPLOY — openresty -t failed after nginx role modifications.
+
+      stderr from openresty -t:
+      {{ nginx_preflight.stderr | default('(no stderr)') }}
+
+      conf.d/ rollback status: {{ _confd_rollback.stdout | default('(no snapshot to roll back to)') }}
+
+      A subsequent systemd restart with this broken config would have
+      taken the host down.  Either the rolled-back conf.d/ is back to
+      its pre-deploy state, OR (if no snapshot was taken — partial
+      deploy with insufficient tags) the broken state is preserved
+      for inspection.  Either way: investigate and re-run.
+  when: nginx_preflight is defined and nginx_preflight.rc != 0
+  tags: [nginx, code, dashboard, servers]
+
+- name: "Atomic guard: clean up successful snapshot"
+  ansible.builtin.file:
+    path: /opt/nginx/conf.d.predeploy
+    state: absent
+  when: nginx_preflight is defined and nginx_preflight.rc == 0
+  tags: [nginx, code, dashboard, servers]
+
 - name: Stop existing OpenResty service before restart
   systemd:
     name: openresty

--- a/infra/ansible/roles/wslproxy/tasks/nginx_config.yml
+++ b/infra/ansible/roles/wslproxy/tasks/nginx_config.yml
@@ -1,6 +1,50 @@
 ---
 # Nginx configuration directories and base configs
 
+# ── ATOMIC GUARD: snapshot conf.d before role-driven modifications ────────
+#
+# Why this exists:
+# The 2026-06-29 prod outage left /opt/nginx/conf.d/ holding a
+# default.conf (and missing tenant .confs) from a different env, and
+# none of the subsequent tasks caught it — the only validation was
+# the systemctl restart at the very end, by which time the wrong
+# files were already live.
+#
+# What it does:
+# Hardlinks the current conf.d/ to /opt/nginx/conf.d.predeploy/ at
+# the start of the role's nginx tasks.  Because cp -al only creates
+# hardlinks (zero data copy, ~10ms for thousands of files), the
+# snapshot is effectively free.  Any Ansible task that *replaces* a
+# file in conf.d/ goes through write-temp + rename, which creates a
+# new inode — the snapshot keeps the OLD inode under conf.d.predeploy.
+# At the end of finalize.yml an openresty -t check decides whether to
+# promote the new state or restore the snapshot.
+#
+# Coverage:
+# Catches any syntax-level breakage from changes to default.conf, the
+# rsynced nginx-conf.d/ files, the synchronized nginx-tenants.d/
+# files, or anything else the role writes to conf.d/.  Does NOT catch
+# *semantically* wrong configs that still parse (env_profile mismatch
+# is handled separately in deploy_data.yml).
+- name: "Atomic guard: snapshot conf.d/ before nginx role modifications"
+  ansible.builtin.shell: |
+    set -euo pipefail
+    rm -rf /opt/nginx/conf.d.predeploy
+    if [ -d /opt/nginx/conf.d ]; then
+      # cp -al = hardlink copy.  Modifications inside conf.d/ via
+      # write-then-rename (Ansible copy/template/synchronize default)
+      # leave the snapshot pointing at the old inodes.  In-place
+      # writes (rare in this role) would leak through — none of the
+      # existing tasks do that.
+      cp -al /opt/nginx/conf.d /opt/nginx/conf.d.predeploy
+    else
+      # First-ever deploy on this host — make an empty snapshot so the
+      # rollback path is unambiguous.
+      mkdir -p /opt/nginx/conf.d.predeploy
+    fi
+  changed_when: false
+  tags: [nginx, code, dashboard, servers]
+
 - name: Ensure base nginx conf directory exists
   ansible.builtin.file:
     path: /opt/nginx/base.d/


### PR DESCRIPTION
## Summary

Belt-and-braces against the 2026-06-29 outage shape. The env_profile guard in PR #1105 catches *wrong env's secrets*; this guard catches *wrong env's nginx config* (or any rendering bug that produces syntactically invalid `conf.d/*`).

## Problem

The existing pre-flight task in [infra/ansible/roles/wslproxy/tasks/finalize.yml](infra/ansible/roles/wslproxy/tasks/finalize.yml) runs `openresty -t` with `ignore_errors: true` — it prints the result but proceeds with `systemctl restart openresty` regardless. If templates rendered a syntax-invalid `default.conf` or stale-env tenant block, the restart fails, workers die, the host is down until manual recovery.

## Fix

Two complementary tasks:

1. **Snapshot** (top of [nginx_config.yml](infra/ansible/roles/wslproxy/tasks/nginx_config.yml)) — `cp -al /opt/nginx/conf.d /opt/nginx/conf.d.predeploy` at the start of the role's nginx tasks. Hardlinks share inodes, so the snapshot is ~10ms and zero disk space.

2. **Rollback** (between pre-flight and restart in [finalize.yml](infra/ansible/roles/wslproxy/tasks/finalize.yml)) — if `nginx_preflight.rc != 0`, swap `conf.d/` back to the snapshot and abort the play **before** the restart task runs. The failed `conf.d/` is preserved at `conf.d.failed-<timestamp>/` for inspection.

On success the snapshot is removed in a final clean-up task.

## What this catches

- Syntax-invalid `default.conf.j2` render for any host
- Repo file in `nginx-conf.d/` containing a bad directive
- `nginx-tenants.d/` rsync writing a directive the live openresty binary doesn't support
- Anywhere the deploy renders syntactically-broken nginx and the existing `ignore_errors: true` would have proceeded to a fatal restart

## What this does NOT catch (left to other PRs)

- **Semantically wrong but syntactically valid configs** (e.g. int's `default.conf` written to prod with `proxy_pass http://int-…;`). That's the env_profile guard's job (PR #1105).
- **Tenant `.conf` written by api.lua between snapshot and rollback** — narrow deploy-time-window race. Cost is bounded (single in-flight tenant, recoverable from `data/servers/` JSON) and the race already existed.

## Why `cp -al`

- coreutils-everywhere, no new dependency
- O(filename count), not O(bytes). Sub-second even with hundreds of tenant confs
- Hardlinks → snapshot costs ~0 disk space
- Ansible's default write-temp-then-rename pattern leaves the snapshot's inodes untouched while `conf.d/` moves to new inodes; rollback is a pure rename

## Test plan

- [x] YAML lint passes
- [ ] Force a bad `default.conf` via Jinja error → expect rollback + loud fail message, no restart, conf.d restored
- [ ] Clean deploy → expect snapshot taken, validation passes, snapshot cleaned up, restart proceeds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)