### PR TITLE
fix(ansible): make distro npm Ubuntu-only (Debian 13 npm uninstallable)

### DIFF
--- a/infra/ansible/roles/base_packages/defaults/main.yml
+++ b/infra/ansible/roles/base_packages/defaults/main.yml
@@ -34,7 +34,6 @@ _os_packages:
       - gcc
       - g++
       - python3
-      - npm
       - openssh-server
       - ca-certificates
       - luarocks
@@ -45,6 +44,12 @@ _os_packages:
         - libpcre3-dev
         - openjdk-21-jdk
         - netcat-traditional
+        # npm from the distro repo installs cleanly on Ubuntu, but on
+        # Debian 13 (trixie) the packaged npm (9.2.0~ds1-3) is uninstallable
+        # (unmet nodejs dependency chain). Node/npm come from NodeSource
+        # (deploy_nextjs_admin_ui.yml) / nvm (install-build-npm-yarn.sh.j2)
+        # on all distros anyway, so keep the distro npm Ubuntu-only.
+        - npm
       Debian:
         - python3-apt
         - libpcre2-dev


### PR DESCRIPTION
## Problem

Deploy run [28658831732](https://github.com/bwalia/wslproxy/actions/runs/28658831732) failed at `TASK [ubuntu : Install common packages]` on the Debian 13 (trixie) host pop0 (187.124.112.155):

```
E: Unable to correct problems, you have held broken packages.
npm : Depends: nodejs:any ... but none of the choices are installable
```

The `ubuntu`/`base_packages` role (they're the same role — `roles/ubuntu` is a symlink to `roles/base_packages`) installed the distro `npm` package via the shared Debian/Ubuntu `common` list. On Debian 13 the packaged npm (`9.2.0~ds1-3`) is uninstallable — its nodejs dependency chain can't be satisfied — which aborts the entire deploy before any app code lands.

## Fix

Move `npm` out of the shared `common` list into the **Ubuntu-only** `distro_specific` block.

- **Ubuntu (int/test):** unchanged — distro npm still installed, works fine.
- **Debian 13 (pop0/pop1):** no longer attempts the broken distro npm.

npm/node are already provided on all distros by:
- **NodeSource** — `deploy_nextjs_admin_ui.yml` (Node 20, bundles npm)
- **nvm** — `install-build-npm-yarn.sh.j2` (react-admin build)

so the distro npm was redundant.

## Note
Unrelated to the recent Vault URL migration — the Vault step resolved to SOPS correctly and succeeded; this apt failure is a pre-existing Debian 13 packaging issue surfaced by deploying to the trixie host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)