### PR TITLE
ci: portable sed for .env.production (macOS/BSD)

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -254,8 +254,13 @@ jobs:
           NEXT_PUBLIC_DEPLOYMENT_TIME=${DEPLOY_TIME}
           NEXT_PUBLIC_TARGET_PLATFORM=BARE_METAL
           ENVEOF
-          # Strip leading whitespace from env file
-          sed -i 's/^[[:space:]]*//' .env.production
+          # Strip leading whitespace from env file.
+          # Use a temp file + mv rather than `sed -i` — BSD/macOS sed
+          # requires an explicit backup-suffix arg for -i (`sed -i ''`),
+          # so bare `sed -i` fails on the macOS runner. This form is
+          # portable across GNU (Linux) and BSD (macOS) sed.
+          sed 's/^[[:space:]]*//' .env.production > .env.production.tmp \
+            && mv .env.production.tmp .env.production
 
           echo "Generated .env.production:"
           cat .env.production


### PR DESCRIPTION
## Problem

After the ansible-install fix, the `acc` deploy on the macOS runner progressed to the **Build Next.js admin dashboard** step and failed:

```
sed: 1: ".env.production": invalid command code .
##[error]Process completed with exit code 1.
```

BSD/macOS `sed -i` requires an explicit backup-suffix argument (`sed -i ''`); bare `sed -i` (GNU form) is invalid on macOS.

## Fix

Replace `sed -i 's/^[[:space:]]*//' .env.production` with a temp-file + `mv` form that works identically on GNU (Linux) and BSD (macOS) sed. Only `sed -i` occurrence in the workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)