### PR TITLE
feat(infra): add POP1 (18.133.126.242) + prebuilt OpenResty tooling

### DIFF
--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -42,6 +42,7 @@ on:
           # 187.77.179.206 (acc) was decommissioned.
           - 187.124.112.155
           - 72.62.211.28
+          - 18.133.126.242
 
       DEPLOY_MODE:
         type: choice
@@ -464,6 +465,44 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   # ──────────────────────────────────────────────────────
+  # Stage 5c: Deploy Prod pop1 (18.133.126.242) — AWS eu-west-2, ssh user admin
+  # Runs LAST, after pop0 + lon1, only when they (and all prior stages) pass.
+  # Dashboard domain: pop1.diytaxreturn.co.uk
+  # ──────────────────────────────────────────────────────
+  deploy-prod-pop1:
+    needs: [deploy-prod-lon1]
+    if: >
+      always() && !failure() && !cancelled() &&
+      ((github.event_name == 'push' && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/main')) ||
+      (github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.TARGET_HOST == '18.133.126.242' || github.event.inputs.TARGET_HOST == 'all')))
+    uses: ./.github/workflows/deploy-environment.yml
+    with:
+      env_name: prod
+      env_label: "Prod pop1 (18.133.126.242)"
+      stage_number: "5c"
+      host_ip: "18.133.126.242"
+      ssh_user: admin
+      connection_mode: ssh_key
+      # pop1 self-seeds: pull its own live settings.json over SSH and
+      # redeploy it (idempotent), instead of decoding an empty GH secret.
+      # The FIRST deploy is done from local ansible (which seeds the host);
+      # thereafter pipeline runs reuse the host's live config.
+      secrets_mode: runner_file
+      seed_from_host: true
+      settings_file_path: "/tmp/wslproxy-pop1/settings.json"
+      env_file_path: "/tmp/wslproxy-pop1/.env"
+      # IP-based health gate — no dependency on DNS/cert for pop1.diytaxreturn.co.uk
+      health_endpoint: "http://18.133.126.242:7691/health"
+      health_check_mode: external
+      docker_prune: true
+      notify_success: true
+      deploy_branch: ${{ github.event.inputs.DEPLOY_BRANCH || github.ref_name }}
+      deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
   # Pipeline Summary (always runs — final report)
   # ──────────────────────────────────────────────────────
   pipeline-summary:
@@ -477,6 +516,7 @@ jobs:
         deploy-test,
         deploy-prod-pop0,
         deploy-prod-lon1,
+        deploy-prod-pop1,
       ]
     if: always()
     steps:
@@ -492,6 +532,7 @@ jobs:
           echo "  Stage 4  — Deploy Test:          ${{ needs.deploy-test.result }}"
           echo "  Stage 5a — Deploy Prod (pop0):   ${{ needs.deploy-prod-pop0.result }}"
           echo "  Stage 5b — Deploy Prod (lon1):   ${{ needs.deploy-prod-lon1.result }}"
+          echo "  Stage 5c — Deploy Prod (pop1):   ${{ needs.deploy-prod-pop1.result }}"
           echo ""
           echo "  Commit:  ${{ github.sha }}"
           echo "  Branch:  ${{ github.ref_name }}"
@@ -503,7 +544,8 @@ jobs:
              [[ "${{ needs.test-int.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-test.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-prod-pop0.result }}" == "failure" ]] || \
-             [[ "${{ needs.deploy-prod-lon1.result }}" == "failure" ]]; then
+             [[ "${{ needs.deploy-prod-lon1.result }}" == "failure" ]] || \
+             [[ "${{ needs.deploy-prod-pop1.result }}" == "failure" ]]; then
               echo "::error::Pipeline failed — see stage results above"
               exit 1
           fi

--- a/infra/POP1_DEPLOY.md
+++ b/infra/POP1_DEPLOY.md
@@ -1,0 +1,99 @@
+# POP1 deploy runbook — 18.133.126.242 (AWS eu-west-2)
+
+New production POP. Dashboard: **pop1.diytaxreturn.co.uk**. Deployed with **local
+Ansible** (GitHub workflows are being retired for Argo). The delivery pipeline
+also carries a pop1 stage (5c, runs last) for when/if a release-branch run is used.
+
+Run everything below **from the Mac that holds the EC2 SSH key.**
+
+---
+
+## 0. Prerequisites (check first)
+
+- **SSH key** for `admin@18.133.126.242` (London keypair, e.g. `cdn_london_keypair.pem`).
+  Test it:
+  ```bash
+  ssh -i /path/to/key.pem admin@18.133.126.242 'whoami; cat /etc/os-release | grep PRETTY; dpkg --print-architecture'
+  ```
+  `admin` must have passwordless sudo (default on Debian cloud AMIs).
+- **DNS:** `pop1.diytaxreturn.co.uk` → `18.133.126.242` (A record). Required for the
+  Let's Encrypt cert auto-ssl issues for the dashboard.
+- **Security group:** inbound **80, 443, 7691** open (80/443 for the dashboard +
+  ACME; 7691 is the admin/API + health port).
+- EIP `18.133.126.242` associated with the instance.
+
+## 1. Get the repo on this Mac
+
+```bash
+git clone https://github.com/bwalia/wslproxy.git   # or pull latest main
+cd wslproxy
+# (POP1 host_vars + inventory entry are already on main once this lands)
+pip install ansible 2>/dev/null || brew install ansible
+ansible-galaxy collection install ansible.posix community.general
+```
+
+## 2. Provide pop1 secrets (settings.json + .env)
+
+Ansible reads them from the paths in `host_vars/18.133.126.242/vars.yaml`
+(`/tmp/wslproxy-pop1/`). Seed them — easiest is to reuse the prod SOPS secrets:
+
+```bash
+mkdir -p /tmp/wslproxy-pop1
+export SOPS_AGE_KEY='AGE-SECRET-KEY-1...'   # the real prod key (same as the SOPS_AGE_KEY GH secret)
+sops -d infra/secrets/prod/settings.sops.json > /tmp/wslproxy-pop1/settings.json
+sops -d --input-type dotenv --output-type dotenv infra/secrets/prod/env.sops.env > /tmp/wslproxy-pop1/.env
+```
+(or just copy a known-good prod `settings.json` + `.env` into `/tmp/wslproxy-pop1/`.)
+
+## 3. Deploy from local Ansible → 18.133.126.242
+
+First (full) deploy — installs OpenResty + deps, configures nginx, deploys code+data:
+
+```bash
+KEY=/path/to/key.pem
+
+ansible-playbook infra/ansible/wslproxy-ops.yml \
+  -i infra/ansible/hosts \
+  -l 18.133.126.242 \
+  --private-key "$KEY" \
+  -u admin --become \
+  --extra-vars "target_env=prod \
+    nginx_user_password=THISCOMESFROMSECRETS \
+    local_settings_file_path=/tmp/wslproxy-pop1/settings.json \
+    local_env_file_path=/tmp/wslproxy-pop1/.env \
+    wslproxy_build_number=local-$(date +%s) \
+    wslproxy_git_sha=$(git rev-parse --short HEAD) \
+    wslproxy_git_repo=bwalia/wslproxy \
+    wslproxy_deployment_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+Faster subsequent code/HTML/nginx changes — add a tag:
+`--tags code` (Lua only) · `--tags dashboard-next` (Next.js) · `--tags nginx` · `--tags servers`.
+
+> **Faster OpenResty install (optional):** the full deploy compiles OpenResty from
+> source on the host (slow). To skip that, use the prebuilt path instead —
+> `TARGET=admin@18.133.126.242 BASE_IMAGE=debian:13 infra/openresty-prebuilt/openresty-express-install.sh full`
+> — then run the playbook with `--tags nginx,servers,code,dashboard-next` (skip `build`).
+
+## 4. Verify
+
+```bash
+# Health on the admin/API port
+curl -sf -o /dev/null -w 'health: %{http_code}\n' http://18.133.126.242:7691/health
+
+# Dashboard over HTTPS (after DNS + first cert issuance; may take a few seconds)
+curl -skI https://pop1.diytaxreturn.co.uk | head -1
+ssh -i "$KEY" admin@18.133.126.242 'sudo /usr/local/openresty/nginx/sbin/nginx -t'
+```
+
+If the cert isn't issued: confirm DNS resolves to 18.133.126.242 and port 80 is
+reachable (auto-ssl uses HTTP-01), then `curl https://pop1.diytaxreturn.co.uk/` to
+trigger issuance.
+
+## 5. Pipeline note (future / Argo migration)
+
+`deploy-wslproxy-delivery-pipeline.yml` now has **Stage 5c → pop1**, gated to run
+**after** pop0 + lon1 and only when all prior stages pass (push to `release`/`main`,
+or `workflow_dispatch` with `TARGET_HOST=18.133.126.242` / `all`). It self-seeds
+from the host's live config (`seed_from_host: true`), so once this local deploy
+seeds pop1, a pipeline run can redeploy it without any stored secret.

--- a/infra/ansible/host_vars/18.133.126.242/vars.yaml
+++ b/infra/ansible/host_vars/18.133.126.242/vars.yaml
@@ -1,0 +1,40 @@
+# ──────────────────────────────────────────────────────────────────────────
+# POP1 — AWS EC2 eu-west-2 (London), EIP 18.133.126.242, ssh user `admin`
+# Dashboard (Next.js) domain: pop1.diytaxreturn.co.uk
+#   (the per-pop dashboard host, cf. prod-our.wslproxy.com on pop0)
+#
+# Deployed primarily via LOCAL ansible (GitHub workflows are being retired in
+# favour of Argo). The delivery pipeline also carries a pop1 stage so a
+# release-branch run still reaches this host LAST, after every other stage
+# passes — see deploy-wslproxy-delivery-pipeline.yml (Stage 5c).
+# ──────────────────────────────────────────────────────────────────────────
+
+# Secrets (file mode). Populate these on the controller before deploying —
+# e.g. decrypt the prod SOPS secrets or drop plaintext here. /tmp mirrors the
+# pipeline's pop0 seed convention. See infra/POP1_DEPLOY.md.
+local_settings_file_path: "/tmp/wslproxy-pop1/settings.json"
+local_env_file_path: "/tmp/wslproxy-pop1/.env"
+
+nginx_user_password: "!!REDACTED!!" # www-data password — encrypt via Ansible Vault
+host_lan_ip: "18.133.126.242"
+nginx_web_ui_enabled: "yes"
+nginx_rest_api_server_enabled: ""
+nginx_data_sync_enabled: ""
+nginx_s3_proxy_pass_host_ip: "127.0.0.1"
+nginx_s3_server_name: "dummy-s3.workstation.co.uk"
+nginx_s3_cli_server_name: "dummy-s3-cli.workstation.co.uk"
+nginx_k3s_dashboard_server_name: "k3s-dashboard.workstation.co.uk"
+
+# Public domains. pop1 exposes ONLY the Next.js dashboard; frontend + legacy
+# react-admin blocks are left empty so there's no :443 server_name collision
+# (each non-empty var renders its own auto-ssl 443 block in default.conf.j2).
+#
+# auto-ssl issues a Let's Encrypt cert for this name on the first HTTPS hit —
+# REQUIRES DNS: pop1.diytaxreturn.co.uk -> 18.133.126.242, and ports 80+443 open.
+nginx_default_server_frontend: ""
+nginx_default_server_backend: ""
+nginx_default_server_backend_port: 7691
+nginx_default_server_backend_nextjs: "pop1.diytaxreturn.co.uk"
+
+letsencrypt_email: "balinder.walia@gmail.com"
+openresty_admin_secondary_color: "#D91656"

--- a/infra/ansible/hosts
+++ b/infra/ansible/hosts
@@ -9,6 +9,7 @@
 192.168.1.140 ansible_user=bwalia
 187.124.112.155 ansible_user=root
 72.62.211.28 ansible_user=root
+18.133.126.242 ansible_user=admin
 
 # ── Environment groups ─────────────────────────────────
 
@@ -21,6 +22,7 @@
 [openresty_prod]
 187.124.112.155 ansible_user=root
 72.62.211.28 ansible_user=root
+18.133.126.242 ansible_user=admin
 
 # ── Group all openresty servers ────────────────────────
 

--- a/infra/openresty-prebuilt/Dockerfile
+++ b/infra/openresty-prebuilt/Dockerfile
@@ -1,0 +1,105 @@
+# syntax=docker/dockerfile:1.7
+# ============================================================================
+# Prebuilt OpenResty for wslproxy — compile ONCE in Docker, extract the
+# /usr/local/openresty tree, install it on bare-metal targets (pop0 etc.)
+# instead of compiling from source on every host (the slow/flaky
+# openresty.sh.j2 path).
+#
+# CRITICAL: a compiled binary is libc-specific. Build on a base whose
+# glibc + arch MATCH the target host, or the extracted nginx won't run.
+# Default debian:13 (trixie) matches the int/prod Debian hosts. Override
+# with --build-arg BASE_IMAGE=debian:12 (etc.) to match a different target.
+#
+# Mirrors: roles/wslproxy/templates/openresty.sh.j2 (compile + luarocks),
+#          roles/wslproxy/tasks/deploy_deps.yml (rock list),
+#          roles/wslproxy/templates/cdn-dependencies.sh.j2 (opm + lualibs).
+# ============================================================================
+ARG BASE_IMAGE=debian:13
+
+# ── Stage 1: build everything into /usr/local/openresty ─────────────────────
+FROM ${BASE_IMAGE} AS builder
+ARG OPENRESTY_VERSION=1.29.2.1
+ARG LUAROCKS_VERSION=3.11.1
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH=/usr/local/openresty/luajit/bin:/usr/local/openresty/bin:/usr/local/bin:/usr/bin:/bin
+
+# Build deps = roles/wslproxy/vars/Debian.yml os_build_deps + PCRE2 + git.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libssl-dev perl make build-essential curl zlib1g-dev wget gcc unzip \
+      lua5.1 liblua5.1-0-dev libpcre2-dev git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# ── Compile OpenResty (configure flags identical to openresty.sh.j2:72) ──
+RUN cd /tmp \
+ && wget -q "https://openresty.org/download/openresty-${OPENRESTY_VERSION}.tar.gz" \
+ && tar -xzf "openresty-${OPENRESTY_VERSION}.tar.gz" \
+ && cd "openresty-${OPENRESTY_VERSION}" \
+ && ./configure --prefix=/usr/local/openresty \
+      --with-stream_realip_module --with-http_ssl_module \
+      --with-http_gzip_static_module --with-http_sub_module \
+      --with-http_v2_module --with-http_stub_status_module \
+      --with-stream --with-http_slice_module \
+ && make -j"$(nproc)" \
+ && make install \
+ && ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/bin/openresty \
+ && /usr/bin/openresty -v \
+ && rm -rf /tmp/openresty-*
+
+# ── luarocks built with system Lua 5.1 (NOT LuaJIT — the 65536 constant
+#    limit can't parse the luarocks manifest; see openresty.sh.j2 notes) ──
+RUN cd /tmp \
+ && wget -q "https://luarocks.github.io/luarocks/releases/luarocks-${LUAROCKS_VERSION}.tar.gz" \
+ && tar xzf "luarocks-${LUAROCKS_VERSION}.tar.gz" \
+ && cd "luarocks-${LUAROCKS_VERSION}" \
+ && ./configure --prefix=/usr/local \
+      --with-lua=/usr --with-lua-include=/usr/include/lua5.1 --lua-suffix=5.1 \
+ && make && make install \
+ && luarocks --version \
+ && rm -rf /tmp/luarocks-*
+
+# ── Rocks into the OpenResty LuaJIT tree (deploy_deps.yml). lua-resty-jwt
+#    pinned to 0.2.3; the rest best-effort — sockproc (lua-resty-auto-ssl)
+#    can fail under newer GCC, matching the role's ignore_errors. The build
+#    FAILS only if a non-optional rock is missing, so verify after. ──
+RUN set -eux; TREE=/usr/local/openresty/luajit; \
+    luarocks install --tree="$TREE" lua-resty-jwt 0.2.3; \
+    for r in lua-resty-session lua-resty-http lua-resty-openidc base64 \
+             lua-resty-redis-connector lua-resty-dns lua-resty-resolver \
+             luafilesystem lua-resty-auto-ssl pgmoon lua-resty-consul; do \
+      luarocks install --tree="$TREE" "$r" || echo "WARN: optional rock '$r' failed to install"; \
+    done; \
+    luarocks list --tree="$TREE"
+
+# ── opm packages + extra lualibs (cdn-dependencies.sh.j2) ──
+RUN set -eux; \
+    opm get olegabr/lua-resty-ip2location ip2location/ip2location-resty \
+            bungle/lua-resty-session bungle/lua-resty-template \
+            thibaultcha/lua-resty-mlcache 3scale/lua-resty-env || true; \
+    cd /tmp; \
+    git clone --depth 1 https://github.com/knyar/nginx-lua-prometheus.git; \
+    cp nginx-lua-prometheus/prometheus.lua \
+       nginx-lua-prometheus/prometheus_keys.lua \
+       nginx-lua-prometheus/prometheus_resty_counter.lua \
+       /usr/local/openresty/lualib/; \
+    git clone --depth 1 https://github.com/openresty/lua-resty-upstream-healthcheck.git; \
+    mkdir -p /usr/local/openresty/lualib/resty/upstream; \
+    cp lua-resty-upstream-healthcheck/lib/resty/upstream/healthcheck.lua \
+       /usr/local/openresty/lualib/resty/upstream/; \
+    rm -rf /tmp/nginx-lua-prometheus /tmp/lua-resty-upstream-healthcheck
+
+# MinIO client (host config-backup tool). Kept inside the openresty tree so
+# it travels with the extracted tarball; the installer symlinks it into PATH.
+RUN wget -q https://dl.min.io/client/mc/release/linux-amd64/mc \
+      -O /usr/local/openresty/bin/mc && chmod +x /usr/local/openresty/bin/mc
+
+# ── Stage 2: runtime image = matching base + only runtime libs + the tree.
+#    The apt list here is exactly what a target host needs alongside the
+#    extracted tree. Extraction (docker cp) pulls /usr/local/openresty. ──
+FROM ${BASE_IMAGE} AS runtime
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libpcre2-8-0 libssl3 zlib1g ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/openresty /usr/local/openresty
+RUN ln -sf /usr/local/openresty/nginx/sbin/nginx /usr/bin/openresty \
+ && /usr/bin/openresty -V

--- a/infra/openresty-prebuilt/README.md
+++ b/infra/openresty-prebuilt/README.md
@@ -1,0 +1,58 @@
+# Prebuilt OpenResty — compile in Docker, install on bare metal
+
+Compile OpenResty (+ all wslproxy Lua deps) **once** in a Docker image, extract
+the `/usr/local/openresty` tree, and install it on a target host — instead of
+the slow/flaky source compile that `roles/wslproxy/templates/openresty.sh.j2`
+runs on every host. No registry/artifact push: local `docker build` →
+`docker cp` → `rsync` over SSH.
+
+## Files
+- `Dockerfile` — Debian multi-stage build. Mirrors the role's
+  `openresty.sh.j2` (compile + configure flags), `deploy_deps.yml` (rock list),
+  and `cdn-dependencies.sh.j2` (opm + prometheus/healthcheck lualibs).
+- `openresty-express-install.sh` — build/extract/install orchestrator.
+
+## Usage
+
+```bash
+cd infra/openresty-prebuilt
+
+# Full: build image -> extract -> install OpenResty on pop0 -> sync api/+html/ -> reload
+TARGET=bwalia@187.124.112.155 ./openresty-express-install.sh full
+
+# Frequent path: only Lua/HTML changed -> sync + reload (no OpenResty reinstall)
+TARGET=bwalia@187.124.112.155 ./openresty-express-install.sh code
+
+# Just build the image / just extract a tarball
+./openresty-express-install.sh build
+./openresty-express-install.sh extract
+```
+
+Config via env: `TARGET`, `IMAGE`, `BASE_IMAGE`, `PLATFORM`, `OPENRESTY_VERSION`,
+`PULL=1` (pull instead of build), `SSH_OPTS`.
+
+## Hard requirements / gotchas
+
+- **glibc + arch must match the target.** Default `BASE_IMAGE=debian:13`,
+  `PLATFORM=linux/amd64` → matches the Debian amd64 hosts. A musl (Alpine) or
+  arm64 binary will NOT run on amd64 Debian. On Apple Silicon the build runs
+  under emulation so the produced binary is still amd64 (correct for pop0).
+- **Never clobbers live config/app.** The tree rsync excludes `nginx/conf/`,
+  `nginx/html/`, `nginx/logs/`, so the host's templated `nginx.conf`, server
+  confs and app code survive. App code is synced separately from the git
+  checkout (the source of truth) to the same paths Ansible uses.
+- **`openresty -t` gates the restart** — a bad config aborts before reload.
+- **Target needs passwordless sudo** (rsync uses `--rsync-path="sudo rsync"`);
+  `infra/scripts`/`setup-runner-host.sh`-style setup already provides this on
+  the runner hosts.
+- **Not host runtime setup.** The IP2Location DB, `/opt/nginx/data` dirs and the
+  resty-auto-ssl fallback cert are still provisioned by the Ansible role /
+  `cdn-dependencies.sh.j2` — this tool only replaces the *compile* step.
+- **First-time hosts:** `nginx/conf` is excluded, so the host must already have
+  a valid wslproxy `nginx.conf` (run the Ansible `nginx` tag once). For an
+  already-deployed host like pop0 it's already there.
+
+## When to rebuild the image
+
+Only when the OpenResty version, configure flags, or the rock/opm list change.
+Day-to-day Lua/HTML edits use `code` mode and never touch the image.

--- a/infra/openresty-prebuilt/openresty-express-install.sh
+++ b/infra/openresty-prebuilt/openresty-express-install.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# openresty-express-install.sh
+# ----------------------------------------------------------------------------
+# Build (or pull) a Docker image that has OpenResty + all wslproxy Lua deps
+# precompiled, EXTRACT the /usr/local/openresty tree out of it, and install
+# it on a bare-metal target (e.g. pop0) — instead of compiling OpenResty from
+# source on every host. Then sync the app code (api/ + html/) and reload.
+#
+# No registry/artifact push: everything is local docker build + docker cp +
+# rsync over SSH.
+#
+# WHY THIS IS SAFE ON A LIVE HOST:
+#   - The OpenResty tree is rsynced with nginx/conf, nginx/html and nginx/logs
+#     EXCLUDED, so the host's real templated nginx.conf, server confs and app
+#     code are never overwritten by the image's defaults.
+#   - App code (api/, html/) is synced separately from the git checkout — the
+#     source of truth — exactly where Ansible's deploy_app.yml puts it.
+#   - `openresty -t` is run before any restart; a bad config aborts the deploy.
+#
+# REQUIREMENTS:
+#   - Local: docker, rsync, ssh.
+#   - The image BASE_IMAGE must match the target's glibc/arch (Debian 13 by
+#     default). Mismatch (e.g. Alpine/musl image -> Debian host) = nginx won't run.
+#
+# USAGE:
+#   ./openresty-express-install.sh [MODE]
+#
+#   MODE (default: full):
+#     full     build/pull image -> extract -> install OpenResty tree on target
+#              -> sync api/ + html/ -> openresty -t -> restart
+#     code     sync api/ + html/ to target -> reload   (the frequent path:
+#              "lua or html files changed")
+#     build    build the image only (no target changes)
+#     extract  build/pull + extract the tree to a local tarball (no target)
+#
+# CONFIG (override via env):
+#   TARGET=bwalia@187.124.112.155   # pop0 (user@host)
+#   IMAGE=wslproxy-openresty:1.29.2.1
+#   BASE_IMAGE=debian:13            # MUST match the target OS/glibc
+#   PULL=0                          # 1 = docker pull IMAGE instead of build
+#   SSH_OPTS="-o ConnectTimeout=15"
+#
+# EXAMPLES:
+#   TARGET=bwalia@187.124.112.155 ./openresty-express-install.sh full
+#   TARGET=bwalia@187.124.112.155 ./openresty-express-install.sh code
+# ----------------------------------------------------------------------------
+set -euo pipefail
+
+MODE="${1:-full}"
+
+# ── Config ──
+TARGET="${TARGET:-bwalia@187.124.112.155}"          # pop0
+IMAGE="${IMAGE:-wslproxy-openresty:1.29.2.1}"
+BASE_IMAGE="${BASE_IMAGE:-debian:13}"
+OPENRESTY_VERSION="${OPENRESTY_VERSION:-1.29.2.1}"
+# Target CPU arch. pop0 is x86_64, so default linux/amd64. On Apple Silicon
+# this builds under emulation (slower) but produces a binary that RUNS on the
+# amd64 host — building native arm64 here would be unusable on pop0.
+PLATFORM="${PLATFORM:-linux/amd64}"
+PULL="${PULL:-0}"
+PREFIX="/usr/local/openresty"
+SSH_OPTS="${SSH_OPTS:--o ConnectTimeout=15}"
+
+# Repo root = two levels up from this script (infra/openresty-prebuilt/..).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+STAGING="$(mktemp -d)"
+trap 'rm -rf "$STAGING"' EXIT
+
+log()  { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m WARN\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mERROR\033[0m %s\n' "$*" >&2; exit 1; }
+
+require() { command -v "$1" >/dev/null 2>&1 || die "'$1' not found on PATH"; }
+
+# Run a command on the target over SSH (no double-sudo password: target needs
+# passwordless sudo, which our setup-runner-host.sh already configures).
+rsh() { ssh $SSH_OPTS "$TARGET" "$@"; }
+
+# ── Steps ───────────────────────────────────────────────────────────────────
+
+build_image() {
+  require docker
+  if [ "$PULL" = "1" ]; then
+    log "Pulling image $IMAGE ($PLATFORM)"
+    docker pull --platform "$PLATFORM" "$IMAGE"
+  else
+    log "Building image $IMAGE (BASE_IMAGE=$BASE_IMAGE, OpenResty $OPENRESTY_VERSION, $PLATFORM)"
+    DOCKER_BUILDKIT=1 docker build \
+      --platform "$PLATFORM" \
+      --build-arg "BASE_IMAGE=$BASE_IMAGE" \
+      --build-arg "OPENRESTY_VERSION=$OPENRESTY_VERSION" \
+      -t "$IMAGE" \
+      "$SCRIPT_DIR"
+  fi
+}
+
+extract_tree() {
+  require docker
+  log "Extracting $PREFIX from $IMAGE"
+  local cid
+  # create (not run) — cp only reads the filesystem, so no emulation needed
+  # even when extracting an amd64 image on an arm64 host.
+  cid="$(docker create --platform "$PLATFORM" "$IMAGE")"
+  # docker cp streams a tar rooted at 'openresty/' -> unpack into STAGING.
+  docker cp "$cid:$PREFIX" - | tar -x -C "$STAGING"
+  docker rm -f "$cid" >/dev/null
+  [ -x "$STAGING/openresty/nginx/sbin/nginx" ] || die "extracted tree missing nginx binary"
+  log "Extracted $(du -sh "$STAGING/openresty" | cut -f1) to staging"
+}
+
+# Extract-only mode: leave a tarball next to the script for inspection.
+extract_to_tarball() {
+  build_image
+  extract_tree
+  local out="$SCRIPT_DIR/openresty-${OPENRESTY_VERSION}-${BASE_IMAGE//[:\/]/_}.tar.gz"
+  log "Writing $out"
+  tar -C "$STAGING" -czf "$out" openresty
+  log "Done: $out"
+}
+
+ensure_target_runtime() {
+  log "Ensuring runtime libs + www-data on target ($TARGET)"
+  # Runtime libs matching the Dockerfile's runtime stage. PCRE2 first
+  # (Debian 13), fall back to pcre3 for older targets.
+  rsh 'sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq && \
+       sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
+         libssl3 zlib1g ca-certificates rsync && \
+       (sudo apt-get install -y -qq libpcre2-8-0 || sudo apt-get install -y -qq libpcre3) ; \
+       id -u www-data >/dev/null 2>&1 || sudo useradd -r -s /usr/sbin/nologin www-data || true'
+}
+
+install_tree() {
+  require rsync
+  ensure_target_runtime
+  log "Rsyncing OpenResty tree -> $TARGET:$PREFIX (preserving conf/html/logs)"
+  # Exclude the host's real config, app code and runtime dirs so we update
+  # only the binary + luajit + lualib + bin. --rsync-path=sudo lets rsync
+  # write into root-owned /usr/local/openresty.
+  rsync -az --delete \
+    --exclude='/nginx/conf/' \
+    --exclude='/nginx/html/' \
+    --exclude='/nginx/logs/' \
+    --rsh="ssh $SSH_OPTS" \
+    --rsync-path="sudo rsync" \
+    "$STAGING/openresty/" "$TARGET:$PREFIX/"
+
+  # Re-create the convenience symlink + a PATH symlink for mc.
+  rsh "sudo ln -sf $PREFIX/nginx/sbin/nginx /usr/bin/openresty ; \
+       sudo ln -sf $PREFIX/bin/mc /usr/local/bin/mc 2>/dev/null || true ; \
+       $PREFIX/nginx/sbin/nginx -v"
+}
+
+sync_app_code() {
+  require rsync
+  [ -d "$REPO_ROOT/api" ]  || die "missing $REPO_ROOT/api"
+  [ -d "$REPO_ROOT/html" ] || die "missing $REPO_ROOT/html"
+  log "Syncing html/ -> $TARGET:$PREFIX/nginx/html"
+  rsync -az --rsh="ssh $SSH_OPTS" --rsync-path="sudo rsync" \
+    "$REPO_ROOT/html/" "$TARGET:$PREFIX/nginx/html/"
+  log "Syncing api/ -> $TARGET:$PREFIX/nginx/html/api"
+  rsync -az --rsh="ssh $SSH_OPTS" --rsync-path="sudo rsync" \
+    "$REPO_ROOT/api/" "$TARGET:$PREFIX/nginx/html/api/"
+}
+
+test_and_reload() {
+  log "Testing config on target (openresty -t)"
+  if ! rsh "sudo $PREFIX/nginx/sbin/nginx -t"; then
+    die "openresty -t FAILED on target — NOT restarting (live config left running)"
+  fi
+  log "Reloading OpenResty on target"
+  # Prefer systemd; fall back to a direct reload/start.
+  rsh 'sudo systemctl reload openresty 2>/dev/null \
+       || sudo systemctl restart openresty 2>/dev/null \
+       || sudo /usr/local/openresty/nginx/sbin/nginx -s reload 2>/dev/null \
+       || sudo /usr/local/openresty/nginx/sbin/nginx'
+  log "Reloaded. Health:"
+  rsh "curl -sf -o /dev/null -w 'HTTP %{http_code}\n' http://127.0.0.1:8080/health || echo 'health check did not return 200 (check manually)'"
+}
+
+# ── Dispatch ──
+case "$MODE" in
+  build)
+    build_image
+    ;;
+  extract)
+    extract_to_tarball
+    ;;
+  code)
+    log "CODE mode: sync api/ + html/ to $TARGET and reload"
+    sync_app_code
+    test_and_reload
+    ;;
+  full)
+    log "FULL mode: install prebuilt OpenResty + app code on $TARGET"
+    build_image
+    extract_tree
+    install_tree
+    sync_app_code
+    test_and_reload
+    ;;
+  *)
+    die "unknown MODE '$MODE' (use: full | code | build | extract)"
+    ;;
+esac
+
+log "Done ($MODE)."


### PR DESCRIPTION
## POP1 — new AWS eu-west-2 production POP

Dashboard: **pop1.diytaxreturn.co.uk** · EIP **18.133.126.242** · ssh user `admin`.
Deployed via **local Ansible** (GitHub workflows being retired for Argo); the
delivery pipeline also gains a pop1 stage that runs **last**.

### Changes
- **inventory** (`infra/ansible/hosts`): add `18.133.126.242` (user `admin`) to `openresty_native_cluster` + `openresty_prod`.
- **host_vars/18.133.126.242**: dashboard wired via `nginx_default_server_backend_nextjs = pop1.diytaxreturn.co.uk` (auto-ssl HTTPS). `frontend`/`backend` left empty to avoid `:443` `server_name` collisions. Secrets via file mode (`/tmp/wslproxy-pop1`).
- **delivery pipeline**: new **Stage 5c `deploy-prod-pop1`** — `needs: [deploy-prod-lon1]`, gated to run only after pop0+lon1 and all prior stages pass; `ssh_key`, self-seeds from the host's live config. Adds `18.133.126.242` to `TARGET_HOST` and wires it into the summary/failure check.
- **infra/POP1_DEPLOY.md**: local-Ansible runbook (key, DNS, security group, secrets, deploy command, verify).
- **infra/openresty-prebuilt/**: `Dockerfile` + `openresty-express-install.sh` to compile OpenResty once in Docker and install the extracted tree on a host instead of compiling from source per host.

### Deploy (from the Mac with the EC2 key)
See `infra/POP1_DEPLOY.md`. Requires DNS `pop1.diytaxreturn.co.uk -> 18.133.126.242` and SG ports 80/443/7691 open for the dashboard cert + health gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)