### PR TITLE
fix(ci): health-check pop1 on its dashboard domain, not :7691

### DIFF
--- a/.github/workflows/deploy-single-environment.yml
+++ b/.github/workflows/deploy-single-environment.yml
@@ -157,7 +157,11 @@ jobs:
       ssh_user: admin
       connection_mode: ssh_key
       secrets_mode: vault_or_sops
-      health_endpoint: "http://18.133.126.242:7691/healthz"
+      # pop1 is a DASHBOARD-ONLY pop: nginx_default_server_backend is empty,
+      # so no admin block listens on :7691 (unlike lon1, which does). Health-
+      # check the public dashboard domain on 443 instead — valid LE cert,
+      # serves /healthz 200. (cf. acc/pop0 uses https://prod-our-v1…/healthz.)
+      health_endpoint: "https://pop1.diytaxreturn.co.uk/healthz"
       health_check_mode: external
       docker_prune: true
       notify_success: true

--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -494,8 +494,11 @@ jobs:
       # fallback so a broken runner SSH key or an offline Vault can't
       # take the pipeline down.
       secrets_mode: vault_or_sops
-      # IP-based health gate — no dependency on DNS/cert for pop1.diytaxreturn.co.uk
-      health_endpoint: "http://18.133.126.242:7691/healthz"
+      # pop1 is DASHBOARD-ONLY: nginx_default_server_backend is empty, so no
+      # admin block listens on :7691 (lon1 differs — it sets that var, so its
+      # :7691 gate is fine). The old IP:7691 gate could never pass here. Health-
+      # check the public dashboard domain on 443 — valid LE cert, /healthz 200.
+      health_endpoint: "https://pop1.diytaxreturn.co.uk/healthz"
       health_check_mode: external
       docker_prune: true
       notify_success: true


### PR DESCRIPTION
## Why run [28671794479](https://github.com/bwalia/wslproxy/actions/runs/28671794479) failed

The **deploy succeeded** — ansible ran clean (`ok=146 failed=0`), configs deployed (`ok=24 failed=0`), nginx config test passed. It failed only at the **Post-deploy health gate**: 12 external probes of `http://18.133.126.242:7691/healthz` all returned `000`.

**Root cause:** pop1 is a **dashboard-only** pop. Its host_vars set `nginx_default_server_backend: ""` (empty), so the admin/backend server block — the one that `listen`s on `:7691` — is never rendered. Nothing listens on 7691, so the external gate can't connect. The host was healthy throughout: `https://pop1.diytaxreturn.co.uk/healthz` returns **200** with a valid Let's Encrypt cert.

This only affects **pop1**. lon1 (72.62.211.28) sets `nginx_default_server_backend: "lon1.pop0.uk"`, so its `:7691` block exists and `http://72.62.211.28:7691/healthz` → 200 — its gate is correct and left unchanged.

## Fix

Point pop1's `health_endpoint` at its real public endpoint, matching the acc/pop0 pattern (`https://prod-our-v1.wslproxy.com/healthz`):

```diff
- health_endpoint: "http://18.133.126.242:7691/healthz"
+ health_endpoint: "https://pop1.diytaxreturn.co.uk/healthz"
```

Applied in both places that deploy pop1:
- `.github/workflows/deploy-single-environment.yml` (prod job)
- `.github/workflows/deploy-wslproxy-delivery-pipeline.yml` (Stage 5c)

The separate SSH-based "Next.js dashboard health gate" already validates the dashboard + API proxy on pop1 independently; this change makes the external gate check something pop1 actually serves.

### Verification
```
curl --resolve pop1.diytaxreturn.co.uk:443:18.133.126.242 \
     https://pop1.diytaxreturn.co.uk/healthz   → 200 (ssl_verify=0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)