### PR TITLE
ci: add deploy-single-environment workflow (per-env deploy for Ring Promoter)

### DIFF
--- a/.github/workflows/deploy-single-environment.yml
+++ b/.github/workflows/deploy-single-environment.yml
@@ -1,0 +1,190 @@
+name: Deploy Single Environment
+# Deploys ONE environment (int | test | prod) in isolation, with NO cascade to
+# other environments. It reuses the same tested reusable workflow
+# (deploy-environment.yml) and the exact per-host settings as the full delivery
+# pipeline — it just drops the int→test→prod chaining.
+#
+# WHY THIS EXISTS
+#   deploy-wslproxy-delivery-pipeline.yml is a cumulative promotion cascade:
+#   `deploy-int` runs on every dispatch and each later stage `needs:` the
+#   previous, gated by TARGET_HOST. That is correct for a "build → promote all
+#   the way up" release, but it cannot deploy a single environment on its own.
+#
+#   Ring Promoter (github.com/bwalia/ring-promoter) models each ring as an
+#   INDEPENDENT environment: it promotes one ring at a time and, on a failed
+#   post-deploy health check, auto-rolls-back THAT ring only. For that it needs
+#   to deploy exactly one environment per dispatch — which is what this workflow
+#   provides. Ring Promoter dispatches it with ENV = the ring's environment.
+#
+# Selecting ENV=prod deploys all three prod hosts (pop0 → lon1 → pop1) in order,
+# stopping if any host fails — but never touches int or test.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ENV:
+        type: choice
+        description: "Which single environment to deploy (no cascade to others)"
+        required: true
+        default: "int"
+        options:
+          - int
+          - test
+          - prod
+      DEPLOY_BRANCH:
+        type: string
+        description: "Git ref to deploy (branch, tag or commit SHA)"
+        required: true
+        default: "build"
+      DEPLOY_MODE:
+        type: choice
+        description: "What to deploy"
+        required: true
+        default: "full"
+        options:
+          - full
+          - code
+          - nginx
+          - servers
+          - dashboard
+          - dashboard-next
+          - os_deps
+          - build
+
+# Serialize deploys to the same environment; don't cancel an in-flight deploy.
+concurrency:
+  group: deploy-single-${{ inputs.ENV }}
+  cancel-in-progress: false
+
+jobs:
+  # ──────────────────────────────────────────────────────
+  # int (192.168.1.193) — local sudo deploy, SOPS-decrypted secrets
+  # ──────────────────────────────────────────────────────
+  int:
+    if: ${{ inputs.ENV == 'int' }}
+    uses: ./.github/workflows/deploy-environment.yml
+    with:
+      env_name: int
+      env_label: "Int (192.168.1.193)"
+      stage_number: "int"
+      host_ip: "192.168.1.193"
+      ssh_user: bwalia
+      connection_mode: local
+      secrets_mode: sops
+      health_endpoint: "http://localhost:8080/health"
+      health_check_mode: local
+      docker_prune: true
+      notify_success: true
+      deploy_branch: ${{ inputs.DEPLOY_BRANCH }}
+      deploy_mode: ${{ inputs.DEPLOY_MODE }}
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+      # Kept so an emergency revert to secrets_mode: github_secret needs no
+      # secret re-add (mirrors the delivery pipeline's int stage).
+      SETTINGS_SECRET: ${{ secrets.DOT_WSLPROXY_SETTINGS_INT }}
+      ENV_CREDS_SECRET: ${{ secrets.DOT_WSLPROXY_ENV_CREDS_INT }}
+
+  # ──────────────────────────────────────────────────────
+  # test (192.168.1.140) — SSH deploy, secrets read from the runner
+  # ──────────────────────────────────────────────────────
+  test:
+    if: ${{ inputs.ENV == 'test' }}
+    uses: ./.github/workflows/deploy-environment.yml
+    with:
+      env_name: test
+      env_label: "Test (192.168.1.140)"
+      stage_number: "test"
+      host_ip: "192.168.1.140"
+      ssh_user: bwalia
+      connection_mode: ssh
+      secrets_mode: runner_file
+      settings_file_path: "/home/bwalia/.secrets/wslproxy/test/settings.json"
+      env_file_path: "/home/bwalia/.secrets/wslproxy/test/.env"
+      health_endpoint: "http://localhost:8080/health"
+      health_check_mode: ssh
+      docker_prune: false
+      notify_success: true
+      deploy_branch: ${{ inputs.DEPLOY_BRANCH }}
+      deploy_mode: ${{ inputs.DEPLOY_MODE }}
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
+  # prod pop0 (187.124.112.155) — first prod host; self-seeds live config
+  # ──────────────────────────────────────────────────────
+  prod-pop0:
+    if: ${{ inputs.ENV == 'prod' }}
+    uses: ./.github/workflows/deploy-environment.yml
+    with:
+      env_name: prod
+      env_label: "Prod pop0 (187.124.112.155)"
+      stage_number: "prod-5a"
+      host_ip: "187.124.112.155"
+      ssh_user: root
+      connection_mode: ssh_key
+      secrets_mode: runner_file
+      seed_from_host: true
+      settings_file_path: "/tmp/wslproxy-pop0/settings.json"
+      env_file_path: "/tmp/wslproxy-pop0/.env"
+      health_endpoint: "https://prod-our-v1.wslproxy.com/health"
+      health_check_mode: external
+      docker_prune: true
+      notify_success: true
+      deploy_branch: ${{ inputs.DEPLOY_BRANCH }}
+      deploy_mode: ${{ inputs.DEPLOY_MODE }}
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
+  # prod lon1 (72.62.211.28) — runs after pop0 succeeds
+  # ──────────────────────────────────────────────────────
+  prod-lon1:
+    needs: [prod-pop0]
+    if: ${{ always() && !failure() && !cancelled() && inputs.ENV == 'prod' }}
+    uses: ./.github/workflows/deploy-environment.yml
+    with:
+      env_name: prod
+      env_label: "Prod lon1 (72.62.211.28)"
+      stage_number: "prod-5b"
+      host_ip: "72.62.211.28"
+      ssh_user: root
+      connection_mode: ssh_key
+      secrets_mode: runner_file
+      settings_file_path: "/home/bwalia/.secrets/wslproxy/lon1/settings.json"
+      env_file_path: "/home/bwalia/.secrets/wslproxy/lon1/.env"
+      health_endpoint: "http://72.62.211.28:7691/health"
+      health_check_mode: external
+      docker_prune: true
+      notify_success: true
+      deploy_branch: ${{ inputs.DEPLOY_BRANCH }}
+      deploy_mode: ${{ inputs.DEPLOY_MODE }}
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # ──────────────────────────────────────────────────────
+  # prod pop1 (18.133.126.242, AWS eu-west-2, ssh user admin) — runs last
+  # ──────────────────────────────────────────────────────
+  prod-pop1:
+    needs: [prod-lon1]
+    if: ${{ always() && !failure() && !cancelled() && inputs.ENV == 'prod' }}
+    uses: ./.github/workflows/deploy-environment.yml
+    with:
+      env_name: prod
+      env_label: "Prod pop1 (18.133.126.242)"
+      stage_number: "prod-5c"
+      host_ip: "18.133.126.242"
+      ssh_user: admin
+      connection_mode: ssh_key
+      secrets_mode: runner_file
+      seed_from_host: true
+      settings_file_path: "/tmp/wslproxy-pop1/settings.json"
+      env_file_path: "/tmp/wslproxy-pop1/.env"
+      health_endpoint: "http://18.133.126.242:7691/health"
+      health_check_mode: external
+      docker_prune: true
+      notify_success: true
+      deploy_branch: ${{ inputs.DEPLOY_BRANCH }}
+      deploy_mode: ${{ inputs.DEPLOY_MODE }}
+    secrets:
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy-single-environment.yml` — a `workflow_dispatch`
workflow that deploys **exactly one** environment (`int` | `test` | `prod`) in
isolation, with **no cascade** to other environments.

It reuses the existing, tested reusable workflow `deploy-environment.yml` and
the **same per-host settings** as `deploy-wslproxy-delivery-pipeline.yml` — it
only drops the `int → test → prod` chaining. `ENV=prod` fans out to all three
prod hosts (`pop0 → lon1 → pop1`) in order, stopping on failure, but never
touches `int` or `test`.

## Why

`deploy-wslproxy-delivery-pipeline.yml` is a cumulative promotion cascade:
`deploy-int` runs on **every** dispatch and each later stage `needs:` the
previous, gated by `TARGET_HOST`. That's correct for a "build → promote all the
way up" release, but it cannot deploy a single environment on its own.

[Ring Promoter](https://github.com/bwalia/ring-promoter) models each ring as an
**independent** environment: it promotes one ring at a time and, on a failed
post-deploy health check, **auto-rolls-back that ring only**. For that it must
deploy exactly one environment per dispatch — which is what this workflow
provides. Ring Promoter dispatches it with `ENV` = the ring's environment
(`ring0→int`, `ring1→test`, `ring2→prod`) and `DEPLOY_BRANCH` = the version.

## Notes

- **No behaviour change** to existing workflows — this is purely additive.
- Per-host `host_ip` / `ssh_user` / `connection_mode` / `secrets_mode` /
  `health_endpoint` are copied verbatim from the delivery pipeline's stages.
- `DEPLOY_BRANCH` accepts a branch, tag or commit SHA (passed to
  `actions/checkout` `ref:`, same as the delivery pipeline).
- Reuses the same secrets (`SLACK_WEBHOOK`, `SOPS_AGE_KEY`,
  `DOT_WSLPROXY_SETTINGS_INT`, `DOT_WSLPROXY_ENV_CREDS_INT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)