### PR TITLE
fix(ansible): keep default.conf on dashboard-only POPs (follow-up to #1112)

### DIFF
--- a/infra/ansible/roles/wslproxy/tasks/finalize.yml
+++ b/infra/ansible/roles/wslproxy/tasks/finalize.yml
@@ -36,21 +36,31 @@
   register: sync_tenants
   tags: [nginx, servers]
 
-- name: Deploy default.conf when frontend or backend is configured
+- name: Deploy default.conf when a frontend, backend or dashboard domain is configured
   template:
     src: default.conf.j2
     dest: /opt/nginx/conf.d/default.conf
     mode: 0664
     owner: www-data
     group: root
-  when: (nginx_default_server_frontend | default('') | length > 0) or (nginx_default_server_backend | default('') | length > 0)
+  # nginx_default_server_backend_nextjs renders the public 443 dashboard
+  # vhost; on dashboard-only POPs (e.g. pop1) it's the ONLY public domain,
+  # so it must keep default.conf (otherwise requests fall through to the
+  # catch-all gateway and the dashboard is unreachable at /).
+  when: >
+    (nginx_default_server_frontend | default('') | length > 0) or
+    (nginx_default_server_backend | default('') | length > 0) or
+    (nginx_default_server_backend_nextjs | default('') | length > 0)
   tags: [nginx, servers]
 
-- name: Remove default.conf when no frontend/backend configured
+- name: Remove default.conf when no public domain is configured
   file:
     path: /opt/nginx/conf.d/default.conf
     state: absent
-  when: (nginx_default_server_frontend | default('') | length == 0) and (nginx_default_server_backend | default('') | length == 0)
+  when: >
+    (nginx_default_server_frontend | default('') | length == 0) and
+    (nginx_default_server_backend | default('') | length == 0) and
+    (nginx_default_server_backend_nextjs | default('') | length == 0)
   tags: [nginx, servers]
 
 - name: Ensure SSL domain directory exists


### PR DESCRIPTION
Follow-up to #1112. That PR was merged as a merge commit at `a24d9059`, which included fixes 1–5 but **not** the final `default.conf` fix — so `main` currently regresses a dashboard-only POP.

## Problem
`finalize.yml` deletes `/opt/nginx/conf.d/default.conf` whenever both `nginx_default_server_frontend` and `nginx_default_server_backend` are empty. But `default.conf` also carries the public **:443 vhost** for `nginx_default_server_backend_nextjs` (the Next.js dashboard). On a **dashboard-only POP** like pop1, frontend/backend are empty by design → the dashboard server block is removed → `pop1.diytaxreturn.co.uk` falls through to the catch-all gateway, and `/` serves the `settings.json` default page (redirect to `wslproxy.com`) instead of the dashboard.

## Fix
Include `nginx_default_server_backend_nextjs` in both the deploy and remove `when` conditions, so `default.conf` is kept/rendered whenever **any** public domain (frontend, backend, or dashboard) is configured.

## Verified
Deployed to pop1: `/` now `307 → /login` and serves the dashboard (`<title>Sign in — WSL Proxy Admin</title>`), matching pop0 (`prod-our.wslproxy.com`). Backward-compatible with multi-domain POPs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)