### PR TITLE
fix: diagnose & reconcile admin-login credential drift; thrice-daily smoke schedule

### DIFF
--- a/.github/workflows/e2e-admin-ui-login.yml
+++ b/.github/workflows/e2e-admin-ui-login.yml
@@ -214,6 +214,52 @@ jobs:
           echo "::error::Admin UI not reachable at $TARGET_URL after 60s"
           exit 1
 
+      - name: Preflight - verify login credentials against the backend
+        # The browser tests below fail cryptically ("Parse test results") when
+        # the *credentials* are stale rather than the login being down — e.g.
+        # after the 2026-06-29 secrets migration re-wrote prod's
+        # settings.super_user without updating this test's creds file/secret.
+        # Hit /api/user/login directly with the exact creds the tests will use
+        # and classify the outcome, so the failure is actionable and the Slack
+        # message doesn't wrongly cry "Admin UI login may be broken".
+        working-directory: .
+        env:
+          TARGET_URL: ${{ matrix.url }}
+          E2E_TEST_EMAIL: ${{ steps.creds.outputs.email }}
+          E2E_TEST_PASSWORD: ${{ steps.creds.outputs.password }}
+        run: |
+          # Body is masked by ::add-mask:: on email/password already; only the
+          # HTTP status is echoed here.
+          STATUS=$(EMAIL="$E2E_TEST_EMAIL" PASSWORD="$E2E_TEST_PASSWORD" python3 - "$TARGET_URL" <<'PY'
+          import json, os, sys, urllib.request, urllib.error
+          url = sys.argv[1].rstrip('/') + '/api/user/login'
+          body = json.dumps({'email': os.environ['EMAIL'], 'password': os.environ['PASSWORD']}).encode()
+          req = urllib.request.Request(url, data=body, method='POST',
+                                       headers={'Content-Type': 'application/json'})
+          try:
+              with urllib.request.urlopen(req, timeout=15) as r:
+                  print(r.status)
+          except urllib.error.HTTPError as e:
+              print(e.code)
+          except Exception:
+              print('000')
+          PY
+          )
+          echo "Login API responded HTTP $STATUS for ${{ matrix.url }}"
+          case "$STATUS" in
+            200)
+              echo "Credentials accepted by the backend — proceeding to UI tests." ;;
+            401|403)
+              echo "::error::Login credentials REJECTED (HTTP $STATUS) by ${{ matrix.url }}. This is a credential mismatch, not a UI outage: the backend settings.super_user no longer matches this job's test creds (on-runner login-creds.json / LOGIN_EMAIL+LOGIN_PASSWORD secrets). Reconcile the two — see api/api.lua login handler and infra/ansible/.../deploy_data.yml."
+              exit 1 ;;
+            000)
+              echo "::error::Could not reach the login API at ${{ matrix.url }}/api/user/login (network/TLS/timeout)."
+              exit 1 ;;
+            *)
+              echo "::error::Login API returned unexpected HTTP $STATUS for ${{ matrix.url }} — the admin login backend may be broken."
+              exit 1 ;;
+          esac
+
       - name: Run Admin UI Login tests
         id: tests
         env:

--- a/.github/workflows/e2e-admin-ui-login.yml
+++ b/.github/workflows/e2e-admin-ui-login.yml
@@ -13,8 +13,9 @@ on:
       - "openresty-admin/package*.json"
       - ".github/workflows/e2e-admin-ui-login.yml"
   schedule:
-    # Hourly smoke check that the admin login is healthy
-    - cron: "0 * * * *"
+    # Thrice-daily smoke check that the admin login is healthy
+    # (00:00, 08:00, 16:00 UTC).
+    - cron: "0 0,8,16 * * *"
   workflow_dispatch:
     inputs:
       TARGET_ENV:

--- a/infra/secrets/reconcile-super-user.sh
+++ b/infra/secrets/reconcile-super-user.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Reconcile a target env's SOPS-encrypted super_user with the canonical
+# admin login plaintext, so the hourly "Admin UI Login Tests" workflow
+# (and the API test workflows) can actually log in.
+#
+# WHY THIS EXISTS
+#   The admin login handler (api/api.lua) compares the STORED hash
+#       settings.super_user.password
+#   against
+#       base64(sha256(<plaintext the client typed>))     (api/helpers.lua:hashPassword)
+#   The 2026-06-29 SOPS/age secrets migration re-wrote prod's
+#   settings.json with a super_user whose hash no longer corresponds to
+#   the canonical LOGIN_EMAIL / LOGIN_PASSWORD repo secrets, so every
+#   valid-credential login test has returned 401 ever since.
+#
+#   This script recomputes the hash from the KNOWN plaintext and writes
+#   it (plus the email) back into infra/secrets/<env>/settings.sops.json,
+#   re-encrypting in place.  Commit + redeploy that env and login works.
+#
+# REQUIREMENTS (run where the age PRIVATE key is available)
+#   - sops + openssl on PATH
+#   - SOPS_AGE_KEY exported (AGE_SECRET_KEY-1…) OR ~/.config/sops/age keys
+#
+# USAGE
+#   ADMIN_EMAIL='admin@example.com' ADMIN_PASSWORD='<plaintext>' \
+#     infra/secrets/reconcile-super-user.sh prod
+#
+#   # dry-run: show what would change, write nothing
+#   DRY_RUN=1 ADMIN_EMAIL=... ADMIN_PASSWORD=... infra/secrets/reconcile-super-user.sh prod
+set -euo pipefail
+
+ENV="${1:?usage: reconcile-super-user.sh <env>   (int|test|acc|prod)}"
+: "${ADMIN_EMAIL:?set ADMIN_EMAIL to the canonical admin login email (= LOGIN_EMAIL secret)}"
+: "${ADMIN_PASSWORD:?set ADMIN_PASSWORD to the canonical admin login plaintext (= LOGIN_PASSWORD secret)}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FILE="$REPO_ROOT/infra/secrets/$ENV/settings.sops.json"
+[ -f "$FILE" ] || { echo "::error::$FILE not found"; exit 1; }
+command -v sops >/dev/null    || { echo "::error::sops not on PATH"; exit 1; }
+command -v openssl >/dev/null || { echo "::error::openssl not on PATH"; exit 1; }
+
+# hashPassword() == base64(sha256(plaintext)) — see api/helpers.lua
+HASH="$(printf '%s' "$ADMIN_PASSWORD" | openssl dgst -sha256 -binary | base64)"
+
+# Read current values from the decrypted document (no plaintext printed).
+CUR_EMAIL="$(sops --decrypt --extract '["super_user"]["email"]' "$FILE" 2>/dev/null || echo '<unset>')"
+CUR_HASH="$(sops --decrypt --extract '["super_user"]["password"]' "$FILE" 2>/dev/null || echo '<unset>')"
+
+email_ok=false; pass_ok=false
+[ "$CUR_EMAIL" = "$ADMIN_EMAIL" ] && email_ok=true
+[ "$CUR_HASH"  = "$HASH" ]        && pass_ok=true
+
+echo "env=$ENV file=$FILE"
+echo "  super_user.email    : $([ "$email_ok" = true ] && echo 'MATCH' || echo "MISMATCH (deployed='$CUR_EMAIL' expected='$ADMIN_EMAIL')")"
+echo "  super_user.password : $([ "$pass_ok"  = true ] && echo 'MATCH' || echo 'MISMATCH (hash differs from base64(sha256(ADMIN_PASSWORD)))')"
+
+if [ "$email_ok" = true ] && [ "$pass_ok" = true ]; then
+  echo "Already reconciled — nothing to do.  If prod still 401s, redeploy the env so the file reaches /opt/nginx/data/settings.json."
+  exit 0
+fi
+
+if [ "${DRY_RUN:-0}" = "1" ]; then
+  echo "DRY_RUN=1 — would update super_user.email and super_user.password; writing nothing."
+  exit 0
+fi
+
+sops --set "[\"super_user\"][\"email\"] \"$ADMIN_EMAIL\"" "$FILE"
+sops --set "[\"super_user\"][\"password\"] \"$HASH\"" "$FILE"
+echo "Updated $FILE (re-encrypted in place)."
+echo
+echo "Next steps:"
+echo "  1. git add $FILE && git commit -m 'fix(secrets): reconcile $ENV super_user with canonical admin login'"
+echo "  2. Redeploy $ENV so it lands on the host as /opt/nginx/data/settings.json"
+echo "     (delivery/promotion pipeline with secrets_mode=sops, or DEPLOY_MODE=servers)."
+echo "  3. Ensure the LOGIN_EMAIL / LOGIN_PASSWORD repo secrets equal ADMIN_EMAIL / ADMIN_PASSWORD"
+echo "     (gh secret set LOGIN_EMAIL --repo bwalia/wslproxy ; gh secret set LOGIN_PASSWORD ...)."


### PR DESCRIPTION
## Why
The hourly **WSL Proxy Admin UI Login Tests** workflow has been red since ~2026-06-29 11:45Z (last green run #527). Root cause is **not** a code change in that window (those commits only touched delivery/promotion pipelines) — the workflow is a scheduled smoke test against **live prod**, and prod's admin credentials drifted.

The **2026-06-29 SOPS/age secrets migration** (`af5e9fd8`, `c505cbf3`, `b9f0cc90`) re-wrote each env's `settings.json`. `api/api.lua` login compares the stored `super_user.password` (a `base64(sha256(plaintext))` hash) against `hashPassword(typed password)`; the deployed hash no longer matches the canonical `LOGIN_EMAIL`/`LOGIN_PASSWORD` the tests use, so every valid-credential login returns **401**. Both prod URLs fail because they share the backend. The failure surfaced only as a cryptic `Parse test results` step and a Slack alert wrongly claiming the UI was down.

## What this PR does
- **`ci(e2e)` preflight** — POST the exact test creds to `/api/user/login` before the browser tests and classify the result (200 → proceed, 401/403 → explicit *credential mismatch*, 000 → unreachable, other → backend broken). Turns an opaque failure into an actionable one.
- **`infra/secrets/reconcile-super-user.sh`** — idempotent helper (with `DRY_RUN`) that recomputes `base64(sha256(ADMIN_PASSWORD))` and writes the email+hash back into `infra/secrets/<env>/settings.sops.json`, re-encrypting in place, so a commit + redeploy realigns the deployed `super_user` with the canonical login. **This is the green-maker** (must be run where the age key lives, then prod redeployed).
- **Schedule** — admin login smoke test moved from hourly (`0 * * * *`) to **thrice daily** (`0 0,8,16 * * *`, 00:00/08:00/16:00 UTC).

## To actually go green (operator, has age key + plaintext)
```
ADMIN_EMAIL='<prod admin email>' ADMIN_PASSWORD='<prod admin password>' \
  infra/secrets/reconcile-super-user.sh prod
# commit the updated settings.sops.json, redeploy prod (secrets_mode=sops),
# and ensure LOGIN_EMAIL / LOGIN_PASSWORD repo secrets match.
```

> Note: the new `schedule` cadence only takes effect once merged to the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)