### PR TITLE
fix(ansible): guard authorized_key against None pubkey lookup

### DIFF
--- a/infra/ansible/roles/wslproxy/tasks/user_setup.yml
+++ b/infra/ansible/roles/wslproxy/tasks/user_setup.yml
@@ -97,8 +97,14 @@
 - name: Add bwalia public key to authorized_keys
   authorized_key:
     user: bwalia
-    key: "{{ lookup('file', '/home/bwalia/.ssh/id_rsa.pub', errors='ignore') | default('') }}"
+    key: "{{ lookup('file', '/home/bwalia/.ssh/id_rsa.pub', errors='ignore') | default('', true) }}"
     state: present
-  when: lookup('file', '/home/bwalia/.ssh/id_rsa.pub', errors='ignore') | default('') | length > 0
+  # `default('', true)` (not bare `default('')`) — when the pubkey file is
+  # absent the file lookup returns None, and Jinja's `default('')` only
+  # replaces *undefined*, not None, so `None | length` raised
+  # "object of type 'NoneType' has no len()". The `true` second arg makes
+  # the default apply to None/empty too. Seen on the macOS runner where
+  # /home/bwalia/.ssh/id_rsa.pub does not exist.
+  when: (lookup('file', '/home/bwalia/.ssh/id_rsa.pub', errors='ignore') | default('', true) | length) > 0
   ignore_errors: true
   tags: [always]


### PR DESCRIPTION
## Problem

In run [28644598803](https://github.com/bwalia/wslproxy/actions/runs/28644598803) the `Add bwalia public key to authorized_keys` task logged a fatal (caught by `ignore_errors`):

```
A 'when' expression failed: The filter plugin 'ansible.builtin.length' failed:
object of type 'NoneType' has no len()
```

`lookup('file', '/home/bwalia/.ssh/id_rsa.pub', errors='ignore')` returns **None** when the file is absent (the macOS runner's home is `/Users/...`, not `/home/bwalia`). Jinja's bare `default('')` only replaces *undefined* — not None — so `None | length` blew up.

## Fix

Use `default('', true)` in both the `key:` and the `when:`, so the default also applies to None/empty. Not the deploy blocker (task was `ignore_errors: true`), but it removes a fatal-error log line every run.

> Note: this does **not** unblock the acc deploy — that fails on a separate `env_profile` mismatch in the encrypted prod settings, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)