### PR TITLE
fix(build): resolve dashboard version from git tag (fallback: system/app.json)

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -148,6 +148,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.deploy_branch }}
+          # Need tags so `git describe --tags --abbrev=0` resolves the
+          # release version at build time.  `fetch-depth: 0` pulls the
+          # full history — required because a shallow clone (the default
+          # depth 1) doesn't include ANY tag refs even with
+          # `fetch-tags: true`.  Cost is small (few MB extra) and this
+          # is the reusable workflow that runs once per deploy.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install Ansible
         run: |
@@ -178,10 +186,52 @@ jobs:
           fi
           echo "Node.js version: $(node --version)"
 
-          # Read version info from system/app.json
-          APP_VERSION=$(python3 -c "import json; print(json.load(open('system/app.json'))['version']['version'])" 2>/dev/null || echo "1.0.0")
-          APP_BUILD=$(python3 -c "import json; print(json.load(open('system/app.json'))['version']['build'])" 2>/dev/null || echo "unknown")
+          # Resolve the release version.  Priority:
+          #   1. `git describe --tags --abbrev=0` — the most recent
+          #      annotated OR lightweight tag reachable from HEAD.
+          #      This is the source of truth for a released build.
+          #   2. `system/app.json:version.version` — fallback for
+          #      untagged branches, forks, and any repo state where a
+          #      tag was never created (or the checkout is somehow
+          #      missing them).
+          #   3. `1.0.0` — hard fallback if BOTH sources fail (a bare
+          #      repo with no tags AND no app.json).  Should never
+          #      trigger in practice; kept so the build can't error
+          #      out on a missing version.
+          #
+          # Historical bug this fixes: on 2026-07-02 int deployed a
+          # 1.0.13-tagged build but showed 1.0.10 in the dashboard
+          # footer because someone bumped the tag without touching
+          # system/app.json.  Git tags are now authoritative.
+          APP_VERSION="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -n "$APP_VERSION" ]; then
+              echo "  version source: git tag ($APP_VERSION)"
+          else
+              APP_VERSION=$(python3 -c "import json; print(json.load(open('system/app.json'))['version']['version'])" 2>/dev/null || echo "")
+              if [ -n "$APP_VERSION" ]; then
+                  echo "  version source: system/app.json ($APP_VERSION) — no git tag reachable from HEAD"
+              else
+                  APP_VERSION="1.0.0"
+                  echo "  version source: default 1.0.0 — no git tag AND no system/app.json"
+              fi
+          fi
+
+          # Build number: keep sourcing from app.json for continuity
+          # with existing dashboards.  If it's missing, use the commit
+          # SHA so operators always have SOMETHING to correlate a
+          # deploy against a build.
+          APP_BUILD=$(python3 -c "import json; print(json.load(open('system/app.json'))['version']['build'])" 2>/dev/null || echo "${GITHUB_SHA:-unknown}")
           DEPLOY_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          # Export the resolved version so the Ansible-playbook step
+          # (a separate shell) can pass it as `wslproxy_version=…` in
+          # --extra-vars.  Without this, Ansible falls back to its own
+          # defaults/main.yml lookup of system/app.json — same bug this
+          # step just fixed.
+          {
+            echo "WSLPROXY_VERSION=${APP_VERSION}"
+            echo "WSLPROXY_BUILD=${APP_BUILD}"
+          } >> "$GITHUB_ENV"
 
           cd openresty-admin-next
 
@@ -634,7 +684,7 @@ jobs:
             -l ${{ inputs.host_ip }} \
             $CONN_FLAGS \
             $TAGS_FLAG \
-            --extra-vars "nginx_user_password=THISCOMESFROMSECRETS target_env=${{ inputs.env_name }} local_settings_file_path=${{ env.settings_path }} local_env_file_path=${{ env.env_path }} wslproxy_build_number=${{ github.run_id }} wslproxy_git_sha=${{ github.sha }} wslproxy_git_repo=${{ github.repository }} wslproxy_deployment_time=$(date -u +%Y-%m-%dT%H:%M:%SZ) $SECRETS_FLAG"
+            --extra-vars "nginx_user_password=THISCOMESFROMSECRETS target_env=${{ inputs.env_name }} local_settings_file_path=${{ env.settings_path }} local_env_file_path=${{ env.env_path }} wslproxy_version=${WSLPROXY_VERSION} wslproxy_build_number=${{ github.run_id }} wslproxy_git_sha=${{ github.sha }} wslproxy_git_repo=${{ github.repository }} wslproxy_deployment_time=$(date -u +%Y-%m-%dT%H:%M:%SZ) $SECRETS_FLAG"
 
       # ── Deploy server/rule configs ──
       - name: Deploy server configs and rules

--- a/infra/ansible/roles/wslproxy/defaults/main.yml
+++ b/infra/ansible/roles/wslproxy/defaults/main.yml
@@ -13,10 +13,34 @@ nginx_nextjs_dashboard_port: 8099
 nginx_nextjs_node_port: 3099
 
 # Dashboard version and build information
-# These values are used by the React dashboard footer
-# Source of truth: system/app.json
-# Note: Using Ansible's file lookup with from_json filter for clean JSON parsing
-wslproxy_version: "{{ (lookup('file', playbook_dir + '/../../system/app.json') | from_json).version.version | default('1.0.0') }}"
+# These values are used by the React dashboard footer.
+#
+# Source of truth, in priority order:
+#   1. `--extra-vars wslproxy_version=…` from the caller.  The CI
+#      workflow (deploy-environment.yml) resolves the version from
+#      `git describe --tags --abbrev=0` and passes it via extra-vars,
+#      so any CI-driven deploy uses the git tag NOT the file value.
+#   2. `git describe --tags --abbrev=0` inside this repo.  Used when
+#      ansible-playbook is invoked locally by a developer without an
+#      explicit override.  `|| echo` ensures a non-zero exit (no tags
+#      reachable, e.g. a shallow clone) yields empty rather than
+#      failing the whole play.
+#   3. `system/app.json:version.version` — legacy fallback for repos
+#      that pre-date tagging.
+#   4. `1.0.0` — hard fallback so the play can't error on a missing
+#      value.
+#
+# Historical bug this fixes: on 2026-07-02 int deployed a 1.0.13
+# tagged build but showed 1.0.10 in the dashboard footer because
+# app.json wasn't bumped alongside the tag.  Git tags are now
+# authoritative.
+wslproxy_version: >-
+  {{ (lookup('pipe',
+             'git -C ' + playbook_dir + '/../../ describe --tags --abbrev=0 2>/dev/null || echo')
+       | trim)
+     or (lookup('file', playbook_dir + '/../../system/app.json')
+         | from_json).version.version
+     | default('1.0.0') }}
 wslproxy_build_number: "{{ (lookup('file', playbook_dir + '/../../system/app.json') | from_json).version.build | default('unknown') }}"
 wslproxy_deployment_time: "{{ ansible_date_time.iso8601 }}"
 


### PR DESCRIPTION
## Summary

Fixes the "footer shows 1.0.10 but we deployed 1.0.13" bug on int (2026-07-02).

## Root cause

Two sources of truth for the version, and they disagreed:

1. Someone created git tag `1.0.13` for the release.
2. `system/app.json` was NOT bumped — still `{"version": {"version": "1.0.10"}}`.
3. The build workflow at [.github/workflows/deploy-environment.yml:182](.github/workflows/deploy-environment.yml#L182) read `system/app.json`:
   ```bash
   APP_VERSION=$(python3 -c "... open('system/app.json') ...")
   ```
   → `APP_VERSION=1.0.10`.
4. Baked into the Next.js bundle via `.env.production`:
   ```
   NEXT_PUBLIC_APP_VERSION=1.0.10
   ```
5. Next.js compiles `NEXT_PUBLIC_*` at **build time**, not runtime → the footer permanently displayed `1.0.10` even though the git ref carried the `1.0.13` tag.

## Fix

Git tag becomes the primary source. Three-layer resolution chain, applied in both the CI workflow and the Ansible defaults so **both paths agree**:

| Priority | Source | Why |
|---|---|---|
| 1 | `git describe --tags --abbrev=0` | Authoritative — the release tag |
| 2 | `system/app.json:version.version` | Legacy fallback for untagged branches / forks |
| 3 | `"1.0.0"` | Hard fallback so builds never error out |

### Files touched

**[.github/workflows/deploy-environment.yml](.github/workflows/deploy-environment.yml)** — CI path:
- Checkout step gets `fetch-depth: 0` + `fetch-tags: true` (a shallow clone has NO tag refs even with fetch-tags on)
- Version-read step tries `git describe` first
- Resolved value exported to `$GITHUB_ENV` as `WSLPROXY_VERSION` and passed to `ansible-playbook --extra-vars wslproxy_version=…`, so the systemd unit env AND the react-admin build (which read `wslproxy_version` via Ansible) both use the tag value

**[infra/ansible/roles/wslproxy/defaults/main.yml](infra/ansible/roles/wslproxy/defaults/main.yml)** — local Ansible path:
- Same three-layer chain via `lookup('pipe', 'git … describe …')` → `lookup('file', 'system/app.json')` → `default('1.0.0')`
- Only fires when a developer runs `ansible-playbook` locally without an explicit override. In CI the extra-vars override wins.

## Verified locally on the current repo state

```
$ git describe --tags --abbrev=0
1.0.13                                ← the correct release version

$ jq -r .version.version system/app.json
1.0.10                                ← stale, now demoted to fallback
```

After merge, the next deploy shows `1.0.13` in the footer. Bump the tag and the next deploy shows the new tag automatically — no more `app.json` bump ritual needed.

## Backwards compatibility

- Callers passing `--extra-vars wslproxy_version=X` still win — override semantics unchanged.
- Deploys from a branch with NO tags reachable from HEAD (fork, feature branch cut before the first tag) still work — they get `app.json`'s value, same as today.

## Test plan

- [x] YAML validates both files
- [x] Simulate scenario 1 (repo has tags): `git describe` returns tag ✓
- [x] Simulate scenario 2 (no tags): falls through to `app.json` ✓
- [ ] After merge: watch int/test deploy pipeline — footer should read the current git tag (1.0.13 today)
- [ ] Create a new tag `1.0.14` and push → next deploy footer reads `1.0.14`

🤖 Generated with [Claude Code](https://claude.com/claude-code)