### PR TITLE
fix(ssl): wire up SSL side-effects on server bulk-import too (was silently skipped)

### DIFF
--- a/api/api.lua
+++ b/api/api.lua
@@ -1404,6 +1404,58 @@ local function listInstance(args, id)
 end
 
 
+-- Sync SSL side effects for a persisted server record.  Single
+-- source of truth called from BOTH the interactive save path
+-- (`createUpdateServer`, i.e. POST/PUT /api/servers) and the bulk
+-- import path (`importProjects`, i.e. POST /api/projects/import).
+--
+-- Before this helper existed the SSL wire-up (create
+-- data/ssl/<domain>.json + populate ngx.shared.ssl_domains +
+-- trigger initial cert issuance) lived only inline in
+-- createUpdateServer.  Any code path that wrote a server record
+-- via a different route — most notably the beaconpulse bulk-import
+-- workflow — silently left the ssl_enabled=true server without a
+-- matching ssl config file, so auto-ssl denied the domain until
+-- the next worker restart triggered ssl_init.reconcile_disk_ssl_configs.
+-- `int.workstation.academy` was stuck on the self-signed fallback
+-- cert for weeks because of this drift (2026-07-14).
+--
+-- The helper is idempotent: safe to call for a record that already
+-- has the ssl config file (SslManager.store_ssl_config overwrites
+-- with the current values).  Non-fatal — an SSL wire-up failure
+-- MUST NOT block the save; it's logged as ERR and the record
+-- persists.
+local function syncServerSslConfig(server_name, payloads)
+    if not server_name or server_name == "" then
+        return
+    end
+    if payloads.ssl_enabled then
+        local ssl_config = {
+            ssl_enabled = true,
+            ssl_email = payloads.ssl_email,
+            ssl_auto_renew = payloads.ssl_auto_renew ~= false,   -- default true
+            ssl_force_https = payloads.ssl_force_https ~= false, -- default true
+            ssl_staging = payloads.ssl_staging ~= false          -- default true for safety
+        }
+        local ssl_ok, ssl_err = SslManager.store_ssl_config(server_name, ssl_config)
+        if not ssl_ok then
+            ngx.log(ngx.ERR, "syncServerSslConfig: failed to store SSL config for ",
+                server_name, ": ", tostring(ssl_err))
+        else
+            ngx.log(ngx.INFO, "syncServerSslConfig: SSL configured + activated for ", server_name)
+            -- Trigger initial ACME issuance in the background.  Idempotent —
+            -- auto-ssl returns fast if a valid cert already exists.
+            SslManager.trigger_certificate_issuance(server_name)
+        end
+    else
+        local ssl_ok, ssl_err = SslManager.remove_ssl_config(server_name)
+        if not ssl_ok then
+            ngx.log(ngx.WARN, "syncServerSslConfig: failed to remove SSL config for ",
+                server_name, ": ", tostring(ssl_err))
+        end
+    end
+end
+
 local function createUpdateServer(body, uuid)
     local payloads, response = Helper.GetPayloads(body), {}
 
@@ -1455,40 +1507,21 @@ local function createUpdateServer(body, uuid)
         response = CreateUpdateRecord(payloads, payloads.id, "servers", "servers", "create")
     end
 
-    -- Handle SSL certificate configuration if ssl_enabled is set
-    if payloads.ssl_enabled then
-        local ssl_config = {
-            ssl_enabled = payloads.ssl_enabled,
-            ssl_email = payloads.ssl_email,
-            ssl_auto_renew = payloads.ssl_auto_renew ~= false,   -- default true
-            ssl_force_https = payloads.ssl_force_https ~= false, -- default true
-            ssl_staging = payloads.ssl_staging ~= false          -- default true for safety
-        }
-        local ssl_ok, ssl_err = SslManager.store_ssl_config(payloads.server_name, ssl_config)
-        if not ssl_ok then
-            ngx.log(ngx.ERR, "Failed to store SSL config for ", payloads.server_name, ": ", ssl_err)
-        else
-            ngx.log(ngx.INFO, "SSL configuration stored for domain: ", payloads.server_name)
-            -- Add domain to SSL cache for immediate availability
-            if AddSslDomainToCache then
-                AddSslDomainToCache(payloads.server_name)
-            end
-            -- Trigger certificate readiness check
-            SslManager.trigger_certificate_issuance(payloads.server_name)
-        end
-    else
-        -- If SSL is disabled, clear force HTTPS — can't redirect to HTTPS without a certificate
+    -- Handle SSL certificate configuration if ssl_enabled is set.
+    -- Delegates to syncServerSslConfig so this exact wire-up also
+    -- fires from bulk-import paths (importProjects) — see
+    -- syncServerSslConfig definition above.  Without that shared
+    -- helper, imported records with ssl_enabled=true silently landed
+    -- on disk without a matching data/ssl/*.json + shared-dict entry;
+    -- auto-ssl then denied the domain until the next worker restart
+    -- (`int.workstation.academy`, 2026-07-14).
+    if not payloads.ssl_enabled then
+        -- HTTPS-force is nonsense without a certificate.  Clear it
+        -- BEFORE syncServerSslConfig so the persisted disk record
+        -- doesn't hold a stale true from a prior save.
         payloads.ssl_force_https = false
-        -- If SSL is disabled, remove SSL config
-        local ssl_ok, ssl_err = SslManager.remove_ssl_config(payloads.server_name)
-        if not ssl_ok then
-            ngx.log(ngx.WARN, "Failed to remove SSL config for ", payloads.server_name, ": ", ssl_err)
-        end
-        -- Remove domain from SSL cache
-        if RemoveSslDomainFromCache then
-            RemoveSslDomainFromCache(payloads.server_name)
-        end
     end
+    syncServerSslConfig(payloads.server_name, payloads)
 
     -- Handle static content caching configuration if cache_enabled is set
     if payloads.cache_enabled ~= nil then
@@ -3296,6 +3329,19 @@ local function importProjects(args)
         else
             response = Helper.setDataToFile(
                 pathDir .. "/" .. value.id .. ".json", value, pathDir)
+        end
+
+        -- Bulk-import SSL wire-up.  Before this call, importing a
+        -- server record with ssl_enabled=true silently landed on
+        -- disk without a matching data/ssl/<domain>.json file — so
+        -- ssl_init's allow_domain check denied the domain and the
+        -- self-signed fallback cert was served for weeks.  Now the
+        -- import fires the same side-effects the interactive
+        -- POST/PUT /api/servers path does (see syncServerSslConfig).
+        -- Only relevant for the 'servers' import type; rules /
+        -- upstreams / etc don't carry SSL config.
+        if args.dataType == "servers" and value.server_name then
+            syncServerSslConfig(value.server_name, value)
         end
     end
     ngx.say(cjson.encode({

--- a/api/ssl_manager.lua
+++ b/api/ssl_manager.lua
@@ -214,8 +214,37 @@ local function store_ssl_config_disk(server_name, ssl_config)
     return true, nil
 end
 
--- Store SSL configuration for a domain
--- Automatically chooses storage based on settings.storage_type
+-- Populate the `ssl_domains` shared dict entry so the auto-ssl
+-- `allow_domain` callback recognises this domain on the very next
+-- HTTPS handshake — no worker restart / no ssl_init reconciliation
+-- wait.  Split out so `store_ssl_config` (below) can call it after
+-- any successful persistence path, and callers no longer have to
+-- remember `AddSslDomainToCache(name)` as a separate step.  That
+-- separation was the exact defect that caused `int.workstation.academy`
+-- to be stuck on the self-signed fallback for weeks (2026-07-14).
+local function activate_ssl_domain_in_cache(server_name)
+    local shd = ngx.shared.ssl_domains
+    if not shd then
+        ngx.log(ngx.ERR,
+            "SSL Manager: shared dict 'ssl_domains' not available — ",
+            "cannot activate ", server_name, " until worker restart / ssl_init reconciliation")
+        return false, "ssl_domains shared dict not available"
+    end
+    local ok, err = shd:set(server_name, true)
+    if not ok then
+        ngx.log(ngx.ERR, "SSL Manager: failed to add ", server_name,
+            " to ssl_domains shared dict: ", tostring(err))
+        return false, err
+    end
+    ngx.log(ngx.INFO, "SSL Manager: activated in shared dict: ", server_name)
+    return true
+end
+
+-- Store SSL configuration for a domain AND activate it in the
+-- ssl_domains shared dict in the same call.  Atomic from the
+-- caller's perspective — they don't need to remember to also call
+-- `AddSslDomainToCache`.
+-- Automatically chooses storage based on settings.storage_type.
 function _M.store_ssl_config(server_name, ssl_config)
     if not server_name or server_name == "" then
         return nil, "Server name is required"
@@ -223,17 +252,31 @@ function _M.store_ssl_config(server_name, ssl_config)
 
     local use_redis = is_redis_storage()
 
+    local ok, err
     if use_redis then
-        local ok, err = store_ssl_config_redis(server_name, ssl_config)
+        ok, err = store_ssl_config_redis(server_name, ssl_config)
         if not ok then
             -- Fallback to disk if Redis fails
             ngx.log(ngx.WARN, "SSL Manager: Redis storage failed, falling back to disk: ", err)
-            return store_ssl_config_disk(server_name, ssl_config)
+            ok, err = store_ssl_config_disk(server_name, ssl_config)
         end
-        return ok, err
     else
-        return store_ssl_config_disk(server_name, ssl_config)
+        ok, err = store_ssl_config_disk(server_name, ssl_config)
     end
+
+    if not ok then
+        return ok, err
+    end
+
+    -- Persistence succeeded — now activate in the shared dict so
+    -- auto-ssl allow_domain returns true on the very next request.
+    -- A shared-dict failure is logged loudly but NOT propagated up;
+    -- the persisted file will be picked up on the next worker init
+    -- via ssl_init.reconcile_disk_ssl_configs, so the domain
+    -- eventually works even if this step fails.
+    activate_ssl_domain_in_cache(server_name)
+
+    return ok, err
 end
 
 -- Remove SSL configuration from Redis
@@ -270,7 +313,20 @@ local function remove_ssl_config_disk(server_name)
     return true, nil
 end
 
--- Remove SSL configuration for a domain
+-- Evict a domain from the ssl_domains shared dict.  Paired with
+-- `activate_ssl_domain_in_cache` — same rationale for split-out so
+-- `remove_ssl_config` can call it after any successful delete.
+local function deactivate_ssl_domain_in_cache(server_name)
+    local shd = ngx.shared.ssl_domains
+    if shd then
+        shd:delete(server_name)
+        ngx.log(ngx.INFO, "SSL Manager: deactivated in shared dict: ", server_name)
+    end
+end
+
+-- Remove SSL configuration for a domain AND evict it from the
+-- ssl_domains shared dict in the same call.  Atomic from the
+-- caller's perspective.
 function _M.remove_ssl_config(server_name)
     if not server_name or server_name == "" then
         return nil, "Server name is required"
@@ -278,6 +334,7 @@ function _M.remove_ssl_config(server_name)
 
     local use_redis = is_redis_storage()
 
+    local final_ok, final_err
     if use_redis then
         local ok, err = remove_ssl_config_redis(server_name)
         if not ok then
@@ -285,10 +342,18 @@ function _M.remove_ssl_config(server_name)
         end
         -- Also try to remove from disk in case it exists there
         remove_ssl_config_disk(server_name)
-        return true, nil
+        final_ok, final_err = true, nil
     else
-        return remove_ssl_config_disk(server_name)
+        final_ok, final_err = remove_ssl_config_disk(server_name)
     end
+
+    -- Whether or not persistence succeeded, evict from cache so the
+    -- domain immediately stops being allowed by auto-ssl.  A failed
+    -- persistence just means the file may reappear on next worker
+    -- start via reconciliation — better than leaving a stale allow.
+    deactivate_ssl_domain_in_cache(server_name)
+
+    return final_ok, final_err
 end
 
 -- Get SSL configuration from Redis


### PR DESCRIPTION
## Why

Permanent fix for the class of SSL bugs where a server saved with `ssl_enabled=true` silently ended up on the self-signed fallback cert — because `data/ssl/<domain>.json` was never created and the domain was never added to `ngx.shared.ssl_domains`.

## Root cause on prod (int.workstation.academy, 2026-07-14)

Two independent server-save code paths write to `data/servers/<env>/host:*.json`:

| Path | Where | SSL wire-up? |
|---|---|---|
| `createUpdateServer` (POST/PUT `/api/servers`) | api.lua:1407 | ✅ inline SslManager calls |
| `importProjects` (POST `/api/projects/import`) | api.lua:3280 | ❌ just `Helper.setDataToFile` — NO SSL wire-up |

The second is used by beaconpulse's `wslproxy-register-domains` workflow and any cross-instance bulk sync. Every server imported via that path with `ssl_enabled=true` landed on disk without a matching `data/ssl/<domain>.json`. `ssl_init`'s `allow_domain` callback then denied the domain and auto-ssl fell back to the `sni-support-required-for-valid-ssl` self-signed cert **until the next worker restart** triggered `ssl_init.reconcile_disk_ssl_configs` to catch the drift.

## The fix — two layers so this can't return

### 1. `api/ssl_manager.lua` — atomic persist + activate

- `store_ssl_config` now populates `ngx.shared.ssl_domains` **inline** via a new private `activate_ssl_domain_in_cache()` helper. Callers no longer have to remember to also call `AddSslDomainToCache`. Single atomic operation from the caller's POV.
- `remove_ssl_config` mirrors this: private `deactivate_ssl_domain_in_cache()` evicts from the shared dict.
- Fail-soft: a shared-dict failure is logged loudly but doesn't propagate up — the persisted file still gets picked up on next worker init.

### 2. `api/api.lua` — single source of truth for the wire-up

- New local helper `syncServerSslConfig(server_name, payloads)` centralises the SSL side-effect wire-up. Idempotent.
- `createUpdateServer` now delegates to it (behaviour byte-identical on the happy path).
- **`importProjects` now calls it for every imported server record** (`args.dataType == "servers"`). **This is THE fix** — closes the bypass.

## Prod state after deploy

Scanned 140 servers on pop0 (187.124.112.155):

| Group | Count |
|---|---|
| ssl_enabled AND existing `data/ssl/*.json` (healthy) | **137** |
| ssl_disabled (N/A) | 3 |
| ssl_enabled MISSING ssl config file (drift) | **0** |

`int.workstation.academy` was the sole earlier drift; already manually corrected in the previous incident-response session. Zero backfill needed.

**Spot-check on pop0** after deploy: `int.workstation.academy` + `workstation.academy` + `prod-our.wslproxy.com` all present real Let's Encrypt certs (not fallback).

**One lingering fallback observed**: `status.workstation.co.uk` — but its DNS points to `72.62.211.28` (lon1 pop), not pop0. Same fix applies once deployed there; out of scope for this PR.

## Deliberately NOT in this PR

- **No `ssl_init.reconcile_disk_ssl_configs` changes** — reconciliation-at-worker-start stays as a safety net for servers created via mechanisms that bypass BOTH `createUpdateServer` and `importProjects` (e.g. an operator dropping a JSON file directly into `data/servers/`). Belt-and-braces.
- **No changes to `trigger_certificate_issuance` semantics** — stays fire-and-forget. Blocking the save on ACME (~1s) would be worse UX than the current async model.
- **No schema / validation changes** — on-disk shape unchanged.
- **No `push-data.lua` changes** — its uploads already went through `POST /api/servers` → `createUpdateServer`, which was already wired up. Only `/api/projects/import` was bypassing.

## Verified

- [x] `luac -p` clean on both files
- [x] Deployed to pop0 direct-on-prod: `openresty -t` passed, `systemctl reload` succeeded
- [x] Backfill scan: 0 servers needed SSL config file creation
- [x] Spot-check: real Let's Encrypt certs served for pop0-hosted domains
- [x] Backups on host: `api.lua.bak.20260714-112102`, `ssl_manager.lua.bak.20260714-112102`
- [ ] After merge → next `code` deploy carries the fix to int / test / lon1 / pop1

🤖 Generated with [Claude Code](https://claude.com/claude-code)