### PR TITLE
fix(ci): drop failing app.json bump from auto-tag (main is protected + step is redundant)

### DIFF
--- a/.github/workflows/auto-tag-main.yml
+++ b/.github/workflows/auto-tag-main.yml
@@ -168,24 +168,23 @@ jobs:
           name: Release ${{ steps.calc_version.outputs.next_version }}
           generate_release_notes: true
 
-      - name: Update system/app.json with new version
-        if: steps.create_tag.outputs.tag_created == 'true'
-        run: |
-          NEXT_VERSION="${{ steps.calc_version.outputs.next_version }}"
-          VERSION_NUM="${NEXT_VERSION#v}"
-          BUILD_NUMBER=$(date -u +"%Y%m%d%H%M%S")
-          DEPLOY_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-          jq -n \
-            --arg version "$VERSION_NUM" \
-            --arg build "$BUILD_NUMBER" \
-            --arg deployed "$DEPLOY_TIME" \
-            '{name: "wslproxy", version: {version: $version, build: $build, deployment_timestamp: $deployed}}' \
-            > system/app.json
-
-          git add system/app.json
-          git commit -m "chore: bump version to $NEXT_VERSION [skip ci]"
-          git push origin main
+      # NOTE: an earlier version of this workflow ALSO wrote the new
+      # version back to system/app.json and committed to main.  That
+      # step was removed 2026-07-14 because:
+      #   1. It failed on every run — main is a protected branch and
+      #      GH006 rejects direct pushes: "Changes must be made
+      #      through a pull request."  Run 29332617331 was the
+      #      trigger.
+      #   2. It became redundant when PR #1126 taught
+      #      deploy-environment.yml to resolve the version from
+      #      `git describe --tags --abbrev=0` FIRST, with
+      #      system/app.json only as a fallback.  The freshly-pushed
+      #      tag IS the source of truth from the moment this workflow
+      #      finishes; the on-disk app.json is never consulted
+      #      when a tag is reachable from HEAD.
+      # If a future need arises for a tracked file that mirrors the
+      # tag (e.g. a docs badge), do it via a PR-emitting bot rather
+      # than a direct push; direct pushes to main are policy-blocked.
 
       - name: Notify Slack on new release
         if: steps.create_tag.outputs.tag_created == 'true'


### PR DESCRIPTION
## The failure

Run [29332617331](https://github.com/bwalia/wslproxy/actions/runs/29332617331) — the auto-tag workflow that finally started producing tags after PR #1153 — failed on the "Update system/app.json with new version" step:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

Same rejection has fired on every merge to main since PR #1153 landed. The **tag creation and GitHub Release both succeeded** — `v1.0.2` (12:25 UTC) and `v1.0.3` (12:28 UTC) are live. Only the app.json commit step failed.

## Fix — remove the step

Direct pushes to main are policy-blocked by branch protection. Working around that would need a PAT with bypass permissions or a PR-emitting bot — both more machinery than the bump is worth. So drop the step entirely, for two reasons:

1. **Branch protection isn't going anywhere.** It's load-bearing (audit trail + CI signals via PR checks).
2. **The bump is redundant.** Since PR #1126 (merged 2026-07-02) the deploy pipeline reads the version from `git describe --tags --abbrev=0` **first**, with `system/app.json` only consulted as fallback for repo states with no reachable tag. The freshly-pushed tag IS the source of truth from the moment this workflow finishes.

So the bump was writing a value the deploy pipeline was going to ignore anyway.

## After this merges

- ✅ No more red X on every merge to main
- ✅ Cleaner git history (no self-modifying `chore: bump version to vX.Y.Z` commits)
- ✅ No more workflow re-fire from the auto-bump commit landing on main
- ✅ Tag + Release still get created on every merge (unchanged)
- ✅ Slack notification still fires (unchanged)

## Deliberately NOT in this PR

- **Not re-enabling direct pushes to main.** The protection is the right default.
- **Not adding a PR-emitting bot to replace the direct push.** If a future need arises for a tracked file that mirrors the tag (e.g. a docs badge), that machinery makes sense — but the version doesn't need it because the deploy pipeline already reads `git describe`.
- **Not removing `system/app.json` entirely.** It's a valid legacy fallback for branches / forks with no reachable tag; harmless to keep even if it's slightly stale.

## Verified

- [x] YAML parses clean
- [x] 7 steps remain (was 8): Checkout / Configure Git / Get latest tag / Calculate next version / Create and push tag / Create GitHub Release / Notify Slack
- [x] Tag + Release steps unchanged — next push to main creates `v1.0.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)