### PR TITLE
fix(server-save): harden reboot-flag write path so it can't break API saves

### DIFF
--- a/api/init.lua
+++ b/api/init.lua
@@ -51,6 +51,26 @@ end
 -- Determine storage type at init time (not in callback)
 local use_redis_storage = settings and settings.storage_type == "redis"
 
+-- Actionable operator warning when settings.json still holds the legacy
+-- reboot-flag path.  api/server-conf.lua rewrites LEGACY_REBOOT_FLAG →
+-- DEFAULT_REBOOT_FLAG at call time so this alone doesn't break saves —
+-- but it's a signal that the deployed settings file drifted from the
+-- current default (/tmp/nginx/nginx-reboot-required) and should be
+-- corrected in the source (SOPS / Vault) so future deploys don't keep
+-- re-writing the stale value onto the host.  Prod 2026-07-14 hit this
+-- exact drift and every server-update returned HTTP 400 for weeks
+-- because the older server-conf.lua deployed there didn't have the
+-- rewrite.
+if settings and settings.nginx and settings.nginx.reboot_file_path
+    and settings.nginx.reboot_file_path:sub(1, 14) == "/var/run/nginx" then
+    ngx.log(ngx.WARN,
+        "startup: settings.nginx.reboot_file_path is legacy '",
+        settings.nginx.reboot_file_path,
+        "' — server-conf.lua rewrites this to /tmp/nginx/... at runtime, ",
+        "but update the source (SOPS / Vault) to '/tmp/nginx/nginx-reboot-required' ",
+        "so deploys stop re-writing the stale value onto the host")
+end
+
 -- Export IP2Location path as global variable for use in log_handler
 -- and geo_lookup.  This is loaded at init time when file I/O is
 -- allowed.

--- a/api/server-conf.lua
+++ b/api/server-conf.lua
@@ -36,6 +36,28 @@ function Conf.compareFiles(sourceFile, destinationFile)
     end
 end
 
+-- The reboot flag is an optional signal for the cron watcher
+-- (nginx_restart_if_required.sh.j2) that a config change wants a
+-- reload.  Routing (rules + server JSON) is already live per-request
+-- via the gateway lua chain, so a failure to write this file MUST NOT
+-- block the API save — it only delays the reload.
+--
+-- History: the flag originally lived at /var/run/nginx/... but that
+-- directory is root-owned tmpfs on modern Debian/systemd — the
+-- www-data openresty worker can't create files there without a chmod.
+-- A pre-2026-07 CreateNginxFlag threw HTTP 400 into the API response
+-- on this write failure, breaking every server-update on prod for
+-- weeks.  Two mitigations layered so the class-of-bug can't return:
+--
+--   1. CreateNginxFlag below silently REWRITES the legacy path to the
+--      /tmp default before io.open, and treats any remaining write
+--      failure as a non-fatal WARN (never propagates to the caller).
+--   2. fix-permissions.sh.j2 relaxes /var/run/nginx to mode 775 as
+--      belt-and-braces — even a hypothetical direct-io caller that
+--      skipped the rewrite would still succeed.
+--
+-- init.lua also emits a WARN at startup if settings.reboot_file_path
+-- is still the legacy value so operators notice the source drift.
 local DEFAULT_REBOOT_FLAG = "/tmp/nginx/nginx-reboot-required"
 local LEGACY_REBOOT_FLAG = "/var/run/nginx/nginx-reboot-required"
 

--- a/infra/ansible/roles/wslproxy/templates/fix-permissions.sh.j2
+++ b/infra/ansible/roles/wslproxy/templates/fix-permissions.sh.j2
@@ -2,10 +2,21 @@
 
 set -x
 
+  # /var/run/nginx historically hosted the reboot flag
+  # (/var/run/nginx/nginx-reboot-required).  The canonical path moved to
+  # /tmp/nginx/... in api/server-conf.lua (LEGACY_REBOOT_FLAG →
+  # DEFAULT_REBOOT_FLAG rewrite), but any host whose settings.json still
+  # points at the legacy path — or any future caller that bypasses the
+  # rewrite — will attempt to create /var/run/nginx/... as the www-data
+  # worker.  Mode 755 blocks that with EACCES, which the old api/server-
+  # conf.lua then surfaced into the API response body as HTTP 400 on
+  # every server-edit.  775 keeps the dir root-owned but writable by the
+  # www-data group — belt-and-braces so a marker-write can never fail
+  # even if the /tmp rewrite is somehow skipped.
   mkdir -p "/var/run/nginx/" \
     && chmod +x "/var/run/nginx/" \
     && chown www-data:root "/var/run/nginx/" \
-    && chmod 755 -R "/var/run/nginx/"
+    && chmod 775 -R "/var/run/nginx/"
 
 mkdir -p "/tmp/nginx/" \
     && chmod +x "/tmp/nginx/" \


### PR DESCRIPTION
## Why

`PUT /api/servers/:id` returned HTTP 400 with body

```
"/var/run/nginx/nginx-reboot-required: Permission denied while creating
 /var/run/nginx/nginx-reboot-required"
```

on `prod-our.wslproxy.com` for weeks, breaking the admin UI's edit flow for every vhost. Fixed live on prod today (2026-07-14) by direct edit; **this PR closes the loop against future regressions.**

## Root cause on prod

Three layers of drift stacked:

- Deployed `api/server-conf.lua` was the pre-2026-07 naive `CreateNginxFlag` that did `ngx.exit(HTTP_BAD_REQUEST)` on write failure.
- Deployed `data/settings.json` still had `nginx.reboot_file_path = /var/run/nginx/nginx-reboot-required`.
- `/var/run/nginx` was mode `0755 root:www-data` — worker (www-data) couldn't create new files there.

`main` already had the graceful `CreateNginxFlag` (rewrites legacy→/tmp, non-fatal WARN) and `api.lua` already had **zero** `CreateNginxFlag` callers. Prod just hadn't caught up.

## What this PR adds (defence-in-depth × 3)

| Layer | File | What |
|---|---|---|
| **1. Runtime warn** | [api/init.lua](api/init.lua) | Startup `ngx.log(ngx.WARN, …)` when `settings.nginx.reboot_file_path` still starts with `/var/run/nginx`. Non-fatal, actionable — tells the operator the source (SOPS/Vault) drifted from the current default. |
| **2. Docs** | [api/server-conf.lua](api/server-conf.lua) | Full history block on the `DEFAULT_REBOOT_FLAG`/`LEGACY_REBOOT_FLAG` constants — what went wrong, why the rewrite + WARN exist, where the other mitigations live. Prevents a future refactor from accidentally re-throwing the failure. |
| **3. Filesystem** | [infra/ansible/.../fix-permissions.sh.j2](infra/ansible/roles/wslproxy/templates/fix-permissions.sh.j2) | `/var/run/nginx` now mode `0775` (was `0755`). Belt-and-braces: even a hypothetical direct-io caller that bypassed the LEGACY→DEFAULT rewrite would succeed because www-data-group can create files. Dir stays root-owned. |

## Deliberately NOT in this PR

- **No changes to `CreateNginxFlag` call sites** — main has zero callers. The function stays as a safe primitive for future callers (WAF policy save, upstream save, etc.).
- **No `data/sample-settings.json` change** — main already ships the `/tmp` path.
- **No SOPS edits** — each env's operator needs to `sops edit infra/secrets/<env>/settings.sops.json` locally. Not urgent (runtime rewrite handles it) but cleaner.
- **The SSL wire-up bug on prod (int.workstation.academy not getting its `data/ssl/*.json` despite api.lua's `SslManager.store_ssl_config` call) is out of scope** — separate bug, deserves its own PR after reproduction.

## Answer to "will this also fix the SSL issue?"

**Indirectly yes for the happy path, but not the root cause.**

- **With the fix**: server saves succeed → reboot flag written → cron reloads → workers restart → `ssl_init.reconcile_disk_ssl_configs()` runs → creates missing `data/ssl/<domain>.json` for any `ssl_enabled=true` server → auto-ssl allows → LE cert issued.
- **Without the fix**: save throws 400 → no reboot flag → no reload → no reconciliation → SSL fallback cert forever.

But the SSL wire-up still has a race window (~1min cron interval) and edge cases (server saved without `config_status: true` skips the flag entirely). A proper fix would create `data/ssl/*.json` and populate `ngx.shared.ssl_domains` **inline** on server save. Main's `api.lua:1467` calls `SslManager.store_ssl_config()` which *should* do this — but on prod today it didn't for `int.workstation.academy`. Worth a follow-up PR to reproduce and root-cause.

## Verification

- [x] `luac -p api/init.lua` clean
- [x] `luac -p api/server-conf.lua` clean
- [x] `bash -n` clean on `fix-permissions.sh.j2` after Jinja-token stub
- [x] Prod already carries the runtime fix via direct edit (2026-07-14). 5 server-update round-trips + 3 vhost regression probes green. Backups on host: `server-conf.lua.bak.20260714-105718`, `settings.json.bak.20260714-105718`
- [ ] After merge → next `code` deploy will rsync main's `api/` onto every host, permanently closing the drift on int/test/prod/pop1

🤖 Generated with [Claude Code](https://claude.com/claude-code)