### PR TITLE
ci: provision SSH deploy key from secrets.SSH_PRIVATE_KEY

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -121,6 +121,12 @@ on:
       # See infra/secrets/README.md for how to generate + rotate it.
       SOPS_AGE_KEY:
         required: false
+      # SSH_PRIVATE_KEY: private key used to reach the target host in
+      # connection_mode=ssh_key. Optional — if empty, the runner is
+      # expected to already have a usable key at ~/.ssh/id_rsa (the
+      # historical behaviour for pre-provisioned runners).
+      SSH_PRIVATE_KEY:
+        required: false
 
 jobs:
   deploy:
@@ -589,6 +595,8 @@ jobs:
       # ── SSH setup (remote connections only) ──
       - name: Setup SSH and test connectivity
         if: inputs.connection_mode != 'local'
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
@@ -596,8 +604,14 @@ jobs:
 
           SSH_OPTS="-o BatchMode=yes -o ConnectTimeout=10"
           if [[ "${{ inputs.connection_mode }}" == "ssh_key" ]]; then
+            # If a key was passed via secret, materialise it. Otherwise
+            # fall back to a key already provisioned on the runner.
+            if [[ -n "${SSH_PRIVATE_KEY:-}" ]]; then
+              printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+              chmod 600 ~/.ssh/id_rsa
+            fi
             if [[ ! -f ~/.ssh/id_rsa ]]; then
-              echo "::error::SSH key not found at ~/.ssh/id_rsa"
+              echo "::error::SSH key not found at ~/.ssh/id_rsa and secrets.SSH_PRIVATE_KEY is empty. Set it with: gh secret set SSH_PRIVATE_KEY --repo bwalia/wslproxy < /path/to/deploy-key"
               exit 1
             fi
             SSH_OPTS="$SSH_OPTS -i ~/.ssh/id_rsa"

--- a/.github/workflows/deploy-single-environment.yml
+++ b/.github/workflows/deploy-single-environment.yml
@@ -84,6 +84,7 @@ jobs:
       deploy_mode: ${{ inputs.DEPLOY_MODE }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
       # Kept so an emergency revert to secrets_mode: github_secret needs no
       # secret re-add (mirrors the delivery pipeline's int stage).
@@ -114,6 +115,7 @@ jobs:
       deploy_mode: ${{ inputs.DEPLOY_MODE }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   # ──────────────────────────────────────────────────────
   # Acceptance — acc / "pop0" (187.124.112.155). vault-first with SOPS fallback
@@ -138,6 +140,7 @@ jobs:
       deploy_mode: ${{ inputs.DEPLOY_MODE }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
       SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
@@ -165,6 +168,7 @@ jobs:
       deploy_mode: ${{ inputs.DEPLOY_MODE }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
       SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}

--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -265,6 +265,7 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
       # Kept so emergency rollback to secrets_mode: github_secret is a
       # one-line revert — no secrets need to be re-added.
@@ -393,6 +394,7 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   # Stage 5 (acc / 187.77.179.206) was decommissioned.  Prod stages
   # below now depend directly on `deploy-test` so the pipeline still
@@ -433,6 +435,7 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       # Provide BOTH — the resolver picks Vault if VAULT_ADDR/VAULT_TOKEN
       # are set AND the settings path is populated; otherwise it uses
       # SOPS_AGE_KEY.  Deploy only fails if BOTH are unavailable.
@@ -469,6 +472,7 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   # ──────────────────────────────────────────────────────
   # Stage 5c: Deploy Prod pop1 (18.133.126.242) — AWS eu-west-2, ssh user admin
@@ -503,6 +507,7 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
       VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
       SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}

--- a/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
@@ -156,6 +156,7 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       SETTINGS_SECRET: ${{ secrets.DOT_WSLPROXY_SETTINGS_INT }}
       ENV_CREDS_SECRET: ${{ secrets.DOT_WSLPROXY_ENV_CREDS_INT }}
 
@@ -291,6 +292,7 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   # ──────────────────────────────────────────────────────
   # Stage 5: Nightly Summary (always runs)

--- a/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
@@ -199,6 +199,7 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
       # Kept so emergency rollback to secrets_mode: github_secret works
       # without another commit.
@@ -324,6 +325,7 @@ jobs:
       deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'code' }}
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   # ──────────────────────────────────────────────────────
   # Summary


### PR DESCRIPTION
## Problem

In `connection_mode=ssh_key`, the `Setup SSH and test connectivity` step required a private key already present at `~/.ssh/id_rsa` on the runner. The macOS `acc`/`prod` runner (`BalindeacStudio`) has none, so the step failed:

```
##[error]SSH key not found at ~/.ssh/id_rsa
```

## Fix

Add an optional `secrets.SSH_PRIVATE_KEY` to the reusable `deploy-environment.yml`:

- When set → the workflow writes it to `~/.ssh/id_rsa` (chmod 600) before connecting.
- When empty → falls back to a pre-provisioned key, so **runners that already have a key are unaffected**.

Pass-through wired through all callers: `deploy-single-environment`, `deploy-wslproxy-promotion-pipeline`, `deploy-wslproxy-delivery-pipeline`, `deploy-wslproxy-nightly-pipeline`. `SSH_PRIVATE_KEY` is `required: false`, so callers that don't pass it still validate.

## To activate

```bash
gh secret set SSH_PRIVATE_KEY --repo bwalia/wslproxy < /path/to/deploy-private-key
```

The key must authenticate as `root@187.124.112.155` (acc) / `root@18.133.126.242` (prod). The step already does `ssh-keyscan` for known_hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)