### PR TITLE
fix(api): removeServerFromRule crashes when rule has no .servers field

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -581,6 +581,16 @@ local function removeServerFromRule(oldRuleId, serverId, envProfile)
         end
         if loadRules and loadRules ~= "null" and type(loadRules) == "string" then
             loadRules = cjson.decode(loadRules)
+            -- Guard: rule JSON may not have a `.servers` field yet if
+            -- no server has ever been linked to it.  Without this
+            -- check, `#loadRules.servers` raises "attempt to get
+            -- length of field 'servers' (a nil value)" and aborts
+            -- the whole PUT /api/servers/... request.  Sibling
+            -- function updateServerInRules already handles this
+            -- shape (see the `if not getRules.servers` branch).
+            if type(loadRules.servers) ~= "table" then
+                return
+            end
             local valueToRemove = serverId
             local i = 1
             while i <= #loadRules.servers do


### PR DESCRIPTION
## Summary

`PUT /api/servers/<id>` aborts on any host where the linked rule's JSON has no `.servers` field yet. Symptom:

```
/usr/local/openresty/nginx/html/api/api.lua:586:
  attempt to get length of field 'servers' (a nil value)
```

Full trace, from prod pop1 (`18.133.126.242`) saving `vault.diytaxreturn.co.uk`:

```
api.lua:6056 main
api.lua:5706 handle_put_request
api.lua:1441 createUpdateServer
api.lua:2194 CreateUpdateRecord
api.lua:611  updateServerInRules
api.lua:637  updateServerInRules
api.lua:566  removeServerFromRule
api.lua:586  removeServerFromRule  ← crash: #nil
```

## Root cause

Server save does a two-way link reconciliation:

1. **`removeServerFromRule`** — strip this server-id from any rule it used to belong to
2. **`updateServerInRules`** — add this server-id to the rules it currently belongs to

Step (2) already tolerates a missing `.servers` field ([api.lua:645-654](api/api.lua#L645-L654)):

```lua
if not getRules.servers and getRules.servers == nil then
    getRules.servers = {}
else
    ...
end
```

Step (1) doesn't — it goes straight to `#loadRules.servers` right after `cjson.decode(loadRules)`. That asymmetry is the whole bug.

## Fix

Mirror the guard from step (2). When the decoded rule JSON has no `.servers` (or `.servers` isn't a table — defensive against schema drift), there's nothing to unlink, so return early.

```lua
if type(loadRules.servers) ~= "table" then
    return
end
```

Explicitly does NOT write back an empty `.servers = {}` — nothing changed, avoid a spurious file/Redis write that would race with concurrent rule edits.

## When this shape appears

Any rule whose JSON has never been linked to a server — which happens for:
- Fresh installs (the pop1 case)
- Rules created directly via the API (bypassing the server-first path)
- Rules imported from S3 with schema drift

## Verified BEFORE this commit

Directly patched `/usr/local/openresty/nginx/html/api/api.lua` on live prod `18.133.126.242`:
- Backup: `api.lua.bak.20260701-140445`
- `luac -p` ✓ `openresty -t` ✓ `systemctl reload openresty` ✓
- Retried the failing `PUT` — succeeded
- Existing servers with populated `.servers` arrays: unchanged behaviour (falls through to the same while-loop)

## Won't fix here (separate concerns)

- **Reconciliation atomicity** — if step (1) or (2) fails halfway, the two-way link is partly applied. Bigger surgery, separate PR.
- **Data cleanup** — any rules created before this patch that got a half-mutated shape from aborted requests. Cheap to spot-fix once traffic is stable.

## Test plan

- [x] `luac -p` passes
- [x] Manually verified on prod pop1 (see above)
- [ ] Import a rule with no `.servers` field, then PUT a server that references it → should succeed after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)