### PR TITLE
ci: make self-hosted deploy runner OS-agnostic (Linux or macOS)

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -125,7 +125,10 @@ on:
 jobs:
   deploy:
     name: "Deploy ${{ inputs.env_label }}"
-    runs-on: [self-hosted, Linux, "${{ inputs.env_name }}"]
+    # OS-agnostic: match any self-hosted runner carrying the env label,
+    # whether it is Linux or macOS. Hardcoding `Linux` here left the `acc`
+    # job queued forever because the only `acc` runner is macOS.
+    runs-on: [self-hosted, "${{ inputs.env_name }}"]
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Problem

The `acc / Deploy Acceptance` job (run [28598607261](https://github.com/bwalia/wslproxy/actions/runs/28598607261)) was stuck **queued** with no matching runner.

The reusable `deploy-environment.yml` requires:

```yaml
runs-on: [self-hosted, Linux, "${{ inputs.env_name }}"]
```

But the only runner carrying the `acc` label is **macOS**:

| Runner | OS | Labels |
|--------|-----|--------|
| BalindeacStudio | macOS | self-hosted, prod, **macOS**, ARM64, **acc** |
| debian001 | Linux | self-hosted, Linux, X64, test |
| debworker00-int | Linux | self-hosted, Linux, X64, int |
| srv1467484 | Linux | self-hosted, Linux, X64, pop0 |

The hardcoded `Linux` label never matches the macOS `acc` runner, so the job queues forever.

## Fix

Drop the hardcoded `Linux` label so the job matches any self-hosted runner with the env label, regardless of OS. Runner selection is now driven purely by the env label (`acc`/`int`/`test`/`pop0`), which already uniquely identifies the target host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)