### PR TITLE
ci(prod): add prod pop1 (18.133.126.242), seeded from pop0

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -58,6 +58,19 @@ on:
         description: "On-host path to the live .env (used only when seed_from_host=true; best-effort)"
         type: string
         default: "/opt/nginx/data/.env"
+      seed_source_ip:
+        description: >-
+          Host to PULL the live settings.json FROM when seed_from_host=true.
+          Defaults to host_ip (self-seed). Set to a DIFFERENT host (e.g. seed a
+          brand-new pop from an existing one) to clone another host's live
+          config onto this deploy target. The runner's ~/.ssh/id_rsa must be
+          authorized on this source host.
+        type: string
+        default: ""
+      seed_source_user:
+        description: "SSH user for seed_source_ip (defaults to ssh_user)."
+        type: string
+        default: ""
       health_endpoint:
         description: "URL to curl for health check (e.g. http://localhost:8080/health)"
         type: string
@@ -371,7 +384,11 @@ jobs:
             echo "::error::seed_from_host requires connection_mode=ssh_key"; exit 1
           fi
           mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          ssh-keyscan -H "${{ inputs.host_ip }}" >> ~/.ssh/known_hosts 2>/dev/null || true
+          # Seed SOURCE host: defaults to the deploy target (self-seed), but can
+          # be overridden to clone another host's live config (e.g. pop1 from pop0).
+          SEED_IP="${{ inputs.seed_source_ip || inputs.host_ip }}"
+          SEED_USER="${{ inputs.seed_source_user || inputs.ssh_user }}"
+          ssh-keyscan -H "$SEED_IP" >> ~/.ssh/known_hosts 2>/dev/null || true
           SSH_OPTS="-o BatchMode=yes -o ConnectTimeout=10 -i ~/.ssh/id_rsa"
           SETTINGS="${{ inputs.settings_file_path }}"
           ENVFILE="${{ inputs.env_file_path }}"
@@ -379,10 +396,10 @@ jobs:
             echo "::error::settings_file_path must be set when seed_from_host=true"; exit 1
           fi
           mkdir -p "$(dirname "$SETTINGS")"
-          echo "Pulling live settings.json from ${{ inputs.ssh_user }}@${{ inputs.host_ip }}:${{ inputs.host_settings_path }}"
-          ssh $SSH_OPTS "${{ inputs.ssh_user }}@${{ inputs.host_ip }}" \
+          echo "Pulling live settings.json from ${SEED_USER}@${SEED_IP}:${{ inputs.host_settings_path }}"
+          ssh $SSH_OPTS "${SEED_USER}@${SEED_IP}" \
             "cat '${{ inputs.host_settings_path }}'" > "$SETTINGS" || {
-            echo "::error::Failed to read live settings from host"; exit 1; }
+            echo "::error::Failed to read live settings from seed source host"; exit 1; }
           if [[ ! -s "$SETTINGS" ]]; then
             echo "::error::Live settings.json on host is empty: ${{ inputs.host_settings_path }}"; exit 1
           fi
@@ -393,7 +410,7 @@ jobs:
           # the deploy-time /tmp/.env, else leave empty (non-fatal warning).
           if [[ -n "$ENVFILE" ]]; then
             mkdir -p "$(dirname "$ENVFILE")"
-            ssh $SSH_OPTS "${{ inputs.ssh_user }}@${{ inputs.host_ip }}" \
+            ssh $SSH_OPTS "${SEED_USER}@${SEED_IP}" \
               "cat '${{ inputs.host_env_path }}' 2>/dev/null || cat /tmp/.env 2>/dev/null || true" > "$ENVFILE" || true
             if [[ -s "$ENVFILE" ]]; then
               echo "Seeded $(wc -c < "$ENVFILE") bytes of .env"

--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -42,6 +42,7 @@ on:
           # 187.77.179.206 (acc) was decommissioned.
           - 187.124.112.155
           - 72.62.211.28
+          - 18.133.126.242
 
       DEPLOY_MODE:
         type: choice
@@ -464,6 +465,46 @@ jobs:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   # ──────────────────────────────────────────────────────
+  # Stage 5c: Deploy Prod pop1 (18.133.126.242)
+  # Brand-new pop. Has no live config of its own, so it SEEDS its
+  # settings.json from pop0 (187.124.112.155) over SSH — an identity
+  # clone — then deploys it. The prod runner's ~/.ssh/id_rsa must be
+  # authorized as admin@18.133.126.242 AND (already is) root@pop0.
+  # ──────────────────────────────────────────────────────
+  deploy-prod-pop1:
+    needs: [deploy-prod-lon1]
+    if: >
+      always() && !failure() && !cancelled() &&
+      ((github.event_name == 'push' && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/main')) ||
+      (github.event_name == 'workflow_dispatch' &&
+      (github.event.inputs.TARGET_HOST == '18.133.126.242' || github.event.inputs.TARGET_HOST == 'all')))
+    uses: ./.github/workflows/deploy-environment.yml
+    with:
+      env_name: prod
+      env_label: "Prod pop1 (18.133.126.242)"
+      stage_number: "5c"
+      host_ip: "18.133.126.242"
+      ssh_user: admin
+      connection_mode: ssh_key
+      # Seed pop1's settings from pop0's live config (identity clone).
+      secrets_mode: runner_file
+      seed_from_host: true
+      seed_source_ip: "187.124.112.155"
+      seed_source_user: root
+      settings_file_path: "/tmp/wslproxy-pop1/settings.json"
+      env_file_path: "/tmp/wslproxy-pop1/.env"
+      # Fresh host: no DNS/cert and inbound ports likely closed, so check
+      # health over the deploy SSH connection against the local admin API.
+      health_endpoint: "http://127.0.0.1:8099/health"
+      health_check_mode: ssh
+      docker_prune: true
+      notify_success: true
+      deploy_branch: ${{ github.event.inputs.DEPLOY_BRANCH || github.ref_name }}
+      deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
   # Pipeline Summary (always runs — final report)
   # ──────────────────────────────────────────────────────
   pipeline-summary:
@@ -477,6 +518,7 @@ jobs:
         deploy-test,
         deploy-prod-pop0,
         deploy-prod-lon1,
+        deploy-prod-pop1,
       ]
     if: always()
     steps:
@@ -492,6 +534,7 @@ jobs:
           echo "  Stage 4  — Deploy Test:          ${{ needs.deploy-test.result }}"
           echo "  Stage 5a — Deploy Prod (pop0):   ${{ needs.deploy-prod-pop0.result }}"
           echo "  Stage 5b — Deploy Prod (lon1):   ${{ needs.deploy-prod-lon1.result }}"
+          echo "  Stage 5c — Deploy Prod (pop1):   ${{ needs.deploy-prod-pop1.result }}"
           echo ""
           echo "  Commit:  ${{ github.sha }}"
           echo "  Branch:  ${{ github.ref_name }}"
@@ -503,7 +546,8 @@ jobs:
              [[ "${{ needs.test-int.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-test.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-prod-pop0.result }}" == "failure" ]] || \
-             [[ "${{ needs.deploy-prod-lon1.result }}" == "failure" ]]; then
+             [[ "${{ needs.deploy-prod-lon1.result }}" == "failure" ]] || \
+             [[ "${{ needs.deploy-prod-pop1.result }}" == "failure" ]]; then
               echo "::error::Pipeline failed — see stage results above"
               exit 1
           fi

--- a/infra/ansible/hosts
+++ b/infra/ansible/hosts
@@ -9,6 +9,7 @@
 192.168.1.140 ansible_user=bwalia
 187.124.112.155 ansible_user=root
 72.62.211.28 ansible_user=root
+18.133.126.242 ansible_user=admin
 
 # ── Environment groups ─────────────────────────────────
 
@@ -21,6 +22,7 @@
 [openresty_prod]
 187.124.112.155 ansible_user=root
 72.62.211.28 ansible_user=root
+18.133.126.242 ansible_user=admin
 
 # ── Group all openresty servers ────────────────────────
 


### PR DESCRIPTION
## What
Adds a brand-new production POP — **pop1 `18.133.126.242`** (`admin` user, AWS eu-west-2) — to the delivery pipeline.

Because pop1 has no live config of its own yet, it **identity-clones pop0's live `settings.json`** over SSH at deploy time (per the chosen "identity copy, no changes" tweak).

## Changes
- **`deploy-environment.yml`** — new optional `seed_source_ip` / `seed_source_user` inputs. When set, `seed_from_host` pulls settings from a *different* host instead of self-seeding. Defaults preserve existing pop0 self-seed behaviour exactly.
- **delivery pipeline** — new `deploy-prod-pop1` stage (**5c**, after lon1): seeds from `root@187.124.112.155` (pop0) → deploys to `admin@18.133.126.242` → health-checks **over SSH** against `http://127.0.0.1:8099/health` (fresh host: no DNS/cert, inbound ports likely closed). Also added the IP to `TARGET_HOST` choices and the pipeline summary.
- **`infra/ansible/hosts`** — pop1 added to `openresty_native_cluster` + `openresty_prod` (`become: yes` handles the non-root `admin` sudo).

## ⚠️ Operator prerequisite (deploy will be red until done)
The prod self-hosted runner's `~/.ssh/id_rsa` must be authorized as **`admin@18.133.126.242`**. Verify with:
```
ssh -o BatchMode=yes -i ~/.ssh/id_rsa admin@18.133.126.242 hostname
```
The same key is already authorized as `root@187.124.112.155` (pop0) for the seed source. (Note: lon1 is still blocked on this same SSH-key gap.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)