### PR TITLE
fix(gateway): forward client Host + default HTTPS port for host-routed backends

### DIFF
--- a/api/gateway_resp.lua
+++ b/api/gateway_resp.lua
@@ -153,7 +153,12 @@ elseif selectedRule.statusCode == 305 then
         selectedRule.redirectUri = string.sub(selectedRule.redirectUri, 1, slashPos - 1)
     end
     local extracted = nil
-    local extractedPort = 80
+    -- Default upstream port follows the scheme: an https:// backend given
+    -- without an explicit port must go to 443, not 80. Previously this was
+    -- hardcoded to 80, so `redirect_uri: "https://<ip>"` proxied a TLS
+    -- handshake to the origin's :80 (HTTP) entrypoint. An explicit ":port"
+    -- in the redirect_uri still overrides this below.
+    local extractedPort = (origin_serverScheme == "https") and 443 or 80
     -- if not isIpAddress(selectedRule.redirectUri) then
     local continueDnsResolve = true
     if selectedRule.rule_data.isConsul then
@@ -255,13 +260,23 @@ elseif selectedRule.statusCode == 305 then
     end
 
     ngx.var.proxy_host = finalProxyHost
-    -- S3 signed requests need s3.<region>.amazonaws.com as Host header
+    -- Upstream Host header selection (drives `proxy_set_header Host $proxy_host_override`).
     if ngx.ctx.s3_host_override then
+        -- S3 signed requests need s3.<region>.amazonaws.com as Host header
         ngx.var.proxy_host_override = ngx.ctx.s3_host_override
     elseif proxy_server_name ~= nil and proxy_server_name ~= "" then
+        -- Operator explicitly pinned the upstream Host on the server config.
         ngx.var.proxy_host_override = proxy_server_name
     else
-        ngx.var.proxy_host_override = selectedRule.redirectUri
+        -- Default: forward the ORIGINAL client Host (e.g. vault.workstation.co.uk).
+        -- By this point selectedRule.redirectUri has been DNS-resolved to a bare IP
+        -- (see the resolver block above), so using it as the Host header would send
+        -- `Host: <ip>` — which host-routing origins (Traefik/nginx Ingress, matching
+        -- Ingress Host() rules) map to no vhost and answer 404. Forwarding the client's
+        -- own Host makes host-routed HTTPS backends work, stays per-request dynamic (no
+        -- hardcoded hostname, so every served host forwards its own Host), and is
+        -- harmless for backends that ignore Host. `proxy_server_name` still overrides.
+        ngx.var.proxy_host_override = ngx.var.host
     end
 
     -- Upstream backend request headers (forwarded to the backend server)

--- a/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
@@ -890,6 +890,10 @@ server {
           proxy_ssl_session_reuse on;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_ssl_server_name on;
+          # SNI = the same hostname we forward as Host, so host-routed HTTPS
+          # origins (Traefik/nginx Ingress) see a matching SNI + Host. Without
+          # this, proxy_ssl_name defaults to the upstream block name.
+          proxy_ssl_name $proxy_host_override;
 
           # WebSocket support
           proxy_http_version 1.1;
@@ -1120,6 +1124,8 @@ server {
           proxy_ssl_session_reuse on;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_ssl_server_name on;
+          # SNI = the same hostname we forward as Host (see the block above).
+          proxy_ssl_name $proxy_host_override;
 
           chunked_transfer_encoding off;
           proxy_set_header x-route-server $proxy_route_server;

--- a/nginx-dev.conf.tmpl
+++ b/nginx-dev.conf.tmpl
@@ -1347,6 +1347,9 @@ server {
           proxy_ssl_session_reuse on;
           proxy_set_header X-Real-IP $remote_addr;
           proxy_ssl_server_name on;
+          # SNI = the same hostname we forward as Host, so host-routed HTTPS
+          # origins (Traefik/nginx Ingress) see a matching SNI + Host.
+          proxy_ssl_name $proxy_host_override;
 
           # WebSocket support
           proxy_http_version 1.1;


### PR DESCRIPTION
## Symptom

`https://vault.workstation.co.uk/v1/tenants`, `/scim/v2/*`, `/healthz` (and every real path) returned **HTTP 404 "404 page not found"** (Traefik's default-backend) through the PoP, while the same requests succeeded when sent directly to the backend with the correct Host header.

## Root cause — two wrong defaults in the dynamic proxy path

wslproxy routes dynamically in Lua (`gateway_resp.lua` sets `$proxy_host_override` / `$proxy_port`; the template does `proxy_set_header Host $proxy_host_override; proxy_pass $proxy_host_scheme://$upstream_server`). For a rule whose `redirect_uri` is `https://13.42.188.136` (IP, no port):

1. **Host header** defaulted to `selectedRule.redirectUri`, which by that point has been **DNS-resolved to a bare IP**. So the origin received `Host: 13.42.188.136` → matched no Traefik `Host()` router → default 404. SNI does not affect Traefik routing; only the Host header does.
2. **Upstream port** was hardcoded to `80` regardless of scheme, so an `https://` backend sent a TLS handshake to the origin's **:80** (HTTP) entrypoint.

Both had to be fixed to get a 200.

## Fix

- `gateway_resp.lua` — Host fallback now forwards the **original client Host** (`ngx.var.host`): per-request dynamic, no hardcoded hostname, so every served host forwards its own Host. `s3_host_override` and an explicit `proxy_server_name` still take priority.
- `gateway_resp.lua` — default upstream port now **follows the scheme** (443 for https, else 80); an explicit `:port` in `redirect_uri` still overrides.
- `nginx.conf.j2` + `nginx-dev.conf.tmpl` — `proxy_ssl_name $proxy_host_override` so backend **SNI matches the forwarded Host** (was defaulting to the upstream block name). Correctness only — not required for the 200 (`proxy_ssl_verify off`, Traefik routes by Host).

## Verification (on pop0)

```
/v1/tenants        -> 200   (was 404)
/scim/v2/Schemas   -> {"Resources":[{"attributes":[{"caseExact":false,...   (was "404 page not found")
redirect loop      -> redirects=0 final=200
bare root /        -> 404   (by design — no app owns /)
/healthz           -> 200
forwarded upstream -> Host=vault.workstation.co.uk  port=443  scheme=https
```

**No regression:** `int.diytaxreturn.co.uk/` → 307 (unchanged); S3-backed hosts (`cognoai.uk`, `cognoaiuk.com`) → 200 still forwarding `s3.eu-west-2.amazonaws.com`; live HTTP backends → 200 forwarding their own host. The few 502s are backends that are simply down (e.g. `acc.workstation.co.uk` → `127.0.0.1:30511`, not listening) — a 502 is a connection failure, independent of the Host header value.

## Deploy notes

The `gateway_resp.lua` change is already live on pop0 (hot-reloaded: rsync + `openresty -t` + graceful reload); that's what the output above was measured against. The two **template** edits (SNI) apply on the next ansible deploy (`--tags nginx`) and are not yet live (not needed for the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
