### PR TITLE
fix(ci): repair auto-tag workflow YAML and release action

### DIFF
--- a/.github/workflows/auto-tag-main.yml
+++ b/.github/workflows/auto-tag-main.yml
@@ -126,14 +126,13 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.create_tag.outputs.tag_created == 'true'
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.calc_version.outputs.next_version }}
-          release_name: Release ${{ steps.calc_version.outputs.next_version }}
-          draft: false
-          prerelease: false
+          name: Release ${{ steps.calc_version.outputs.next_version }}
+          generate_release_notes: true
 
       - name: Update system/app.json with new version
         if: steps.create_tag.outputs.tag_created == 'true'
@@ -143,16 +142,12 @@ jobs:
           BUILD_NUMBER=$(date -u +"%Y%m%d%H%M%S")
           DEPLOY_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-          cat > system/app.json <<EOF
-{
-  "name": "wslproxy",
-  "version": {
-    "version": "$VERSION_NUM",
-    "build": "$BUILD_NUMBER",
-    "deployment_timestamp": "$DEPLOY_TIME"
-  }
-}
-EOF
+          jq -n \
+            --arg version "$VERSION_NUM" \
+            --arg build "$BUILD_NUMBER" \
+            --arg deployed "$DEPLOY_TIME" \
+            '{name: "wslproxy", version: {version: $version, build: $build, deployment_timestamp: $deployed}}' \
+            > system/app.json
 
           git add system/app.json
           git commit -m "chore: bump version to $NEXT_VERSION [skip ci]"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -127,17 +127,13 @@ jobs:
           DEPLOY_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           # Store the full release version (e.g., v1.0.16-build.3)
-          cat > system/app.json <<EOF
-{
-  "name": "wslproxy",
-  "version": {
-    "version": "${RELEASE_VERSION#v}",
-    "base_version": "${BASE_VERSION#v}",
-    "build_number": ${BUILD_NUMBER},
-    "deployment_timestamp": "${DEPLOY_TIME}"
-  }
-}
-EOF
+          jq -n \
+            --arg version "${RELEASE_VERSION#v}" \
+            --arg base "${BASE_VERSION#v}" \
+            --argjson build "$BUILD_NUMBER" \
+            --arg deployed "$DEPLOY_TIME" \
+            '{name: "wslproxy", version: {version: $version, base_version: $base, build_number: $build, deployment_timestamp: $deployed}}' \
+            > system/app.json
 
           git add system/app.json
           git commit -m "chore: update version to $RELEASE_VERSION [skip ci]"


### PR DESCRIPTION
## Summary
- Fix invalid YAML in `auto-tag-main.yml` that caused the workflow to fail in 0s with no jobs (unindented heredoc JSON broke the parser).
- Write `system/app.json` via `jq` instead of a shell heredoc.
- Replace deprecated `actions/create-release@v1` with `softprops/action-gh-release@v2`.
- Apply the same heredoc/YAML fix to `release-build.yml`, which had the identical issue.

## Test plan
- [ ] Merge PR and confirm `auto-tag-main.yml` appears in Actions with the correct workflow name (not the file path).
- [ ] Verify the next push to `main` creates a semver tag and GitHub release.
- [ ] Confirm `system/app.json` is updated with the new version commit.


Made with [Cursor](https://cursor.com)