### PR TITLE
fix(ci): don't clobber prod runner SSH key in S3 sync workflow

### DIFF
--- a/.github/workflows/sync-prod-data-to-s3.yml
+++ b/.github/workflows/sync-prod-data-to-s3.yml
@@ -36,11 +36,23 @@ jobs:
 
     steps:
       - name: Setup SSH
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
+          # If a key was passed via secret, materialise it. Otherwise fall
+          # back to the key already provisioned on the prod runner. Do NOT
+          # overwrite the runner's working key with an empty/stale secret —
+          # that clobbers auth and yields "Permission denied (publickey)".
+          if [[ -n "${SSH_PRIVATE_KEY:-}" ]]; then
+            printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+            chmod 600 ~/.ssh/id_rsa
+          fi
+          if [[ ! -f ~/.ssh/id_rsa ]]; then
+            echo "::error::SSH key not found at ~/.ssh/id_rsa and secrets.SSH_PRIVATE_KEY is empty. Set it with: gh secret set SSH_PRIVATE_KEY --repo bwalia/wslproxy < /path/to/deploy-key"
+            exit 1
+          fi
           ssh-keyscan -H ${{ env.PROD_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Test SSH connectivity


### PR DESCRIPTION
## Problem

The scheduled **Sync Prod Data to S3** workflow fails at *Test SSH connectivity* with:

```
root@187.124.112.155: Permission denied (publickey,password).
```

(e.g. [run 28849945865](https://github.com/bwalia/wslproxy/actions/runs/28849945865/job/85562542039))

## Root cause

The `Setup SSH` step unconditionally overwrote the runner's SSH key:

```bash
echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
```

The `prod` self-hosted runner already has a **working key pre-provisioned** at `~/.ssh/id_rsa`. When the `SSH_PRIVATE_KEY` repo secret is empty or stale, this line writes a bad/empty key **over the good one**, so every subsequent SSH/rsync to prod fails with `Permission denied (publickey,password)`.

The canonical `deploy-environment.yml` avoids this by only writing the secret when it's non-empty and otherwise falling back to the runner's existing key.

## Fix

Mirror `deploy-environment.yml`:
- Only materialise `SSH_PRIVATE_KEY` when it's non-empty (via `printf '%s\\n'`).
- Otherwise fall back to the runner's pre-provisioned `~/.ssh/id_rsa`.
- Error clearly if neither is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)