### PR TITLE
ci: support macOS runners in tool-install steps (brew)

### DIFF
--- a/.github/workflows/backup-wslproxy-data.yml
+++ b/.github/workflows/backup-wslproxy-data.yml
@@ -63,12 +63,14 @@ jobs:
           echo "Checking for required tools..."
           if ! command -v jq &> /dev/null; then
             echo "jq is required but not installed. Installing..."
-            if command -v zypper &> /dev/null; then
+            if command -v brew &> /dev/null; then
+              brew install jq
+            elif command -v zypper &> /dev/null; then
               sudo zypper install -y jq
             elif command -v apt-get &> /dev/null; then
               sudo apt-get update && sudo apt-get install -y jq
             else
-              echo "::error::No supported package manager found"; exit 1
+              echo "::error::No supported package manager found (brew, zypper or apt-get)"; exit 1
             fi
           fi
           command -v curl >/dev/null 2>&1 || { echo "curl is required but not installed."; exit 1; }

--- a/.github/workflows/deploy-diytaxreturn-configs.yml
+++ b/.github/workflows/deploy-diytaxreturn-configs.yml
@@ -121,13 +121,17 @@ jobs:
 
       - name: Install Ansible
         run: |
-          if command -v zypper &> /dev/null; then
+          if command -v ansible &> /dev/null; then
+            echo "Ansible already installed: $(ansible --version | head -1)"
+          elif command -v brew &> /dev/null; then
+            brew install ansible
+          elif command -v zypper &> /dev/null; then
             sudo zypper install -y ansible
           elif command -v apt-get &> /dev/null; then
             sudo apt-get update
             sudo apt-get install -y ansible
           else
-            echo "::error::No supported package manager found (zypper or apt-get)"
+            echo "::error::No supported package manager found (brew, zypper or apt-get)"
             exit 1
           fi
 

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -125,7 +125,10 @@ on:
 jobs:
   deploy:
     name: "Deploy ${{ inputs.env_label }}"
-    runs-on: [self-hosted, Linux, "${{ inputs.env_name }}"]
+    # OS-agnostic: match any self-hosted runner carrying the env label,
+    # whether it is Linux or macOS. Hardcoding `Linux` here left the `acc`
+    # job queued forever because the only `acc` runner is macOS.
+    runs-on: [self-hosted, "${{ inputs.env_name }}"]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -162,12 +162,16 @@ jobs:
 
       - name: Install Ansible
         run: |
-          if command -v zypper &> /dev/null; then
+          if command -v ansible &> /dev/null; then
+            echo "Ansible already installed: $(ansible --version | head -1)"
+          elif command -v brew &> /dev/null; then
+            brew install ansible
+          elif command -v zypper &> /dev/null; then
             sudo zypper install -y ansible
           elif command -v apt-get &> /dev/null; then
             sudo apt-get install -y ansible
           else
-            echo "::error::No supported package manager found"
+            echo "::error::No supported package manager found (brew, zypper or apt-get)"
             exit 1
           fi
 

--- a/.github/workflows/deploy-wslproxy-virtual-servers.yml
+++ b/.github/workflows/deploy-wslproxy-virtual-servers.yml
@@ -150,13 +150,17 @@ jobs:
 
       - name: Install Ansible
         run: |
-          if command -v zypper &> /dev/null; then
+          if command -v ansible &> /dev/null; then
+            echo "Ansible already installed: $(ansible --version | head -1)"
+          elif command -v brew &> /dev/null; then
+            brew install ansible
+          elif command -v zypper &> /dev/null; then
             sudo zypper install -y ansible
           elif command -v apt-get &> /dev/null; then
             sudo apt-get update
             sudo apt-get install -y ansible
           else
-            echo "::error::No supported package manager found (zypper or apt-get)"
+            echo "::error::No supported package manager found (brew, zypper or apt-get)"
             exit 1
           fi
 

--- a/.github/workflows/sync-configs-to-environments.yml
+++ b/.github/workflows/sync-configs-to-environments.yml
@@ -47,12 +47,16 @@ jobs:
 
       - name: Install Ansible and AWS CLI
         run: |
-          if command -v zypper &> /dev/null; then
+          if command -v ansible &> /dev/null; then
+            echo "Ansible already installed: $(ansible --version | head -1)"
+          elif command -v brew &> /dev/null; then
+            brew install ansible
+          elif command -v zypper &> /dev/null; then
             sudo zypper install -y ansible
           elif command -v apt-get &> /dev/null; then
             sudo apt-get update && sudo apt-get install -y ansible
           else
-            echo "::error::No supported package manager found"
+            echo "::error::No supported package manager found (brew, zypper or apt-get)"
             exit 1
           fi
           # Install AWS CLI if not present
@@ -173,12 +177,16 @@ jobs:
 
       - name: Install Ansible and AWS CLI
         run: |
-          if command -v zypper &> /dev/null; then
+          if command -v ansible &> /dev/null; then
+            echo "Ansible already installed: $(ansible --version | head -1)"
+          elif command -v brew &> /dev/null; then
+            brew install ansible
+          elif command -v zypper &> /dev/null; then
             sudo zypper install -y ansible
           elif command -v apt-get &> /dev/null; then
             sudo apt-get update && sudo apt-get install -y ansible
           else
-            echo "::error::No supported package manager found"
+            echo "::error::No supported package manager found (brew, zypper or apt-get)"
             exit 1
           fi
           # Install AWS CLI if not present


### PR DESCRIPTION
## Problem

The self-hosted `acc` runner (`BalindeacStudio`) is **macOS**, which has neither `zypper` nor `apt-get`. Every `Install Ansible` step therefore fell through to:

```
::error::No supported package manager found
```

and failed. Confirmed live: run [28599045453](https://github.com/bwalia/wslproxy/actions/runs/28599045453) failed at the **Install Ansible** step on the macOS runner.

## Fix

Add a `brew` branch to the tool-install steps, plus an early short-circuit if the tool is already installed:

```bash
if command -v ansible &> /dev/null; then
  echo "Ansible already installed: $(ansible --version | head -1)"
elif command -v brew &> /dev/null; then
  brew install ansible
elif command -v zypper &> /dev/null; then
  ...
```

Applied to the ansible install in:
- `deploy-environment.yml` (reusable — used by the stuck `acc` deploy)
- `sync-configs-to-environments.yml` (both jobs)
- `deploy-diytaxreturn-configs.yml`
- `deploy-wslproxy-virtual-servers.yml` (self-hosted job)

And the `jq` install in `backup-wslproxy-data.yml` (`runs-on: self-hosted`, so it can also land on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)