### PR TITLE
fix(dashboard): 500 on /swagger refresh — null-body-status Response

### DIFF
--- a/openresty-admin-next/src/app/swagger/[[...path]]/route.ts
+++ b/openresty-admin-next/src/app/swagger/[[...path]]/route.ts
@@ -43,6 +43,21 @@ async function handler(
       .includes("text/html");
   if (!isEntryHtml) return upstreamResponse;
 
+  // Defence-in-depth: even for the entry HTML path, don't try to
+  // rewrite null-body responses.  `proxyToUpstream` already returns
+  // these with a null body, but if the upstream ever preserves
+  // `content-type: text/html` on a 304/205 (nginx does), the
+  // `new Response(rewritten, { status: 304 })` at the bottom of this
+  // function would throw the same TypeError as the proxy did before
+  // its fix.
+  if (
+    upstreamResponse.status === 204 ||
+    upstreamResponse.status === 205 ||
+    upstreamResponse.status === 304
+  ) {
+    return upstreamResponse;
+  }
+
   const html = await upstreamResponse.text();
   // If the upstream ever starts emitting its own <base> tag, leave it
   // alone — avoids accidentally adding a conflicting second tag.

--- a/openresty-admin-next/src/lib/api/proxy-upstream.ts
+++ b/openresty-admin-next/src/lib/api/proxy-upstream.ts
@@ -114,7 +114,25 @@ export async function proxyToUpstream(
       : [];
   for (const cookie of setCookies) respHeaders.append("set-cookie", cookie);
 
-  const respBody = await upstream.arrayBuffer();
+  // 204 No Content and 304 Not Modified are "null-body statuses" per
+  // the Fetch spec — `new Response(body, { status: 304 })` throws
+  // `TypeError: Response constructor: Invalid response status code
+  // 304`, even if the body is an empty ArrayBuffer.  When the upstream
+  // (loopback openresty on the admin port) answers a conditional GET
+  // with 304 — trivially reproducible by hitting /swagger, cacheing
+  // the ETag, then refreshing — this line used to crash with an
+  // unhandled exception and Next.js surfaced it as HTTP 500.
+  //
+  // Repro before this fix (from journal on prod 187.124.112.155):
+  //   TypeError: Response constructor: Invalid response status code 304
+  //     at lJ (src_lib_api_proxy-upstream_ts_46e1c0ba._.js:38:2235)
+  //     at async m (server/app/swagger/[[...path]]/route.ts)
+  //
+  // Fix: pass `null` as the body when the status forbids one; the
+  // response's status + headers still forward verbatim.
+  const isNullBodyStatus =
+    upstream.status === 204 || upstream.status === 304;
+  const respBody = isNullBodyStatus ? null : await upstream.arrayBuffer();
   return new Response(respBody, {
     status: upstream.status,
     statusText: upstream.statusText,


### PR DESCRIPTION
## Summary

`/swagger` returned HTTP 500 whenever the browser sent a conditional GET (`If-None-Match`) and the upstream openresty replied with `304 Not Modified`. Reproducible in two clicks: load `/swagger`, refresh 2–3 times.

## Root cause — a Fetch spec footgun, in two files

Per the [Fetch spec](https://fetch.spec.whatwg.org/#null-body-status), statuses 101 / 204 / 205 / 304 are **null-body statuses** — `new Response(body, { status: 304 })` throws even if `body` is an empty ArrayBuffer or empty string:

```
TypeError: Response constructor: Invalid response status code 304
```

Both files that build Response objects for `/swagger` traffic missed this:

### 1. `proxy-upstream.ts:118` (the real crash)

```ts
const respBody = await upstream.arrayBuffer();
return new Response(respBody, { status: upstream.status, ... });   // ← 304 throws
```

The prod stack trace confirms this is where the request dies:
```
TypeError: Response constructor: Invalid response status code 304
  at lJ (chunks/src_lib_api_proxy-upstream_ts_46e1c0ba._.js:38:2235)
  at async m (server/app/swagger/[[...path]]/route.ts)
```

### 2. `swagger/[[...path]]/route.ts:63-67` (never reached until (1) is fixed)

```ts
return new Response(rewritten, { status: upstreamResponse.status, ... });   // ← same shape
```

Only reachable when `proxyToUpstream` returns a 304 with `content-type: text/html` (nginx does preserve this). Fixed too as defence-in-depth.

## Fix

Symmetric one-liner in both places: check the status *before* touching the body, pass `null` for null-body statuses.

```ts
const isNullBodyStatus = upstream.status === 204 || upstream.status === 304;
const respBody = isNullBodyStatus ? null : await upstream.arrayBuffer();
return new Response(respBody, { status: upstream.status, ... });
```

Status + headers still forward verbatim, so caching still works.

## Verified on prod 187.124.112.155 (before this commit)

Pre-fix (from live journal):
```
Jul 02 07:45:12 wslproxy-nextjs: ⨯ TypeError: Response constructor: Invalid response status code 304
    at lJ (chunks/src_lib_api_proxy-upstream_ts_46e1c0ba._.js:38:2235)
```

Post-fix (compiled chunks patched in-place, service restarted):
```
$ curl -H 'If-None-Match: "6a429385-40d"' http://127.0.0.1:3099/swagger
HTTP/1.1 304 Not Modified                    ← was 500

# 5 rapid public refreshes:
attempt 1: HTTP 304
attempt 2: HTTP 304
attempt 3: HTTP 304
attempt 4: HTTP 304
attempt 5: HTTP 304
journal — no TypeErrors
```

Confirmed working in the browser by @bwalia.

## Why a TS-source PR is still needed even after the prod hotfix

The direct-on-prod patch is on the compiled minified chunks in `.next/`:
- `.next/server/chunks/src_lib_api_proxy-upstream_ts_46e1c0ba._.js.bak.20260702-074845`
- `.next/server/chunks/[root-of-the-server]__ae1d9705._.js.bak.20260702-074049`

The next `npm run build` overwrites those. This PR persists the fix at the source, so future deploys don't regress.

## Test plan

- [x] Reproduce on prod: 5 refreshes → 5 × 304, no TypeError
- [x] Browser-tested by @bwalia on `https://prod-our.wslproxy.com/swagger`
- [ ] After merge: next deploy rebuilds Next.js; verify the chunks still work
- [ ] Consider adding a Playwright test that hits `/swagger` twice with an ETag round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)