### PR TITLE
fix(secrets): correct prod settings.sops.json (env_profile int->prod)

### DIFF
--- a/infra/secrets/prod/settings.sops.json
+++ b/infra/secrets/prod/settings.sops.json
@@ -1,107 +1,108 @@
 {
-	"ai_endpoint": "ENC[AES256_GCM,data:XdqIgtB1HK4GiBfgu5HFnaVcidT4lBYcjZc=,iv:dikcUA/XkeIodQdtMaJMPgX29Mo7eY2fRbNNb5Z03tc=,tag:ISSCfwX6xoCRGaeh0pyPAQ==,type:str]",
-	"ai_model": "ENC[AES256_GCM,data:YjfNAUjhjaY=,iv:8qSdrkfH8HcR2f8VZ8J8LRDDVf9GHUYM7ITgGQR1FTc=,tag:MDXHufGCh8bRVjWpxLF+LA==,type:str]",
+	"ai_endpoint": "",
+	"ai_model": "ENC[AES256_GCM,data:ZbUR5udFdnw=,iv:sIwNXk2NFv+cmI+zb7q5TwepP+47qFWYBkVV2zP1kvE=,tag:G/21EJWZ7Ls/fLxfYpPGNA==,type:str]",
 	"captcha": {
-		"cookie_ttl": "ENC[AES256_GCM,data:vuDpew==,iv:b/vuNKO+PxtaV+uB9LbyfpMvNq6YgR52SI0GvGOVOMo=,tag:TWJV7cWE8Kzw98+ioIT9YA==,type:float]",
-		"provider": "ENC[AES256_GCM,data:wcC1UmR1MtSr,iv:+hv2AQv+7rOFTzmPkmStk6rhqzNU7ipAnQNSUml+1bg=,tag:GvUeVeXr2X1BOso7i2axVQ==,type:str]",
+		"cookie_ttl": "ENC[AES256_GCM,data:Gkc3nw==,iv:KNHtfbDbKaIEhLg63V8pHMBW/cRHfuhTpgD1GswfNJA=,tag:7W0BkRa48DKJzH2orRZ10w==,type:int]",
+		"provider": "ENC[AES256_GCM,data:H14z6Dj46vtZ,iv:CpV5IVNaRQDve/qKSgmmbz625MHwEdtZ8UhXBsu59IA=,tag:WTDxCu2wRZtje3KofBh31Q==,type:str]",
 		"secret_key": "",
 		"site_key": "",
-		"theme": "ENC[AES256_GCM,data:u3lJCA==,iv:DdHYLQfobDL8GYrW/JTrKh/Jl5ltkc6t8np8BAgp3Is=,tag:lSeNaNMH7IwW8vvp4uyj7w==,type:str]"
+		"theme": "ENC[AES256_GCM,data:VfeAtQ==,iv:hctT67glzlt13MPWY1gJiRh55Y9qdar2t8QA1ERgv60=,tag:N/jkJl0iaCdVkKUJoA/Hlg==,type:str]"
 	},
 	"consul": {
-		"dns_server_host": "ENC[AES256_GCM,data:Bgsl+s21GTDi,iv:odO9tErrplLd6n+CtwE63tCwUJ2BmuYzu0xdV5OXzmU=,tag:6mBOlydPVXpM0jOAtS8AIQ==,type:str]",
-		"dns_server_port": "ENC[AES256_GCM,data:3ehtCQ==,iv:D/7mTYye3wBkcPNuDTAGbrc2p+JpiPQbCUzJIJGnszE=,tag:Nzp3TkNpZkE1F9LUTi06kg==,type:float]"
+		"dns_server_host": "ENC[AES256_GCM,data:s0Bj7XtAcW+n,iv:gBaXcY/haxRAzi5tMkzaemwL30zjJ3NpF7prCTb6174=,tag:8j1sCJde35i382KW34sK9g==,type:str]",
+		"dns_server_port": "ENC[AES256_GCM,data:dB0zGw==,iv:bmnNus03AHt2wZf0Oh2Z8sh90W+NZ3c72Z/2kQNUSB8=,tag:2f+rrdkzFmRvRqkbW2Fbxw==,type:int]"
 	},
 	"dns": {
-		"auto_discover_zones": "ENC[AES256_GCM,data:Seaiig==,iv:A/eWuixTliHZhCRrDfrw2cIjfNX8tFpFCakc4GWSNmA=,tag:EOrriXsADlkubTED0UnP1A==,type:bool]",
-		"default_proxied": "ENC[AES256_GCM,data:jNJBhXk=,iv:+oWCnYLi3sGgLsDPlTXgfw4rHWCfTEuCdufR9IiyrUk=,tag:SBp36ATqFunz4H7fNDwLog==,type:bool]",
-		"default_ttl": "ENC[AES256_GCM,data:6Y3Q,iv:eO1EfDtDhkRbrRXRJc1K5cEyQiCQwEXW26vXy4hXmFY=,tag:HFv6WNmpPAzTfv4O4GBlDA==,type:float]",
-		"enabled": "ENC[AES256_GCM,data:jCUpiQ==,iv:2TNl5y0OrCd/t9aSck5LkAziAkZF5wRBNY0nqrc+H0g=,tag:KCiqOqSuBIxAwtksxbGDPw==,type:bool]",
+		"auto_discover_zones": "ENC[AES256_GCM,data:M7lPXg==,iv:pg/HL+OznmeVMthRqzlbL/7lkdPqdeEOjCZL0090eTI=,tag:xUD8eDmdhPtiqvAyqnmI9g==,type:bool]",
+		"default_proxied": "ENC[AES256_GCM,data:2f4tB30=,iv:MxY5IfAh/vUGOYlJOJSgr7tfcR+BKh1jH8OLWAzeZxM=,tag:jydJqcys4SLlWJq0tA/P2g==,type:bool]",
+		"default_ttl": "ENC[AES256_GCM,data:eb5y,iv:3PYKjCpjtqjMHuPBeonBkWAEssRpu59rnN8wkS53Fog=,tag:Wu3UMX+iZiACKeqEfoy6LA==,type:int]",
+		"enabled": "ENC[AES256_GCM,data:iCgjOA==,iv:Prsn3wrIPoXTopAWWhRLcs939gKInuLeskDKAWF40So=,tag:UbG2BA1e2nhZg2D5btNhkQ==,type:bool]",
 		"providers": [
 			{
-				"api_token": "ENC[AES256_GCM,data:in1CYTHN/UEJpTj8r7PkWG7/sRRDugP6rHhFspjO/++INLh/IpT7WLIQXCHq1zpkvTUQ+DM=,iv:L92sWai6vNKogk02ppeR3vPH3hBNWZLnUXK32W+wFIg=,tag:iypk9YNQvoP0neKBwdBsYg==,type:str]",
+				"api_token": "ENC[AES256_GCM,data:McpHVaJLyU/tHrvY65XMcGGH4EM48f4BM+8Y1ssnhz8LSiC+nhut8fNbA3BngUF4nH9c4O4=,iv:e0evQwIU0J/KpsQUGo9EhsBYGD7IDAMb/85JtBLJfoo=,tag:S8zlIUUJE0VO0575On+1VQ==,type:str]",
 				"managed_zones": [],
-				"name": "ENC[AES256_GCM,data:86RSYtL3fXVHVa8BWxgcBjgr,iv:wSty7/bdnTxV1KHjLAd/0z2zsM/xcrWNFur9yHr9Cu0=,tag:wTPn6KE6UuSVdhzZSAodyQ==,type:str]",
-				"type": "ENC[AES256_GCM,data:Wup627UbQ761Nw==,iv:E5aW5gfKqoPfFtBlQZwfD5YPzFrb7GEYs4Gki3OgXSE=,tag:mUv5kYsKQU5B0fkHue9xzA==,type:str]"
+				"name": "ENC[AES256_GCM,data:RvO19E6bt/9+56VC4W8QWinx,iv:leFNh+9IErYiBdKx3l2ZeFIO2xUmYmcDBvqgRvVne8U=,tag:q0lnZKWprOP+/GIM3n//BQ==,type:str]",
+				"type": "ENC[AES256_GCM,data:z4lN1YHndA94cQ==,iv:jwteIxDtYtjKbVTEPrOXTeN8yq7smBFgfSQbm9qaQXM=,tag:Hta1nqT+1sJkCpDnULqB0g==,type:str]"
 			}
 		]
 	},
 	"dns_resolver": {
 		"nameservers": {
-			"port": "ENC[AES256_GCM,data:8zE=,iv:0Jr1r37VGflP+1J8w0ndtVBRaCGVEinhmReabFvI6ZA=,tag:nqysoGbbXjQdoO+apPo6eQ==,type:str]",
-			"primary": "ENC[AES256_GCM,data:v8QQtGW/lg==,iv:QITdcCJ0xWr/ccwpO2oGqgSKk+As/6FK7EetkT6UhiE=,tag:aB8FY6ILwwPUL7NaqnzExA==,type:str]",
-			"secondary": "ENC[AES256_GCM,data:eSJh6tYcCg==,iv:2xSqnA4xfzQyHtsDGFY5X3tkIPoV3XZoBPMAsdMNlPs=,tag:ZG1j6oGdXwQzSbZv6YgH/w==,type:str]"
+			"port": "ENC[AES256_GCM,data:/CA=,iv:yPiVbnEMWkClOhegawDF6IVW6Cx9cPMtMP6tR1XQSnA=,tag:0KTK+gyQBN5zkyUNpggV0Q==,type:str]",
+			"primary": "ENC[AES256_GCM,data:7RxaoRSdrw==,iv:xBDNZhtqWo1eZ/5PPSfJaFrHxjNI4Rm39yi7EyjepOE=,tag:P8kAJDF32kazxctlYBdyWg==,type:str]",
+			"secondary": "ENC[AES256_GCM,data:IWORvrIliA==,iv:FrxDeuiXlYbN07wtcOEsScgrOU7Ie8wPn2R03+IDLoo=,tag:0zSsVg4PVGB9c5tEFCpIyw==,type:str]"
 		}
 	},
-	"env_profile": "ENC[AES256_GCM,data:bP+8,iv:alFL+VcdqjA7jvzkddFK7RgH/p/yT1+GrVK9KS3cRc4=,tag:bmNX0OVWQuUHg90NrtYyrA==,type:str]",
+	"env_profile": "ENC[AES256_GCM,data:B1VTfQ==,iv:v0dYXc+RI2nqAYrq68aG4dC7E3MWyw5pSagGxIlJfKg=,tag:2EBoe9hGUjs+AoIqQBGsDQ==,type:str]",
 	"env_vars": {
-		"API_PAGE_SIZE": "ENC[AES256_GCM,data:xhRbAw==,iv:jvFVnKkFZpA2aaElFWG+lrOUE1rR4jvNz714A3cJzE4=,tag:fdEWpwG+F3DNyKEUbKZCKQ==,type:float]",
-		"APP_NAME": "ENC[AES256_GCM,data:wVqKXRczc65B,iv:9jZI0apAu8sNBMFynhC8lbZNxHYG9PAOtVggmeOMUvc=,tag:8YtjR3ry0yBlTxSyc4Vb4g==,type:str]",
-		"FRONT_URL": "ENC[AES256_GCM,data:FPh4O05QegyxxYmonHxeEwmlObZ+TXxE,iv:sIgFZBUUdDOzpJWddKogusqGCFFhufydJDcnnzSoCfo=,tag:bRr6WBjoMBL+x1fMU4QGog==,type:str]",
-		"HOSTNAME": "ENC[AES256_GCM,data:AuvdsPyEEtu8ju/THXoNxw==,iv:5fu2GxDxrhdL9dSXn24fkOwyIFCRc/2IQaEMFlX6hOA=,tag:qEqWM6xvPsEmNMCFAOrN/w==,type:str]",
-		"JWT_SECURITY_PASSPHRASE": "ENC[AES256_GCM,data:yq/bwS7qebkqzx90C1EL0GjfJVCe7yRBML98emH86dZk1OTJr8oqeFUw6S4PszuNeA==,iv:0+17R/SBNUt5cbfUBue0zCiW8yNUu90x5KnxNqnQuj8=,tag:4KQ3chmy8X+GHaRnQQjWvg==,type:str]",
-		"NGINX_CONFIG_DIR": "ENC[AES256_GCM,data:xoqrSjX7QSJKBQ==,iv:WZOy/DMFChbNxcw5DUCrM6UvFAkz64ynaDXtNGXEsa8=,tag:JIRrnyFNyEWFQlZAP5mxsg==,type:str]",
-		"REDIS_HOST": "ENC[AES256_GCM,data:PX3seSUVY5GF,iv:SADlNJqyWF2EdDQP8fxCbS5v1tH3/v28L6GtIKoPvBQ=,tag:/8h4vG8YKOP+K7RzyXBhoQ==,type:str]",
-		"REDIS_PORT": "ENC[AES256_GCM,data:6RupYA==,iv:UJBXLH/ERC9uevKyzm+L9V+Eq2tT5zAetfJcWftBfXs=,tag:jAHzQMG8p9L4dtyiUSrLVw==,type:float]",
-		"STACK": "ENC[AES256_GCM,data:avWCa5In4A==,iv:9aq6aSmmHZnsBSa81hj7SxrO+cPnadsww44dXo41nGk=,tag:A3Xc/sT+0txF3525Qh3ZzQ==,type:str]",
-		"VERSION": "ENC[AES256_GCM,data:w6sy,iv:KtCwgUeAldnyXRAg84fOpMjdVWVGzD1eg/A1txzo8EE=,tag:rGlVU/VOi7RJVbMMFd40Lw==,type:str]",
-		"VITE_DEPLOYMENT_TIME": "ENC[AES256_GCM,data:IPt2gLeY3uVkkNn4i/Y=,iv:mcOQDnYgwYuF7zqDdeoZOA0g8rm1EDqY1Gl57rMlYxk=,tag:TK+SShm6yY2YNVB2f60NjA==,type:str]"
+		"API_PAGE_SIZE": "ENC[AES256_GCM,data:BeR/mA==,iv:+aFBJK2qWjhhMENE5MVCMsEz2cTjMMYZ7Pt09woURBw=,tag:MDne3n8g21t+LG/0EkD/lw==,type:int]",
+		"APP_NAME": "ENC[AES256_GCM,data:cx5vW3obyDvP,iv:NjtgzhQwKlyRQFtWRbqsl6ldjLCaRRKTh6ct3k3TlEI=,tag:ixWNlHkKLmMqzoS8m8P4CA==,type:str]",
+		"FRONT_URL": "ENC[AES256_GCM,data:DkTXIMHZdql0JqMpn2dTKd4QhUnFSI8P626FB2z2KA==,iv:2vraF/9C1R/kGbIaYJvadnR5O695XyxrX8Sy2PYvcuU=,tag:yczeuTwuzQuNIF5g9e/Dqw==,type:str]",
+		"HOSTNAME": "ENC[AES256_GCM,data:6PIyMCaZaKOVhhQxopA7uf49vvPWuoA=,iv:YbdKqA5KVwYmLyu2jwgD6DwHQ9H/Gv2c0fF0qOrs7sg=,tag:Ol8TvwOOSB6VaEbAc32l8w==,type:str]",
+		"JWT_SECURITY_PASSPHRASE": "ENC[AES256_GCM,data:IhnmJ9q0G9CBYT/vdZjbwKLaZwyFwYCYeWz4GKQkBKLroXAuG5ExFA+HC0EJM7Iq2g==,iv:YMrqsNaGYQhQ9q3NjfnfvmVtIVrJBB/BhiYXjYTdSF0=,tag:Q/YpJQxYx8iM5UOiuS0nlg==,type:str]",
+		"NGINX_CONFIG_DIR": "ENC[AES256_GCM,data:2Nw22d6dVHhu9A==,iv:DE3XrZQs7sj/NjohG/7njw8vGQLEotiNxWXvAWxKKG4=,tag:PLb2ztKJ136Kc8Qq5TbF+Q==,type:str]",
+		"REDIS_HOST": "ENC[AES256_GCM,data:QitAS5DBOpFL,iv:FcKRJUpoucfcmQu5aKGenbB4XmrmwdWYGH7UmV6bMjo=,tag:+7fDYpbKPLWS2dl6tZGENQ==,type:str]",
+		"REDIS_PORT": "ENC[AES256_GCM,data:Pz4ABA==,iv:lMXZrjUY86u97IpY0JzCcyiEw80v1TI7ymVe8JghLNA=,tag:hJkFOYYlKc0802NEEEX7ig==,type:int]",
+		"STACK": "ENC[AES256_GCM,data:4HqS8kbe9A==,iv:5v+MsClPQDJt/vKXnBkPx+c9Hn99owUPYdR6RrLJ88k=,tag:n3OM5mmMd9n6Dy93f/QY7w==,type:str]",
+		"VERSION": "ENC[AES256_GCM,data:fUr1,iv:goDx2jOOgpsOVhW+7sSEkGZHgq/Ri4a6EsjRhL2jtdE=,tag:Sn5KAwwn1GGgGBHm9rEJeQ==,type:str]",
+		"VITE_DEPLOYMENT_TIME": "ENC[AES256_GCM,data:UnxCEMsf46sCcfLSQzg=,iv:ye7R03j+1eV9UY/lePFVQz3i0LXnEivDqfkzh/b/YWs=,tag:mxO9xVTY6a7c3dGOMpQpgQ==,type:str]",
+		"CONTROL_PLANE_API_URL": "ENC[AES256_GCM,data:6g13RMLWHhNHhUlQ8jPkt/v503g23y0CoWTxBB1/F0Hy,iv:dWuld2XCE9bMhaJqFI9inQtF/iJnZ00o35/aITUhR0o=,tag:cfnupi/23CgCks75meveSw==,type:str]"
 	},
-	"instance_hash": "ENC[AES256_GCM,data:ln/bHxjyVac1RsYBJ3GRZB8Xuff+KyiM7ODhtPWeSQpeXPvzKKRdrQ==,iv:9wCA+IzJgtOINFkj8pwPjY6tnHv8kI4T64H/BMYathc=,tag:YJCqWiaXh+QZHdJv5bJE0A==,type:str]",
-	"instance_id": "ENC[AES256_GCM,data:0iQlwhe0wV8+0Gr3,iv:6gXoW5J4tAPrMvFoSjY7fNBaRnD/LjGN8yBJrJT9s0I=,tag:mnr2YNjeRJoqJDqUePWB2g==,type:str]",
-	"instance_locked": "ENC[AES256_GCM,data:6jZz3+k=,iv:XoIXeYGsUdXHdy0YpwCnNMNLZ8wL8sGXK6Cr5OuTqmw=,tag:m8siLbUAzNmQpt8BVcxFZQ==,type:str]",
-	"instance_name": "ENC[AES256_GCM,data:7LZSF5J+M0Dp9K5j,iv:RRNakQDhoGHpvC/9CEyxu2LRY+urdpQCsnJCyXz+yxU=,tag:x5anRaMT6pvS9jGl3+zjlg==,type:str]",
-	"ip2location_path": "ENC[AES256_GCM,data:Tkm74+QnX+KcOWwIeLaPdGBAFLzJHDsr+EiPp49rDm4rDqQ=,iv:6U+UKQHn/7cSITZmc24jW1pJUBOpQDpkKEkHyG3CDHM=,tag:BYZXd5pCB7xlDGAKv6sSSg==,type:str]",
+	"instance_hash": "ENC[AES256_GCM,data:CHkRnu1zzHqRX3QPRDEmc3KAIXoQkVlSiUuWUkdMK25awsAUMtt5Pw==,iv:9+TuU5rj80Ipnho3eJdCQdhRN/pRbrXVQnrlRrfmeZY=,tag:62fF0/NYwtPSJiUmcrtXTQ==,type:str]",
+	"instance_id": "ENC[AES256_GCM,data:L6W++CBp6GO4JrThrQ==,iv:+K2IJiQEczLSfmfNsQsuWd/YexOabhjFockcDTbxW5k=,tag:J0QPpwhXmo0k3sh44Z7XrQ==,type:str]",
+	"instance_locked": "ENC[AES256_GCM,data:8ZlZV2c=,iv:RXIvIDkTCXbWO/ivNgV3VG4nrC5GO7bvrqLhtIB9dWI=,tag:knF8kvNLtCz/CiMTonx8RA==,type:str]",
+	"instance_name": "ENC[AES256_GCM,data:PfNlX25BmgBu2y+FXg==,iv:HKqHbVbVf0CVuelwWffiFO8SMvHQq+FuREOJ8yYFDCk=,tag:VJJwLujKvGY+S+0Hoon2Kw==,type:str]",
+	"ip2location_path": "ENC[AES256_GCM,data:UfjB1ab00H7lsvRuor/LUAaYAQYSQzj6o6NUkKc8sb28rEk=,iv:a1Bbj+Ui6WbigVYY5i6yv61plV2MT/zCr0Jap+aIlzc=,tag:+BfBYklbOnzpy5KwD059LQ==,type:str]",
 	"mcp": {
 		"api_key": "",
-		"api_key_header": "ENC[AES256_GCM,data:gjUic6LxzZoAt4D7cA==,iv:7nrEupTHCeef87P0sWhBMA0Sf5GHkwqx8ZbarbZvDGA=,tag:u4mEVd/EpLfwqCBmO4SKXg==,type:str]",
-		"enabled": "ENC[AES256_GCM,data:5APgWQ==,iv:qrvqiiwD+jW6DWRKXOsSu/vf+V0nPoVCfrEesegYKzQ=,tag:bN8xqeE36EToUQSxEH723w==,type:bool]",
-		"mode": "ENC[AES256_GCM,data:Dx0bRme1U2Mp,iv:MrUT7BDzstcFUuwJITZk1nDiV8ER5Y8o1suHszP404M=,tag:wyhodwU3MFhbyF3kUZPh1A==,type:str]",
-		"rate_limit": "ENC[AES256_GCM,data:YT41,iv:ImP9y5C4WMQdOr1KrEPk9HyvxZO0CMCdVna6hhExBtw=,tag:gT18+JCxUpJJErlxWKLlTA==,type:float]",
-		"redact_secrets": "ENC[AES256_GCM,data:WJjSwQ==,iv:xs4bfvOEsh8MukdItkxjb9fvNjrFXqpohq0e0xUUW1w=,tag:AsHFnilKb6VkxY/+KUOzbA==,type:bool]",
-		"tools_enabled": "ENC[AES256_GCM,data:6EdEZRo=,iv:GX1xyA0QFypXVe9wJ07nF890n0CUfrpEw4aJwdfz6Eo=,tag:8Sq7+4v5bj+1iY08xARIMA==,type:bool]"
+		"api_key_header": "ENC[AES256_GCM,data:QTGrleeC1l7Ft1BwOA==,iv:cT3l44JKgwV9XJfmtDRUyZy8voT4fqSuhDfOKTJJZ0I=,tag:KIY7uk6MpqP5h6s8SZPDhw==,type:str]",
+		"enabled": "ENC[AES256_GCM,data:CeyUBg==,iv:SDF5B5P2FSqkKxI8PLDyc7TzMe1J0WD4eEWBVUzEJD0=,tag:gaVdYmN3dVXROum8o9p1XQ==,type:bool]",
+		"mode": "ENC[AES256_GCM,data:3U7jlmNCiYTx,iv:wLEoFPpPDER57Rb9MhbF/NRbPg+ywzEC0xlW/q5XUZQ=,tag:Szfd7nr7aEiD8Ekk/n9yGA==,type:str]",
+		"rate_limit": "ENC[AES256_GCM,data:Wj/e,iv:Gey+QLMjp6ewkA4H8WYzjNYjpFSNQvoE8yQvdAfC1UA=,tag:yBivEq4I0QYJjEvCQ7Lphw==,type:int]",
+		"redact_secrets": "ENC[AES256_GCM,data:zVJFkg==,iv:Kj9eAzHxR4Q24bFrbx/tIU6rUQ2U3qEoKQdwm+4fkz4=,tag:HSSeVWiD1oqUZPCLLsQOow==,type:bool]",
+		"tools_enabled": "ENC[AES256_GCM,data:pmBysio=,iv:KI/4UvlSmiWZrCY2OH79MCEgs95GYll8xfA2Co7IHlI=,tag:J+bflA+bvgtUmVBHD7o+uw==,type:bool]"
 	},
 	"nginx": {
-		"content_type": "ENC[AES256_GCM,data:4oQKw3rXyzS/,iv:FYxWLwRjJnYRf9pnKxWg9UIbn7SvH5gQqOlrzGg5+YY=,tag:EHO3p89D63Iinkgibx1row==,type:str]",
+		"content_type": "ENC[AES256_GCM,data:d69wSqronVes,iv:JHqFkt3CaqBu7+MePmC0yyc1E7I82+jVMeHctZ3KH7Q=,tag:AfHoQxEj1Le/WHaDI+zPNQ==,type:str]",
 		"default": {
-			"conf_mismatch": "ENC[AES256_GCM,data:+a5Jm8ZyDAakyKrKkD49dOW3Dgrk8sqyiCrHnk9SYdSoBpAUIAmU/nIdsIPVbX79Lo37G6kQrm9Qn6u87ad7o+jiPsGAFK795eG9e+gEcKzeB28K9/iSMWoh0dGuAK2yVyvMcJLbNtoWJQsFTnc51WRNZfcR6StWq15ciqdUlvovhGdNRMk8E5OPTgIf/pEcIVex839KcCh/TmR0AhRo1sciZaB6lLX8BJJN8NR0yrtRYldZGpzNnNP13rof7fvbZxWbT+L9BcDl6GKvQpNzw7ldcCR1zVViNuLaWQatbDvcQXZG1UGy7SDy4HHXYE/v1Hq0f2ISbezvYQRlB25TNFSnF66DqNOOckVQ3kCGRR+mitIXgn0TxbffULdQg9TTT8LKhryVvH9uxSPcxbogys/3QG0sQyMuOejk6+m3g64=,iv:nGI71IdUfXeeSdp1kn+Glyr4xf9BehPv7vOpS0N7usA=,tag:Lb/sIeL5EZ84cgoPvzBblQ==,type:str]",
-			"no_rule": "ENC[AES256_GCM,data:ueZHfpbAEIIiV1m68pNHr3knHC2208wA4VfQFAzzQjngrP16nU7yMoOEizq5eEBSm1JFyChUwizD99yoV42Mceyk0chbODWum2eq/VeK0STLHgxKZ7oZHxxS95kSokn3wkpCZYLbZ7JxexFjzDLxdTo61nqXKfy5hB9J7z0kcKHs05uQ2mjoSHf6C8bddhz5eH6kzE62D9UPqcVY4aRWpUIX5oW/4kgTkC4+nlGX4EKI31m2RRCE6MB5yxL3zlgOiSnhXpDKbvJNTUYYFWtONLf5kd/jPbyfwfBXcyhW2XNHlkEwjTniAU/ADf2NfOqQbala2WZNf0zw2xqKK61RwBpxP1oNrT5OGWEPdhAKT6eP/7FVrjL8/CVzFML1HCN8CdSnv672uCXHuTn35eILXUs3iQWLKX5HJUZ4aSjRF3o=,iv:iUzG0L4ESQ9sXfctRaI1xBLBARhvZAaYMHIJ7/uSJso=,tag:LF0QZW2nXm6p/CpBay+ZTQ==,type:str]",
-			"no_server": "ENC[AES256_GCM,data:hjAXZ7zgM+r82+yFdjI9vC18g0SLAi8kStvvYdASgwEKEvlVUpqqEsEDtHIjNVLgsEiTRHCX9u2eNMTQLpTtSLpD2WiFnFyxuit5rVxd2nN9PXwwm3y0wL7LL7x02HaSQk2bEGfQsJYW4zWYUOY4E3CUbn5w/GIMGlWyHBCUoxfCYRBAM9PsAo+HvWVx3dop5TvciRJH/KQs3zS8UQhUBgV6+5J4FAsSYnWGjZ6FZyUs8vFEnxLPW+mZ/PjJmX30KW7z3mDuHFck55V/+nfbg59IXj/Cn/ZAOvCjJ1ZI5k7oMkptw3we3exH6EMYvr9DRSO9P2BBWHExW/ae+Ue/BWMK+pI+deV6yhtn45rRRSrfxDj1YehklhHuZnkdaULDkieIvbvzs8ebNxsNle2nMCAIZip82UV+RpS/lLVbcSo=,iv:Ud9eKnwancEAABnwyq6n06Au55DovLk8ifLMLGU4G9k=,tag:wePZARKajC42QaZL4Pk/Ow==,type:str]"
+			"conf_mismatch": "ENC[AES256_GCM,data:Myx49DXQV29zYxGAKH9hwlDRAoJCum1Rz+m+eg/zO+CFjwdXgEyKpgnSWmYe19DvhVDVWxbfHv8+HajPl5oWYsL5oOqRT6wHyK/F5FSAmcRLVzCQZ4/CNQwGdt0N6/JOIHKN+HXkfmcQgOivKvE3n9jlY1Cv2b/Gp8ohyf0G04dL5eUrMDXe7sftTVKU9/wzTzMQBp/7//FLhGG/AzJiGn/2sKrM3uVflmgzh0pGMAru05yghr7h9Up0QlVCtA2lbSVZAQ4a61ipFrlNiNAhSUW3Yw/VEPrjEbUx3NNa31vDBZ0gxpsnruAjB6B556Kb5U7xUogwZQLcssgdqlmLdkBhOmcOnY2M2o/MMr9EkKwXpZn6zHXDnheCacbd++jChLoQDJZpij7ZpA10o2M9g89yGe63b/6oE2PWJVSwFbAaI4RmoeUxL2dXrXtXHfrgXacW4Rv+R4JWz4BLa4HaEYF8BrEDbcN5vqEb8CL2+es/gQ9J2A0vBZRzIkUV1MzVAHakXDMRXeDOCCg+7r/oRIRw9S0fbeZ4j+CD2+/5+klNZ+BWcCbDhn/pecSx0HPF6FkRi1qQfYjBhxfaynsl7Lj7/gs/RstaCKX6oDUBigFzkRgTCg4DgmepuXYPPfbsRy/O+ifKZAEOCFo1Y5AbU0oRFtbBzmMIHHz7ZAaPDipukqHUdhzof6X8rOBMmSmYTEoQtjxvI6u2g+yfYycTM8d98WmvscYyAQ8mnx55Z0jbNdVxU9s7i6oMPxuuJr6XSmcuYbRPsTEnQiANDqgqXZuL3tpuKadVSfRjAVWh8atNYfx2MJpNyW0MA/MgbctwE1D7hsvglKqabPa0wcRNCVgCcwALuI4MxWaBV0T2sE6jrGC8JkBq60QnDgKs/ZD9M+UhIVIrvUsT5CpakJb1g2XndodNuL6CuBNTsDm98+7YhqIEuBeYRgd8KZWNHQUll242TVCEW9riCxlKi8QglBy4ggn5Xc+33va9RFPMDY0PhymQxJs175svzorKClMWADx/baNR9nsHCbA7fvm6tnjcYQJiQCOxUd1pXq0Oep41xADq5IYmXd5QUo9+hwlOyiS48JxfXUsH6I7nCuAFtVJFt46A/FOygTkPEN8dKXEBDYV635exfx4p6FNaSLfCIk24mZKLuhnoB/hcxInqyaGUNNEfhAmCVm1o1X4Kf7tc3+Gg3iJtOsTc9BI2H7Ga63avri3B2BicyHrGGApTOyiZcM3ZwUU0mRWWlDx5Aw604K0eu7DJNZaXwh3bTkWIqVusy54STapQDXOLN5/jDTACyW4PFFhvr1wP+KOq8mZlqk1iWgeEE4U0AwRo4YpwdrgwbPOvIXhniJGA1cMZMfwF1WiIzlBAwySE7cm7oJ2PsuZMPiUs/QfTk8iWZgm10JHP9lZ5ihnJnSLuv+cLOfZH0UQPJKE1HgBSemKv3aPprwwmY+OBpUtkTjHwNcumBRsFQk5ErEFcRhViAX98KF5F3grMAdAuZjmpFOv2/b7vwN9J0HhOxy+Y2I2BCW/8YqebuEe1xP7MWC3r7Vf3qMoCUtHrh2RSmuTy7SCx7etMadLYT7FZ0baueG1oc6fIkY7luwz8uMBoij1AXcvmW/GCwZimIBw7I6neoFs1OMN9FOqlIiTlQ7lsbQw/k3PKcGFkWBVBCkRgkn5FpqwwfXsOXTXNdSZfIxue21Id4tJ50fC7MS9cGLQv0thMS0d54L13oUn0o4HHx9k0ohrBuR8DcZx32aMUWw0mA3JkzvzBxWufINxahbd+QVYzlKSiCkHyWlnGme4D4L0vQhZtthTjmB/9bQXeAz6rq3+N6DqqR7w1rpHym8I1Bp9hsALXBSP5tyn5f46JuGc7uuFbSmGsX5kqRVr//3iEE5v4ZSP8diNvZIe1MOqnVuNHo/sc+92nMrl7iCpsAl2VW7JN/FEz498zxTbTwJmHDPJpqiDNdGf34BfjTUc+QSnLtcSFtUTPqw==,iv:fl5fWxmtcmyO0aRu2Lb7CSw+eW775n6zNoibaRyw+TM=,tag:Yj7UIppFa2jhEZ8cgZLLcg==,type:str]",
+			"no_rule": "ENC[AES256_GCM,data:WzJe+UM/gBTo0Yen4yiBOPM0VCHLGHq4IDHty+DfS86YfHs0uHdCgjbavB61R9d+uBcUXPf6iXoa8gZ8dwlMi2rga7JpYxVDm4ezusFMv9Vbx3mhikJYZmTp7YUnaKf6Pio3gZYHCQwL8BT9+M6xiL2qcbJRQ3JsDMqoDGuQRU/pjWHavpdRpHSMKohCBpS1UjmUtQIkOMyPoeQfyJA5DhbrAxK4xMe8WwUTaLf76TozQSDxYxTJZXuM4W8nXLWYiir/qn0xTzs60z1ZREpUDOcHIBriGelvf0uhL1ymU3qr/WQ8bYu7Wi+vUGJ6bLOLDYLLZFSGKA5PKkgWRVp1nvFAAeA2sKbGVgCH7yXK86USrYKq9y5l/5PYgxdZzj5/7xsggrIZ0FqlHz2XyGTDWkZFSzylxByxvMMt6lucrGnvmvi8PG/IZjobn18tvtlCbb/YIzEeuSkxNfD4X2VKysuOytm8Jt4RWCm3G68Db/bkaie1jNbWStv5Gc4QDNSXWx26ETfWd0rfJIrsDThr+A+TD86CBcLQ4XZHVa5qJR2kYiSZhLvF0my9d23iqh7TQaUmnWkUaZGPQIGT8iN+hNftMeqoLsrIfex32c060N+JcWbkSMKW330J6NbEPW5FIJ4ahgRRmaw/AWzyt8oYrwM47ciY4sOSd74dl9BrDNcsgEwObpz+3mWQh8RA6M3l1xZGYrldZsJ4LVqENPS7S0iA+mfWo1nMTxmcjWcuOUMB+nhHAih0zMf6lpatDIw97qsKHV/OGbvekp6GbtpykwxtOyBAP33CZrRHDGUhN36Ctn2CDc5Np1V5cey/Fzv1oE0IOpWVEudY6ctFITbNAZLDd3XxzYrBLG1JbqxCuBYQgdUN1rCdbOlh/bglmDaft6WkiYEvAq/nbQLhiY6nIjd6vZfBWoxKQXX3P/woBmPdGEwSKRL54cXwt7CGliooNf7uCKaPrnhEYwUxaR2bxkn7GZ3dxRzfU4gYoW5CE3JAYvUR6Xh3zsG05Y3NZIP0QicT61qSXVunp75IhQ2NLSqJH3Uv2YOIVioLUfV1ZzpeQ7djSGroDaBJYIXYLjNWq/fuF6mABgXl1AIdcXXXtfdMNBo8Cvm3vMGMNsMdFxLt4EoayICwCVzuIb0n5Z4q0zqUZiaE2i1wRmmW7gZ+5Hm0PLIdV8fNh4kOElIYF6F3KAnv8lacpJgrBIKV8CM3o04gV1AyXawbTlrCxmYhdwDAweY7jK+eZF46HSDsTS+vuJMueRVSdHb6eDcARTpulF5nMMJ4Zyad9TJPwJxfjvTSUTbaeB9OP5T3SeEMpQFpfbJCal0Lc2WAfs9vXgwAiby/Hrp05K6ds6gemT1qXYbxXCv2BaRDEeqc/1aqrd6qkgXBbiP5ORhgTYMC+wWlXmyZkDVYK+FY1K/XlzcyxwFfDfZQX2fMaHtwWCJ5Ob7vdFBpEelZ47nWwPgA7jdzyjzBldI+2LxYrJ2V+bbM2ByYu/ExhOTtBbW+6OTAsOc/QyOIKS6GXpSGXOrBVIdsdFYWI1Lar6WohK3qBIVf1tnPX0GuLW0ANJqXWtP+okhUCW9paRI8yhUSHfuhJrhKPzz+2XnbxWZsV61jQl3Ll/0C8CiLIee1ItIZCc6RMNsJ69AKuOaKMp6pYF1DPTaQwktkzkxOW6+lP8+gwbJ2TsowzMUB6AaH1vH9CFLRp/QaYZUxEP/KmIOh5rzGkSP6VZTMlLkO5cXPItQp+aRRcKjea3tKh79acrfX6TgmJQ5vbkTHdop9CQouC8mXXhY1RRWSoF3DyBAue335DkBxjjUufpC5zYR2LC0R2hgHUIb3Li4ToWIGvCByTeAhu0dgLkU5ERSIH7IRj0WCkJ0z7ZUvHC95EsEjomV7Vpsmkz+z2IN0Gd35HtQw1N6+oD88AszhdBo35ZLphDkJ1/x635AW49MXOZ5zCnLpbHKneHwWJQoU7mol8fsuYeraRo03W4MzpA==,iv:RxeDLTzvH0IWcbIqUi5DuF9YLIByMnPIluWQgjzdvd0=,tag:T6SD6LxE5KdAxsyM85DxdA==,type:str]",
+			"no_server": "ENC[AES256_GCM,data:mI/4pluy6hg0NUo/Oi+r0pbGIiQi4fcgteirhRDLKVzz+F6L98OwJAdyx4GDqHp2Hg7CyqgAJKcg2EPz72HcjZDCmrnoOxgTlGnxpKbCgrO3FrFOe+SlyDTm+wjhVGzX80LHseIDqJAAL/NBHWGoiKtVjG5Ax1T5V2EkkwIoHTp3cj/flaNG8QyYLFXyF2diYzJC8eBj9TAKD39sscvIPvo/hGnVcKhxXPjTHZUziR2mw4sgdCh2juwWwuqBAkqANyQTcWQMMHk/KMJR6F65izFrPv6MVmRDS9T4YCAvznJTkyN1frnfv1ZuQV5lTxAEWLGMDMzSWXzaD+TTBbjKrZvWS/SWCBOcP6mUJTNuhxYBHhLQQeGdOgK98MNTuJpJjms0XrwrzBknhjYuqgOH4lIR0+ewNx7dted7neorxV3nZDPi1pcT06nBLtpV8jwPvDnaSBdlnemNfH/Ji3X0qT5B7eiod7PrYSMPDC8+o5MZx7cf4/ytVu4BGkzflRTcLsGOaXziRNwKUAjCzeM+tK8RrJ6BYdZP3SfgzFCXeSf3h+UppceD0oF7zxG1txxyFH4Mk/BA9+FZkuZg4BZ9hnMOAE53gVhIGQ60dhPKdW08Tss+5ckBbNeC966+AfnLwKYiEpVI4YbxudwkSCFtIuRu6VHAJ25OATfv/fSaqq7uOpJkGjcviiisQnTSXWM5/t05Ysu4VcEHnQYd7WfSKsRhIVEmZWMiJc0X040xBdaO4kA0oZhO/4Ia3p9VS5bZ6R2jxnDIyxLo2Aq6t/sexfj3bp1kVU7V03PYjemP85KQlBz9G1oIT8l1WMr8NA4I7ByA7mYkQU3yhk2jBtKVG+yLrn47Mlwi1SR4NydKu4RKnNOcZNf01fLjGlrJ4BRAKhVeBafvDaYCiM+6+qG1ANlpTmDrI6w8TpYe9hHMqPJVR3EZqzC2WdUq4PBCi3GI8t8vWefh+ytKb4NgnR35FuogmneFnTUerOf+S0zJrXSE6Zsf8RXz0nJoED0XRAnqUTTkyMv1VFZBXDHPPfgaM8OAXqpgm2gkgv1cU7ie8op/tCgTTikEADtV+IvizgMBNJ6dgTFDwiatSp+Ou2Sa28vfDG92X3VzGG1r+Vci2ljR6ZMpmurk2g5nERmvQx5JsrC4IWOuNOxGDpATwH5E5gjYPBguxU7ekvazEyanA5+56Q88UKrJJIMOSpvJLvkg+HWA/AASCcqgy2jQIAje08HvrE0ugw5CgoqgSnyFkq3q6VB+zX9RFAkkLWnFuoZBh9pDVQJHfehUJan0naVwJAdLU292eoadLSnX1dh3hysTu6jOOWrLI5FHBv3xnbVV8E4e/uI/k3z9I8vnKPHdDuVC84D9+tdtTRwzOnEzbsUMQ0Za0xQ8ydH/dpDsvaa+AsA8HNqZZDqKeNfRkXpqRXAvUZ1y7CkENEzG4aS7pvL3WQxYebFz5hc5t9YFfq8XAfXtiaveqh9/5i/MvBBUYjoVyObmb3OH30TBNMjBNre3aq4q7aHbPhe5Rvoaql9KYbDqIwiLRD0aJVAWP/E2Cpp73fMP0JC1n8Iv536CF/MDJAmEpWxU7nxbmqlGwDtHGqireIRetFgAwQHP9NBIjO1cs0oWH9RqS4HEwtfMeg17t/yF,iv:N1qD8iPIGZBYjKmouvjNj5V+2sv9T7hR8eJ6Wtmy/BE=,tag:wTZtyyTiU5qaFaDl8LO5gw==,type:str]"
 		},
-		"reboot_file_path": "ENC[AES256_GCM,data:bitkbi0L9htAxnCoIP9jbaCzqQ5+tdQOGwzXxcMreuT+m5gX,iv:IIzqA4/7+gkkju8FSCY9gecEbGUfsb2ANMx4P329kN4=,tag:84DBV6Wu0hV8pLqopZ8T9g==,type:str]",
-		"tenant_conf_path": "ENC[AES256_GCM,data:99uSs3OCDUt8vroV6WWNLIo=,iv:zr9l5AQbJMatKJQZrsXjwo2G3hcTwYoOpq1cNK4Fi6A=,tag:6TH83YcHEJW+DlFYRbl3Fg==,type:str]"
+		"reboot_file_path": "ENC[AES256_GCM,data:TG20ocSaWfEUi4nUuB9zhoeK0wuTbgzrNUWmiaurNg2NMn13,iv:sE4S+GlgYaE8HCmGh/iSqq2teHSTTFVsS0w5sbVUdnY=,tag:3B+2Euw9CrsBwhYuJwbetg==,type:str]",
+		"tenant_conf_path": "ENC[AES256_GCM,data:850+weE+4U6ONZK2oVN8SvU=,iv:1VwoSzRkKuVx1SHyKVFGx3cji4cePJjHbsd9bcB+cQU=,tag:rVSKga5m5kE5S7Q/WSXNVg==,type:str]"
 	},
 	"redis_host": "",
-	"redis_port": "ENC[AES256_GCM,data:UHhvEHV8H4wN,iv:c75gddNr05stC/vT4Wf6I31rFD4Je9CFqNbEEhhFUTk=,tag:hmX4fA6d8ZpkqJ+fLakUKQ==,type:str]",
+	"redis_port": "ENC[AES256_GCM,data:7zr4uTYPqgTp,iv:mB6NtZXcZxAX2mmzG/Be1+2eH5U5BIGZhGTkrlNjnqM=,tag:yW60GbGYPHlaBGEgmjNv1Q==,type:str]",
 	"roles": [
-		"ENC[AES256_GCM,data:RBjHVvIKIS+1EwJWEShM,iv:TQ41AL4yBlr7fTVvWbENJcKQfqRbGA85Nl6VUTaNS00=,tag:AbhAyMI0WR1UL91gIM0gEA==,type:str]",
-		"ENC[AES256_GCM,data:K9smRmQ=,iv:VkU/IfdDrdBYN86JzssHxp2kigRwPIMG62Ht/jxgvqI=,tag:mlWo64WrGrr3c5B8myIWVQ==,type:str]",
-		"ENC[AES256_GCM,data:uB0sZ8i+KUQB,iv:gA7WROYFBug+LrhGrRP1UUkWGDJlOz3MzuxgbXHD4kE=,tag:8N0zu86dmqr8CfxjeDQEiQ==,type:str]",
-		"ENC[AES256_GCM,data:Zcy18lj4xgalaQ==,iv:IyUbBYsmOyDQIDRmcKqJftQSebf6UucY3mqO7rDm1qg=,tag:zcfJ2Wqa3Sdl+ejNlEaylQ==,type:str]"
+		"ENC[AES256_GCM,data:0zdchBmkjYs0F3Jhy+uH,iv:zoUDbC/YhzO2NI34UAjblRa1hT6XIjwPuNyGl4jCQIM=,tag:v/eqQBjxanWTJFlIKQOSTQ==,type:str]",
+		"ENC[AES256_GCM,data:ddS2jIU=,iv:iTKMmcY1lYJVB60tV3afRcJ0lHK60TqJlDNVt+Kp4mw=,tag:ZVsu7bllTkJZ+Zp9u2OLfQ==,type:str]",
+		"ENC[AES256_GCM,data:ALSlaZyU4MFA,iv:qhkIzaPbt53FTMRZcYbK8T4agFTOEIyML5QxtNgijUU=,tag:l1IpQKJqS+jqs1xY49/6rg==,type:str]",
+		"ENC[AES256_GCM,data:XRpJ+7sLxCYC1w==,iv:ia2/AkbqagCKFe1gy2TYIkG4nwvtMHz47Mc71Lkf2aA=,tag:/y2yhObmXQ9+I6O/MnT5nQ==,type:str]"
 	],
-	"serial_number": "ENC[AES256_GCM,data:gh6wYmisU3ZH+zKtfWvB9lQuS01nFVXZMmUOgJLHpAI=,iv:dtqzS/YfAMuwLqKrHexgJvDCySvfsH9t7l1n6x7M/L8=,tag:MT9RW2L/Yk3FlI4bZ52BNg==,type:str]",
-	"storage_type": "ENC[AES256_GCM,data:7QrOjw==,iv:ycY1zufYeahTi2NRoZnq3d8QoueLFLHhu6w0JQ6tTQk=,tag:or2CA5PQw/40z7fyv6umWg==,type:str]",
+	"serial_number": "ENC[AES256_GCM,data:sMYwUV3x1j2TzuJf8A2TjEmmPdp1bmG5l4zeMcUkGSw=,iv:uuAg3uKqIv8/JfHc0c9V5Bhk1rO+3frDleR58IfASVU=,tag:OSvGYH1nT+wrKLefHkhfyQ==,type:str]",
+	"storage_type": "ENC[AES256_GCM,data:gH8HVQ==,iv:TgqM9LlErWdm2nA+p2v6KXo0uO8AxiaXJG+7su3TQn8=,tag:YAUZugItd7ZdwWd098bQpQ==,type:str]",
 	"super_user": {
-		"email": "ENC[AES256_GCM,data:8VaRr3d2aPc8b89Vg+m5LN7eng==,iv:56DfoLiUCRZrGkVPOY1nJ12WEgLeVW9gZbQ8GvtYpgM=,tag:NrHjx6BIaOEcpIDCkdxYHw==,type:str]",
-		"password": "ENC[AES256_GCM,data:IEcxSflhUbqvW1OSl3javfzgvbpwLsAeSLwBNbyYRAQqlFbt/psv6kG4k1Q=,iv:QUoT4HI5PQB/mgGAcFenEV0EnsyHlmQiulvLlWRKEro=,tag:TELIxtm+iZSpiFQQvOOUuA==,type:str]",
-		"username": "ENC[AES256_GCM,data:C8WsTVc=,iv:U9xhsdAXZditBaSsbxWgJoWHNYa+ZxYhoJrTnSuTWG4=,tag:X04u2cWdLZX8gADFzabhvw==,type:str]"
+		"email": "ENC[AES256_GCM,data:UHVQN00qxnabkQ6FdzjB/EyAyA==,iv:cp5a3wfLmKBwNzL+mfQIPJqUc+X9Y7rptUJXwDA24kQ=,tag:a+EWknvqIGa5hiNhkDEeNQ==,type:str]",
+		"password": "ENC[AES256_GCM,data:uRr8JaGFdrP7vZNQPL9kAVQezwo/QTjfaBfADIB3BV7rkaViI0vGHIb4gnQ=,iv:95UqPtoRAT9h63gUPAyA2Qz/euDY8P8f5zb7Cxty2vw=,tag:DXu5+JThbUQhPbIW4Buw1A==,type:str]",
+		"username": "ENC[AES256_GCM,data:rLImY6I=,iv:HZv4kXpjwcFQ9/37OLgUs9qyqxWDJ7M/cnN+b8KXmzY=,tag:KU+4ljN+GXybYCUWrE/vhg==,type:str]"
 	},
 	"waf": {
-		"body_inspection": "ENC[AES256_GCM,data:13VbzA==,iv:D7grpGWQVmWBuMXCf4VEZA12SIL+2b81jWSOpd0cCuY=,tag:S6q3O4fbI37B6q+TDmfkjw==,type:bool]",
-		"default_policy": "ENC[AES256_GCM,data:pDqpCBCF7EJXC+BmcF9JCdey,iv:W1aY5elKiO8x6HaFzPgxUBKfp85m5QOuqmnuFzs/FhQ=,tag:oY3rk23MMwkKznxGiNg79g==,type:str]",
-		"enabled": "ENC[AES256_GCM,data:5vVtRA==,iv:hYjDrS4qLhmDX1ibAu1joVKldM+vcNfQZ6ae5ZUt9go=,tag:YrRaCy+TVrZAFXhF4FVOVw==,type:bool]",
-		"max_body_size": "ENC[AES256_GCM,data:s9Bhe8Ddzw==,iv:vLWNIhD+iKqXNddSD8VZ1Es6R1oxEMCE1pEtaWARpjM=,tag:a7u7lOi0Jhzc0wbSJvKJHQ==,type:float]"
+		"body_inspection": "ENC[AES256_GCM,data:wDmcWg==,iv:n3jED0OgAQWES5cchGuAtpEh19Mly55LobpZ5QOV5YM=,tag:Zxuk392MZwZ5mIttNgJalg==,type:bool]",
+		"default_policy": "ENC[AES256_GCM,data:QKnxa19aRV9Cv/eiVdvIG1db,iv:cUXynYQcgVbCIG9p96K9ASJXgCT6PaMTb0TH52+pIT0=,tag:BJNBjr4Fl7ZVCc5w1e92fg==,type:str]",
+		"enabled": "ENC[AES256_GCM,data:s99DOQ==,iv:wC+LJleBTh1RR8I1BIH2w2WOMzeD7nzh/HSdYqVsf4s=,tag:wrFrUlSVmf0QzLD4Ag5S5g==,type:bool]",
+		"max_body_size": "ENC[AES256_GCM,data:9IIze9aVHw==,iv:Kk7UT2RQzb9Mor+caceV7UUcbohxsB2PRodXIcAOgb4=,tag:rM2mrHaVvSZbdVHUBKlxqw==,type:int]"
 	},
 	"sops": {
 		"age": [
 			{
-				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqZWxvZTFNeWdlUkNGSVUw\nYzVpaXQ2cm1ReVBWVkc1a01DbWhhMytWZ21VCkh3UU9HY0RUR3ZmZjVQUWhIT0xs\nOFpzbks2ckYrZ0d4VU9MelZkUlJLTU0KLS0tIFk0K0Ura3hqWWRlazNDa0ZLeUVH\nUWRKSmROOUQ2MWdRK2F0RlBaL294WWMKQIXyYBmHrM9qPaJbug3eoYeMc8P9jwwJ\nf5CTKpIW91ENxnzryJydD+KhJC/eWfzcv+WUiaWRx2SGRF0FoDAoJA==\n-----END AGE ENCRYPTED FILE-----\n",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJM0xyRlJ1QlEvREw0SVZ3\nRjYyV3psbisyVCtONXNIaG5pTWJlWitZK0ZvCnBNVHFWK2lacFAzSms1VlF2ZlpK\nNURBcnBDNnNjbU9lYjJobUR4U3phN2sKLS0tIHlIZHJnOHV3Q1I5REx4dlJpd2FZ\nMFVXTitHWC9sdzMxSEQ3NHF0ZG9pNUEKrgBmkACFarc6zEXgxfzM5HHI+LXEA1/F\nMSYhoT9aq8q0knhWvHIzhSTCQRMPo0/jMNawC8yg/qGGt2awNGP0aA==\n-----END AGE ENCRYPTED FILE-----\n",
 				"recipient": "age1n5h080hae9czwpsgfgz4vapxd86ud2742maxc5gezurlwzs9ee7s07e0k4"
 			}
 		],
-		"lastmodified": "2026-06-29T13:45:13Z",
-		"mac": "ENC[AES256_GCM,data:VOEbfniDTlHNLBw2Cc1+/4tIl3HtnIe9v2X6ps7f9UdXNgcPboyi9rWQP9OofYAdCSszEn55NCXpjcjKx0/uSZM5g+kYsjEbVBmqMdJDlThNENlhMU1MF5eb3vYWwT/LHpO0zhEJiAGalUvG0maiM7x1w63MUbKHgLBiPN6P7Ao=,iv:I8OAGhkx+TFvXVQzVBrdJToiyvo8KelzV/GzOwD6UoI=,tag:/sJMQJFtitO4ugQ/2OpNig==,type:str]",
+		"lastmodified": "2026-07-03T07:51:21Z",
+		"mac": "ENC[AES256_GCM,data:n7gDspW2zGkreXY/IWf3kVHUQCbqWykL3ZjHzsLMn8FNdxeKYOzdRnt0pyWKWJDddMJvmUiZOYAgbKT5bkiB+PFOMWLVBueuGWrYt6rNkdpmPub2Jd5n0A1Zqh6jZIDJ6qUXkwD3DaZWL2Ha60ASCtoXtBW+III5WIDuHG8He+k=,iv:5YyD5Lzklp37VZox47tWfIUGrMlI95+288TMALPS5es=,tag:C3YiSH5Ewyn6EFZrwFcJnw==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.13.1"
+		"version": "3.13.2"
 	}
 }


### PR DESCRIPTION
## Problem

The acc/pop0 deploy (run [28644598803](https://github.com/bwalia/wslproxy/actions/runs/28644598803)) failed on the env_profile guard in `roles/wslproxy/tasks/deploy_data.yml`:

```
ABORTING DEPLOY — env_profile mismatch. infra/secrets/prod/settings.sops.json
decrypts to env_profile='int' but the workflow's target_env='prod'.
```

The prod SOPS settings had been seeded from int (`env_profile='int'` + int hostname/identity). The guard (added after the 2026-06-29 outage) correctly refused to write it.

## Fix

Rebuilt from the **live pop0** `settings.json` (already `env_profile=prod`) and tailored for pop1 (`18.133.126.242` / `pop1.diytaxreturn.co.uk`):

| field | old | new |
|---|---|---|
| `env_profile` | int | **prod** |
| `instance_id` / `instance_name` | wslproxy-int | wslproxy-pop1 |
| `env_vars.HOSTNAME` | int.wslproxy.com | pop1.diytaxreturn.co.uk |
| `env_vars.FRONT_URL` | https://int.wslproxy.com | https://pop1.diytaxreturn.co.uk |
| `ai_endpoint` | http://192.168.1.193:11434 | `""` (int LAN, unreachable from AWS) |
| `instance_hash` / `serial_number` | int's | regenerated (distinct POP) |

Secrets (JWT passphrase, super_user, Cloudflare dns token) preserved. Recipient unchanged (`age1n5h080…`). Verified: `sops -d` → `env_profile = prod`.

## Follow-up (not in this PR)
`test/settings.sops.json` also decrypts to `env_profile='int'` and would fail the test deploy's guard. `acc/settings.sops.json` too (though acc deploys via the prod file, so it's currently unused). Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)