### PR TITLE
fix(ansible): stop `killall nginx` from restarting k3s container nginx

### DIFF
--- a/infra/ansible/roles/wslproxy/tasks/finalize.yml
+++ b/infra/ansible/roles/wslproxy/tasks/finalize.yml
@@ -224,8 +224,19 @@
   ignore_errors: true
   tags: [nginx, code, dashboard, servers]
 
-- name: Kill any stale nginx processes
-  shell: killall nginx 2>/dev/null || true
+# A bare `killall nginx` matches every process named "nginx" in the HOST pid
+# namespace — which on a k3s node includes the nginx masters running inside
+# containers (longhorn-ui, beacon-nginx, any ingress/app pod built on nginx).
+# They take the SIGTERM, exit 0 ("Completed"), and kubelet restarts them, so a
+# nightly deploy silently racked up a restart per pod per night on whichever
+# node hosts this runner. Scope the kill to host processes by skipping anything
+# whose cgroup says it belongs to a container runtime.
+- name: Kill any stale host nginx processes (never container nginx)
+  shell: |
+    for pid in $(pgrep -x nginx 2>/dev/null || true); do
+      grep -qE 'kubepods|containerd|docker|libpod|crio' "/proc/$pid/cgroup" 2>/dev/null && continue
+      kill -TERM "$pid" 2>/dev/null || true
+    done
   changed_when: false
   tags: [nginx, code, dashboard, servers]
 


### PR DESCRIPTION
## Problem

`roles/wslproxy/tasks/finalize.yml` stops OpenResty and then reaps stale masters with:

```yaml
- name: Kill any stale nginx processes
  shell: killall nginx 2>/dev/null || true
```

`killall` matches by process name across the **host** PID namespace. On `debworker00` — a k3s worker that also hosts the wslproxy self-hosted runner — that name matches the nginx masters running *inside containers*:

| cgroup | nginx processes |
|---|---|
| `kubepods.slice` (containers) | **41** |
| `system.slice/openresty.service` (intended target) | 3 |

Those 41 take the SIGTERM, shut down gracefully (**exit 0 / `Completed`**), and kubelet restarts them in place.

## Evidence

Every nginx-based pod on that node terminated at the *identical second*, `2026-07-20T05:54:35Z`, with `exit 0`:

```
RST NS               POD                            EXIT REASON      LAST-FINISHED
 11 longhorn-system  longhorn-ui-887d56cd8-bfctf       0 Completed   2026-07-20T05:54:35Z
  9 int              beacon-nginx-f895f886-8xf26       0 Completed   2026-07-20T05:54:35Z
  1 test             beacon-nginx-5fff777449-lzwcs     0 Completed   2026-07-20T05:54:35Z
  1 acc              beacon-nginx-6976976d7d-f2jcm     0 Completed   2026-07-20T05:54:35Z
```

`openresty.service` reports `ActiveEnterTimestamp=Mon 2026-07-20 06:54:42 BST` — the deploy's stop → `killall` → `pause: 2` → start sequence, lining up exactly with the kill.

Ruled out as causes: no kernel OOM (`journalctl -k` clean), no reboot (20d uptime, single boot), no k3s/containerd restart (`NRestarts=0`), and no resource pressure (node at 31% CPU / 3% memory requests with 100 GiB available; `longhorn-ui` sets no requests or limits at all — QoS `BestEffort`).

Control: the second `longhorn-ui` replica, on `debian002` which does not host the runner, has **0 restarts over 11 days**.

## Fix

Skip any pid whose cgroup indicates a container runtime, preserving the task's original intent for genuinely stale host masters.

## Verification

Dry-run of the new selection on `debworker00`:

```
WOULD-KILL pid=800550  cgroup=0::/system.slice/openresty.service
WOULD-KILL pid=1133786 cgroup=0::/system.slice/openresty.service
WOULD-KILL pid=1133787 cgroup=0::/system.slice/openresty.service
---
WOULD KILL: 3   WOULD SKIP (container): 41
```

Selects exactly the intended host processes, spares every container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)