### PR TITLE
chore(ansible): pin pop1 SSH private key for local deploys

### DIFF
--- a/infra/ansible/host_vars/18.133.126.242/vars.yaml
+++ b/infra/ansible/host_vars/18.133.126.242/vars.yaml
@@ -15,6 +15,13 @@
 local_settings_file_path: "/tmp/wslproxy-pop1/settings.json"
 local_env_file_path: "/tmp/wslproxy-pop1/.env"
 
+# SSH key for LOCAL controller deploys (ansible-playbook run from a workstation).
+# pop1 is an AWS EC2 host reached as `admin` with the diytaxreturn EC2 keypair.
+# The self-hosted CI runner overrides this on the command line with
+# `--private-key ~/.ssh/id_rsa` (see deploy-environment.yml), so pinning the
+# local path here does not affect pipeline runs.
+ansible_ssh_private_key_file: "/Users/balinderwalia/projects/diy-tax-return-infra/diytaxreturn-aws-ec2-keypair.pem"
+
 nginx_user_password: "!!REDACTED!!" # www-data password — encrypt via Ansible Vault
 host_lan_ip: "18.133.126.242"
 nginx_web_ui_enabled: "yes"


### PR DESCRIPTION
## What
Pin `ansible_ssh_private_key_file` for pop1 (`18.133.126.242`) in `host_vars` so local `ansible-playbook` runs use the diytaxreturn EC2 keypair without relying on a matching `~/.ssh/config` Host entry.

## Why
pop1 is an AWS EC2 host reached as `admin` with the diytaxreturn keypair (not the fleet's root `id_rsa`). Local controller deploys previously worked only because a `~/.ssh/config` entry existed on one workstation.

## CI safety
The self-hosted runner overrides the key on the command line with `--private-key ~/.ssh/id_rsa` (see `deploy-environment.yml`), which takes precedence over the inventory variable, so pipeline runs are unaffected.

## Verified
`ansible -i hosts 18.133.126.242 -m ping` → SUCCESS / pong using the pinned key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)