### PR TITLE
chore: add WSL Proxy POP migration skill

### DIFF
--- a/.claude/skills/wslproxy-pop-migrate/SKILL.md
+++ b/.claude/skills/wslproxy-pop-migrate/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: wslproxy-pop-migrate
+description: >-
+  Migrate WSL Proxy servers, rules, and SSL allow-list files between POPs
+  (source → target) without overwriting existing files. Use when the user
+  asks to migrate/sync POP data, copy servers/rules between hosts, move
+  domains from pop0 to pop1, or fix missing SSL after a POP migration.
+disable-model-invocation: true
+---
+
+# WSL Proxy POP data migration
+
+Migrate live gateway data from a **Source POP** to a **Target POP** so routing
+and Let's Encrypt auto-ssl work on the target. OpenResty routes from JSON on
+disk at request time — no `nginx -t` / reboot is required for servers+rules.
+
+## Inputs (ask if missing)
+
+| Input | Example |
+|-------|---------|
+| Source SSH | `root@187.124.112.155` (pop0) |
+| Target SSH | `admin@18.133.126.242` (pop1) |
+| Remote data root | `/opt/nginx/data` (default) |
+| Local work dirs | `Source POP/`, `Target POP/` under repo root |
+
+## Required trees (never skip)
+
+Copy **all three** or SSL will not issue:
+
+| Tree | Purpose |
+|------|---------|
+| `servers/` | Host records (`host:<domain>.json` + staged `conf/`) |
+| `rules/` | Routing rules |
+| **`ssl/`** | Auto-ssl allow-list (`<domain>.json`). **Missing this → `domain not allowed - using fallback`** |
+
+Optional (only if user asks): `varnish/`, `upstreams/`, `waf_policies/`, `waf_rules/`.
+
+**Never** copy `settings.json` / `.env` between POPs — those are host-specific secrets and `env_profile`.
+
+## Hard rules
+
+1. **Do not overwrite** files that already exist on Target (`rsync --ignore-existing` or skip-if-exists).
+2. **Always include `ssl/`** with servers+rules.
+3. After installing new `ssl/*.json`, **`sudo systemctl reload openresty`** on Target — `ssl_domains` shared dict only refreshes at worker start.
+4. Fix ownership to `www-data:root` after copy.
+5. Do not commit live dumps; keep them gitignored (`Source POP/`, `Target POP/`, `Migration-to-copy/`).
+
+## Workflow
+
+Prefer the script (low freedom / consistent):
+
+```bash
+# From repo:
+.cursor/skills/wslproxy-pop-migrate/scripts/migrate-pop-data.sh \
+  --source root@187.124.112.155 \
+  --target admin@18.133.126.242 \
+  --reload
+
+# Same script also lives at:
+#   .claude/skills/wslproxy-pop-migrate/scripts/migrate-pop-data.sh
+```
+
+Or follow the manual steps below.
+
+### 1. Probe SSH + layout
+
+```bash
+ssh -o BatchMode=yes "$SOURCE" 'hostname; ls /opt/nginx/data/; du -sh /opt/nginx/data/{servers,rules,ssl}'
+ssh -o BatchMode=yes "$TARGET" 'hostname; ls /opt/nginx/data/; du -sh /opt/nginx/data/{servers,rules,ssl}'
+```
+
+### 2. Download full data trees locally
+
+```bash
+mkdir -p "Source POP" "Target POP"
+rsync -avz -e "ssh -o BatchMode=yes" "$SOURCE:/opt/nginx/data/" "Source POP/"
+rsync -avz -e "ssh -o BatchMode=yes" "$TARGET:/opt/nginx/data/" "Target POP/"
+# rsync exit 23 on Target is OK if settings.json is unreadable; servers/rules/ssl must succeed
+```
+
+### 3. Stage only missing files
+
+For each of `servers`, `rules`, `ssl`:
+
+- Walk Source files
+- If the same relative path exists under Target → **skip**
+- Else copy into `Migration-to-copy/<tree>/...`
+
+### 4. Push to Target
+
+**servers / rules** — often world-writable:
+
+```bash
+rsync -avz --ignore-existing -e "ssh -o BatchMode=yes" \
+  Migration-to-copy/servers/ "$TARGET:/opt/nginx/data/servers/"
+rsync -avz --ignore-existing -e "ssh -o BatchMode=yes" \
+  Migration-to-copy/rules/ "$TARGET:/opt/nginx/data/rules/"
+```
+
+**ssl/** — often `www-data`-only (admin rsync fails with Permission denied). Stage to `/tmp` then sudo-install:
+
+```bash
+rsync -avz -e "ssh -o BatchMode=yes" Migration-to-copy/ssl/ "$TARGET:/tmp/ssl-migrate/"
+ssh "$TARGET" 'bash -s' <<'EOF'
+SRC=/tmp/ssl-migrate; DEST=/opt/nginx/data/ssl
+for f in "$SRC"/*.json; do
+  base=$(basename "$f")
+  [ -e "$DEST/$base" ] && continue
+  sudo cp "$f" "$DEST/$base"
+  sudo chown www-data:root "$DEST/$base"
+  sudo chmod 664 "$DEST/$base"
+done
+rm -rf /tmp/ssl-migrate
+EOF
+```
+
+Then:
+
+```bash
+ssh "$TARGET" 'sudo chown -R www-data:root /opt/nginx/data/servers /opt/nginx/data/rules /opt/nginx/data/ssl'
+```
+
+### 5. Reload OpenResty (required for SSL)
+
+```bash
+ssh "$TARGET" 'sudo systemctl reload openresty'
+```
+
+Without this, `allow_domain` still returns false (shared dict stale) even though `ssl/<domain>.json` is on disk.
+
+### 6. Verify
+
+```bash
+# DNS must point at Target
+dig +short <domain> A
+
+# Allow-list present
+ssh "$TARGET" "test -f /opt/nginx/data/ssl/<domain>.json && echo ok"
+
+# Cert should be Let's Encrypt (not CN=sni-support-required-for-valid-ssl)
+echo | openssl s_client -connect <domain>:443 -servername <domain> 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates
+
+# Must NOT keep logging: auto-ssl: domain not allowed - using fallback - <domain>
+ssh "$TARGET" "sudo grep <domain> /usr/local/openresty/nginx/logs/error.log | tail -5"
+```
+
+Report: skipped counts, copied counts per tree, reload done, sample domain cert status.
+
+## Why SSL breaks after servers-only migration
+
+```
+auto-ssl: domain not allowed - using fallback - argocd.fictionally.org
+```
+
+`lua-resty-auto-ssl` gates issuance on `ssl_domains` shared dict, populated from
+`/opt/nginx/data/ssl/<domain>.json` — **not** from `servers/host:<domain>.json`
+alone (`ssl_enabled: true` on the server is insufficient until the ssl allow-list
+file exists and the dict is refreshed).
+
+## Architecture notes (do not regress)
+
+- Catch-all vhost + `gateway_ack.lua` reads `data/servers/` + `data/rules/` per request → live immediately after JSON copy.
+- `config_status` / `conf.d` / reboot flags are **not** required for normal domain routing.
+- 502 after a good LE cert = backend/upstream issue, not SSL.
+
+## Checklist
+
+```
+- [ ] Source + Target SSH confirmed
+- [ ] Local Source POP/ and Target POP/ dumps pulled
+- [ ] Diff staged: servers + rules + ssl (missing only)
+- [ ] Pushed with no overwrite
+- [ ] ssl/ installed (sudo if needed)
+- [ ] chown www-data:root
+- [ ] systemctl reload openresty on Target
+- [ ] Verified sample domain LE cert + no "domain not allowed"
+- [ ] Dumps remain gitignored / not committed
+```

--- a/.claude/skills/wslproxy-pop-migrate/scripts/migrate-pop-data.sh
+++ b/.claude/skills/wslproxy-pop-migrate/scripts/migrate-pop-data.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Migrate WSL Proxy servers/, rules/, and ssl/ from Source POP → Target POP.
+# Never overwrites existing files on the target. Reloads openresty when --reload.
+set -euo pipefail
+
+SOURCE=""
+TARGET=""
+REMOTE_DATA="/opt/nginx/data"
+WORK_ROOT=""
+DO_RELOAD=0
+TREES=(servers rules ssl)
+
+usage() {
+  cat <<'EOF'
+Usage: migrate-pop-data.sh --source USER@HOST --target USER@HOST [options]
+
+  --source USER@HOST   Source POP SSH target (required)
+  --target USER@HOST   Target POP SSH target (required)
+  --data-root PATH     Remote data dir (default: /opt/nginx/data)
+  --work-dir PATH      Local work root (default: repo root / cwd)
+  --reload             systemctl reload openresty on target after install
+  --trees LIST         Comma-separated trees (default: servers,rules,ssl)
+  -h, --help           Show help
+
+Example:
+  ./migrate-pop-data.sh \
+    --source root@187.124.112.155 \
+    --target admin@18.133.126.242 \
+    --reload
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source) SOURCE="$2"; shift 2 ;;
+    --target) TARGET="$2"; shift 2 ;;
+    --data-root) REMOTE_DATA="$2"; shift 2 ;;
+    --work-dir) WORK_ROOT="$2"; shift 2 ;;
+    --reload) DO_RELOAD=1; shift ;;
+    --trees) IFS=',' read -r -a TREES <<< "$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+[[ -n "$SOURCE" && -n "$TARGET" ]] || { echo "ERROR: --source and --target required" >&2; usage; exit 1; }
+
+# Refuse accidental omission of ssl when using default trees
+has_ssl=0
+for t in "${TREES[@]}"; do [[ "$t" == "ssl" ]] && has_ssl=1; done
+if [[ $has_ssl -eq 0 ]]; then
+  echo "WARNING: 'ssl' not in --trees. Auto-ssl will reject new domains (domain not allowed)." >&2
+  echo "         Continuing anyway because you overrode --trees." >&2
+fi
+
+if [[ -z "$WORK_ROOT" ]]; then
+  # Prefer git repo root if available
+  if WORK_ROOT=$(git rev-parse --show-toplevel 2>/dev/null); then
+    :
+  else
+    WORK_ROOT=$(pwd)
+  fi
+fi
+
+SRC_LOCAL="$WORK_ROOT/Source POP"
+TGT_LOCAL="$WORK_ROOT/Target POP"
+MIG="$WORK_ROOT/Migration-to-copy"
+
+ssh_opts=(-o BatchMode=yes -o ConnectTimeout=20)
+
+echo "==> Probing Source $SOURCE"
+ssh "${ssh_opts[@]}" "$SOURCE" "hostname; ls '$REMOTE_DATA' >/dev/null; du -sh '$REMOTE_DATA'/servers '$REMOTE_DATA'/rules '$REMOTE_DATA'/ssl 2>/dev/null || true"
+echo "==> Probing Target $TARGET"
+ssh "${ssh_opts[@]}" "$TARGET" "hostname; ls '$REMOTE_DATA' >/dev/null; du -sh '$REMOTE_DATA'/servers '$REMOTE_DATA'/rules '$REMOTE_DATA'/ssl 2>/dev/null || true"
+
+mkdir -p "$SRC_LOCAL" "$TGT_LOCAL" "$MIG"
+rm -rf "$MIG"
+mkdir -p "$MIG"
+
+echo "==> Downloading Source → $SRC_LOCAL"
+rsync -az --delete -e "ssh ${ssh_opts[*]}" "$SOURCE:$REMOTE_DATA/" "$SRC_LOCAL/" || true
+
+echo "==> Downloading Target → $TGT_LOCAL"
+# Do not --delete Target mirror from a partial pull; keep what we get
+rsync -az -e "ssh ${ssh_opts[*]}" "$TARGET:$REMOTE_DATA/" "$TGT_LOCAL/" || true
+
+SKIPPED=0
+COPIED=0
+SUMMARY_FILE=$(mktemp)
+
+echo "==> Staging missing files only"
+for tree in "${TREES[@]}"; do
+  if [[ ! -d "$SRC_LOCAL/$tree" ]]; then
+    echo "  skip tree (missing on Source): $tree"
+    continue
+  fi
+  tree_copied=0
+  tree_skipped=0
+  while IFS= read -r -d '' f; do
+    rel="${f#"$SRC_LOCAL/"}"
+    if [[ -e "$TGT_LOCAL/$rel" ]]; then
+      SKIPPED=$((SKIPPED + 1))
+      tree_skipped=$((tree_skipped + 1))
+    else
+      mkdir -p "$MIG/$(dirname "$rel")"
+      cp "$f" "$MIG/$rel"
+      COPIED=$((COPIED + 1))
+      tree_copied=$((tree_copied + 1))
+    fi
+  done < <(find "$SRC_LOCAL/$tree" -type f -print0 2>/dev/null)
+  echo "$tree $tree_copied $tree_skipped" >> "$SUMMARY_FILE"
+done
+
+echo "Staged to copy: $COPIED"
+echo "Already on Target (skip): $SKIPPED"
+while read -r tree tree_copied tree_skipped; do
+  echo "  $tree: copy=$tree_copied skip=$tree_skipped"
+done < "$SUMMARY_FILE"
+rm -f "$SUMMARY_FILE"
+
+if [[ $COPIED -eq 0 ]]; then
+  echo "==> Nothing to push."
+  exit 0
+fi
+
+push_tree_rsync() {
+  local tree="$1"
+  [[ -d "$MIG/$tree" ]] || return 0
+  echo "==> Push $tree via rsync --ignore-existing"
+  rsync -az --ignore-existing -e "ssh ${ssh_opts[*]}" \
+    "$MIG/$tree/" "$TARGET:$REMOTE_DATA/$tree/" || true
+}
+
+push_ssl_sudo() {
+  [[ -d "$MIG/ssl" ]] || return 0
+  echo "==> Push ssl via /tmp + sudo (directory often not writable by SSH user)"
+  rsync -az -e "ssh ${ssh_opts[*]}" "$MIG/ssl/" "$TARGET:/tmp/ssl-migrate/"
+  ssh "${ssh_opts[@]}" "$TARGET" "REMOTE_DATA='$REMOTE_DATA' bash -s" <<'EOF'
+set -euo pipefail
+SRC=/tmp/ssl-migrate
+DEST="${REMOTE_DATA}/ssl"
+sudo mkdir -p "$DEST"
+copied=0
+skipped=0
+shopt -s nullglob
+for f in "$SRC"/*; do
+  [ -f "$f" ] || continue
+  base=$(basename "$f")
+  if [ -e "$DEST/$base" ]; then
+    skipped=$((skipped + 1))
+  else
+    sudo cp "$f" "$DEST/$base"
+    sudo chown www-data:root "$DEST/$base"
+    sudo chmod 664 "$DEST/$base"
+    copied=$((copied + 1))
+  fi
+done
+echo "ssl remote install: copied=$copied skipped=$skipped"
+rm -rf /tmp/ssl-migrate
+EOF
+}
+
+for tree in "${TREES[@]}"; do
+  if [[ "$tree" == "ssl" ]]; then
+    push_ssl_sudo
+  else
+    push_tree_rsync "$tree"
+  fi
+done
+
+echo "==> Fix ownership on Target"
+ssh "${ssh_opts[@]}" "$TARGET" \
+  "sudo chown -R www-data:root '$REMOTE_DATA'/servers '$REMOTE_DATA'/rules '$REMOTE_DATA'/ssl 2>/dev/null || true"
+
+# Refresh local Target mirror for staged trees
+for tree in "${TREES[@]}"; do
+  [[ -d "$MIG/$tree" ]] || continue
+  mkdir -p "$TGT_LOCAL/$tree"
+  rsync -a --ignore-existing "$MIG/$tree/" "$TGT_LOCAL/$tree/"
+done
+
+if [[ $DO_RELOAD -eq 1 ]]; then
+  echo "==> Reloading openresty on Target (refresh ssl_domains shared dict)"
+  ssh "${ssh_opts[@]}" "$TARGET" 'sudo systemctl reload openresty && systemctl is-active openresty'
+else
+  echo "==> NOTE: run with --reload (or: ssh $TARGET 'sudo systemctl reload openresty')"
+  echo "    New ssl/*.json files are ignored until workers reload."
+fi
+
+echo "==> Done"
+echo "Local dumps: $SRC_LOCAL | $TGT_LOCAL | $MIG"

--- a/.cursor/skills/wslproxy-pop-migrate/SKILL.md
+++ b/.cursor/skills/wslproxy-pop-migrate/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: wslproxy-pop-migrate
+description: >-
+  Migrate WSL Proxy servers, rules, and SSL allow-list files between POPs
+  (source → target) without overwriting existing files. Use when the user
+  asks to migrate/sync POP data, copy servers/rules between hosts, move
+  domains from pop0 to pop1, or fix missing SSL after a POP migration.
+disable-model-invocation: true
+---
+
+# WSL Proxy POP data migration
+
+Migrate live gateway data from a **Source POP** to a **Target POP** so routing
+and Let's Encrypt auto-ssl work on the target. OpenResty routes from JSON on
+disk at request time — no `nginx -t` / reboot is required for servers+rules.
+
+## Inputs (ask if missing)
+
+| Input | Example |
+|-------|---------|
+| Source SSH | `root@187.124.112.155` (pop0) |
+| Target SSH | `admin@18.133.126.242` (pop1) |
+| Remote data root | `/opt/nginx/data` (default) |
+| Local work dirs | `Source POP/`, `Target POP/` under repo root |
+
+## Required trees (never skip)
+
+Copy **all three** or SSL will not issue:
+
+| Tree | Purpose |
+|------|---------|
+| `servers/` | Host records (`host:<domain>.json` + staged `conf/`) |
+| `rules/` | Routing rules |
+| **`ssl/`** | Auto-ssl allow-list (`<domain>.json`). **Missing this → `domain not allowed - using fallback`** |
+
+Optional (only if user asks): `varnish/`, `upstreams/`, `waf_policies/`, `waf_rules/`.
+
+**Never** copy `settings.json` / `.env` between POPs — those are host-specific secrets and `env_profile`.
+
+## Hard rules
+
+1. **Do not overwrite** files that already exist on Target (`rsync --ignore-existing` or skip-if-exists).
+2. **Always include `ssl/`** with servers+rules.
+3. After installing new `ssl/*.json`, **`sudo systemctl reload openresty`** on Target — `ssl_domains` shared dict only refreshes at worker start.
+4. Fix ownership to `www-data:root` after copy.
+5. Do not commit live dumps; keep them gitignored (`Source POP/`, `Target POP/`, `Migration-to-copy/`).
+
+## Workflow
+
+Prefer the script (low freedom / consistent):
+
+```bash
+# From repo:
+.cursor/skills/wslproxy-pop-migrate/scripts/migrate-pop-data.sh \
+  --source root@187.124.112.155 \
+  --target admin@18.133.126.242 \
+  --reload
+
+# Same script also lives at:
+#   .claude/skills/wslproxy-pop-migrate/scripts/migrate-pop-data.sh
+```
+
+Or follow the manual steps below.
+
+### 1. Probe SSH + layout
+
+```bash
+ssh -o BatchMode=yes "$SOURCE" 'hostname; ls /opt/nginx/data/; du -sh /opt/nginx/data/{servers,rules,ssl}'
+ssh -o BatchMode=yes "$TARGET" 'hostname; ls /opt/nginx/data/; du -sh /opt/nginx/data/{servers,rules,ssl}'
+```
+
+### 2. Download full data trees locally
+
+```bash
+mkdir -p "Source POP" "Target POP"
+rsync -avz -e "ssh -o BatchMode=yes" "$SOURCE:/opt/nginx/data/" "Source POP/"
+rsync -avz -e "ssh -o BatchMode=yes" "$TARGET:/opt/nginx/data/" "Target POP/"
+# rsync exit 23 on Target is OK if settings.json is unreadable; servers/rules/ssl must succeed
+```
+
+### 3. Stage only missing files
+
+For each of `servers`, `rules`, `ssl`:
+
+- Walk Source files
+- If the same relative path exists under Target → **skip**
+- Else copy into `Migration-to-copy/<tree>/...`
+
+### 4. Push to Target
+
+**servers / rules** — often world-writable:
+
+```bash
+rsync -avz --ignore-existing -e "ssh -o BatchMode=yes" \
+  Migration-to-copy/servers/ "$TARGET:/opt/nginx/data/servers/"
+rsync -avz --ignore-existing -e "ssh -o BatchMode=yes" \
+  Migration-to-copy/rules/ "$TARGET:/opt/nginx/data/rules/"
+```
+
+**ssl/** — often `www-data`-only (admin rsync fails with Permission denied). Stage to `/tmp` then sudo-install:
+
+```bash
+rsync -avz -e "ssh -o BatchMode=yes" Migration-to-copy/ssl/ "$TARGET:/tmp/ssl-migrate/"
+ssh "$TARGET" 'bash -s' <<'EOF'
+SRC=/tmp/ssl-migrate; DEST=/opt/nginx/data/ssl
+for f in "$SRC"/*.json; do
+  base=$(basename "$f")
+  [ -e "$DEST/$base" ] && continue
+  sudo cp "$f" "$DEST/$base"
+  sudo chown www-data:root "$DEST/$base"
+  sudo chmod 664 "$DEST/$base"
+done
+rm -rf /tmp/ssl-migrate
+EOF
+```
+
+Then:
+
+```bash
+ssh "$TARGET" 'sudo chown -R www-data:root /opt/nginx/data/servers /opt/nginx/data/rules /opt/nginx/data/ssl'
+```
+
+### 5. Reload OpenResty (required for SSL)
+
+```bash
+ssh "$TARGET" 'sudo systemctl reload openresty'
+```
+
+Without this, `allow_domain` still returns false (shared dict stale) even though `ssl/<domain>.json` is on disk.
+
+### 6. Verify
+
+```bash
+# DNS must point at Target
+dig +short <domain> A
+
+# Allow-list present
+ssh "$TARGET" "test -f /opt/nginx/data/ssl/<domain>.json && echo ok"
+
+# Cert should be Let's Encrypt (not CN=sni-support-required-for-valid-ssl)
+echo | openssl s_client -connect <domain>:443 -servername <domain> 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates
+
+# Must NOT keep logging: auto-ssl: domain not allowed - using fallback - <domain>
+ssh "$TARGET" "sudo grep <domain> /usr/local/openresty/nginx/logs/error.log | tail -5"
+```
+
+Report: skipped counts, copied counts per tree, reload done, sample domain cert status.
+
+## Why SSL breaks after servers-only migration
+
+```
+auto-ssl: domain not allowed - using fallback - argocd.fictionally.org
+```
+
+`lua-resty-auto-ssl` gates issuance on `ssl_domains` shared dict, populated from
+`/opt/nginx/data/ssl/<domain>.json` — **not** from `servers/host:<domain>.json`
+alone (`ssl_enabled: true` on the server is insufficient until the ssl allow-list
+file exists and the dict is refreshed).
+
+## Architecture notes (do not regress)
+
+- Catch-all vhost + `gateway_ack.lua` reads `data/servers/` + `data/rules/` per request → live immediately after JSON copy.
+- `config_status` / `conf.d` / reboot flags are **not** required for normal domain routing.
+- 502 after a good LE cert = backend/upstream issue, not SSL.
+
+## Checklist
+
+```
+- [ ] Source + Target SSH confirmed
+- [ ] Local Source POP/ and Target POP/ dumps pulled
+- [ ] Diff staged: servers + rules + ssl (missing only)
+- [ ] Pushed with no overwrite
+- [ ] ssl/ installed (sudo if needed)
+- [ ] chown www-data:root
+- [ ] systemctl reload openresty on Target
+- [ ] Verified sample domain LE cert + no "domain not allowed"
+- [ ] Dumps remain gitignored / not committed
+```

--- a/.cursor/skills/wslproxy-pop-migrate/scripts/migrate-pop-data.sh
+++ b/.cursor/skills/wslproxy-pop-migrate/scripts/migrate-pop-data.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Migrate WSL Proxy servers/, rules/, and ssl/ from Source POP → Target POP.
+# Never overwrites existing files on the target. Reloads openresty when --reload.
+set -euo pipefail
+
+SOURCE=""
+TARGET=""
+REMOTE_DATA="/opt/nginx/data"
+WORK_ROOT=""
+DO_RELOAD=0
+TREES=(servers rules ssl)
+
+usage() {
+  cat <<'EOF'
+Usage: migrate-pop-data.sh --source USER@HOST --target USER@HOST [options]
+
+  --source USER@HOST   Source POP SSH target (required)
+  --target USER@HOST   Target POP SSH target (required)
+  --data-root PATH     Remote data dir (default: /opt/nginx/data)
+  --work-dir PATH      Local work root (default: repo root / cwd)
+  --reload             systemctl reload openresty on target after install
+  --trees LIST         Comma-separated trees (default: servers,rules,ssl)
+  -h, --help           Show help
+
+Example:
+  ./migrate-pop-data.sh \
+    --source root@187.124.112.155 \
+    --target admin@18.133.126.242 \
+    --reload
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source) SOURCE="$2"; shift 2 ;;
+    --target) TARGET="$2"; shift 2 ;;
+    --data-root) REMOTE_DATA="$2"; shift 2 ;;
+    --work-dir) WORK_ROOT="$2"; shift 2 ;;
+    --reload) DO_RELOAD=1; shift ;;
+    --trees) IFS=',' read -r -a TREES <<< "$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+[[ -n "$SOURCE" && -n "$TARGET" ]] || { echo "ERROR: --source and --target required" >&2; usage; exit 1; }
+
+# Refuse accidental omission of ssl when using default trees
+has_ssl=0
+for t in "${TREES[@]}"; do [[ "$t" == "ssl" ]] && has_ssl=1; done
+if [[ $has_ssl -eq 0 ]]; then
+  echo "WARNING: 'ssl' not in --trees. Auto-ssl will reject new domains (domain not allowed)." >&2
+  echo "         Continuing anyway because you overrode --trees." >&2
+fi
+
+if [[ -z "$WORK_ROOT" ]]; then
+  # Prefer git repo root if available
+  if WORK_ROOT=$(git rev-parse --show-toplevel 2>/dev/null); then
+    :
+  else
+    WORK_ROOT=$(pwd)
+  fi
+fi
+
+SRC_LOCAL="$WORK_ROOT/Source POP"
+TGT_LOCAL="$WORK_ROOT/Target POP"
+MIG="$WORK_ROOT/Migration-to-copy"
+
+ssh_opts=(-o BatchMode=yes -o ConnectTimeout=20)
+
+echo "==> Probing Source $SOURCE"
+ssh "${ssh_opts[@]}" "$SOURCE" "hostname; ls '$REMOTE_DATA' >/dev/null; du -sh '$REMOTE_DATA'/servers '$REMOTE_DATA'/rules '$REMOTE_DATA'/ssl 2>/dev/null || true"
+echo "==> Probing Target $TARGET"
+ssh "${ssh_opts[@]}" "$TARGET" "hostname; ls '$REMOTE_DATA' >/dev/null; du -sh '$REMOTE_DATA'/servers '$REMOTE_DATA'/rules '$REMOTE_DATA'/ssl 2>/dev/null || true"
+
+mkdir -p "$SRC_LOCAL" "$TGT_LOCAL" "$MIG"
+rm -rf "$MIG"
+mkdir -p "$MIG"
+
+echo "==> Downloading Source → $SRC_LOCAL"
+rsync -az --delete -e "ssh ${ssh_opts[*]}" "$SOURCE:$REMOTE_DATA/" "$SRC_LOCAL/" || true
+
+echo "==> Downloading Target → $TGT_LOCAL"
+# Do not --delete Target mirror from a partial pull; keep what we get
+rsync -az -e "ssh ${ssh_opts[*]}" "$TARGET:$REMOTE_DATA/" "$TGT_LOCAL/" || true
+
+SKIPPED=0
+COPIED=0
+SUMMARY_FILE=$(mktemp)
+
+echo "==> Staging missing files only"
+for tree in "${TREES[@]}"; do
+  if [[ ! -d "$SRC_LOCAL/$tree" ]]; then
+    echo "  skip tree (missing on Source): $tree"
+    continue
+  fi
+  tree_copied=0
+  tree_skipped=0
+  while IFS= read -r -d '' f; do
+    rel="${f#"$SRC_LOCAL/"}"
+    if [[ -e "$TGT_LOCAL/$rel" ]]; then
+      SKIPPED=$((SKIPPED + 1))
+      tree_skipped=$((tree_skipped + 1))
+    else
+      mkdir -p "$MIG/$(dirname "$rel")"
+      cp "$f" "$MIG/$rel"
+      COPIED=$((COPIED + 1))
+      tree_copied=$((tree_copied + 1))
+    fi
+  done < <(find "$SRC_LOCAL/$tree" -type f -print0 2>/dev/null)
+  echo "$tree $tree_copied $tree_skipped" >> "$SUMMARY_FILE"
+done
+
+echo "Staged to copy: $COPIED"
+echo "Already on Target (skip): $SKIPPED"
+while read -r tree tree_copied tree_skipped; do
+  echo "  $tree: copy=$tree_copied skip=$tree_skipped"
+done < "$SUMMARY_FILE"
+rm -f "$SUMMARY_FILE"
+
+if [[ $COPIED -eq 0 ]]; then
+  echo "==> Nothing to push."
+  exit 0
+fi
+
+push_tree_rsync() {
+  local tree="$1"
+  [[ -d "$MIG/$tree" ]] || return 0
+  echo "==> Push $tree via rsync --ignore-existing"
+  rsync -az --ignore-existing -e "ssh ${ssh_opts[*]}" \
+    "$MIG/$tree/" "$TARGET:$REMOTE_DATA/$tree/" || true
+}
+
+push_ssl_sudo() {
+  [[ -d "$MIG/ssl" ]] || return 0
+  echo "==> Push ssl via /tmp + sudo (directory often not writable by SSH user)"
+  rsync -az -e "ssh ${ssh_opts[*]}" "$MIG/ssl/" "$TARGET:/tmp/ssl-migrate/"
+  ssh "${ssh_opts[@]}" "$TARGET" "REMOTE_DATA='$REMOTE_DATA' bash -s" <<'EOF'
+set -euo pipefail
+SRC=/tmp/ssl-migrate
+DEST="${REMOTE_DATA}/ssl"
+sudo mkdir -p "$DEST"
+copied=0
+skipped=0
+shopt -s nullglob
+for f in "$SRC"/*; do
+  [ -f "$f" ] || continue
+  base=$(basename "$f")
+  if [ -e "$DEST/$base" ]; then
+    skipped=$((skipped + 1))
+  else
+    sudo cp "$f" "$DEST/$base"
+    sudo chown www-data:root "$DEST/$base"
+    sudo chmod 664 "$DEST/$base"
+    copied=$((copied + 1))
+  fi
+done
+echo "ssl remote install: copied=$copied skipped=$skipped"
+rm -rf /tmp/ssl-migrate
+EOF
+}
+
+for tree in "${TREES[@]}"; do
+  if [[ "$tree" == "ssl" ]]; then
+    push_ssl_sudo
+  else
+    push_tree_rsync "$tree"
+  fi
+done
+
+echo "==> Fix ownership on Target"
+ssh "${ssh_opts[@]}" "$TARGET" \
+  "sudo chown -R www-data:root '$REMOTE_DATA'/servers '$REMOTE_DATA'/rules '$REMOTE_DATA'/ssl 2>/dev/null || true"
+
+# Refresh local Target mirror for staged trees
+for tree in "${TREES[@]}"; do
+  [[ -d "$MIG/$tree" ]] || continue
+  mkdir -p "$TGT_LOCAL/$tree"
+  rsync -a --ignore-existing "$MIG/$tree/" "$TGT_LOCAL/$tree/"
+done
+
+if [[ $DO_RELOAD -eq 1 ]]; then
+  echo "==> Reloading openresty on Target (refresh ssl_domains shared dict)"
+  ssh "${ssh_opts[@]}" "$TARGET" 'sudo systemctl reload openresty && systemctl is-active openresty'
+else
+  echo "==> NOTE: run with --reload (or: ssh $TARGET 'sudo systemctl reload openresty')"
+  echo "    New ssl/*.json files are ignored until workers reload."
+fi
+
+echo "==> Done"
+echo "Local dumps: $SRC_LOCAL | $TGT_LOCAL | $MIG"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ html/.DS_Store
 
 # Dashboard build artifacts
 dashboard/bin/
+
+# Local POP migration dumps (do not commit live host data)
+Source POP/
+Target POP/
+Migration-to-copy/


### PR DESCRIPTION
## Summary
- Adds Cursor/Claude skill `wslproxy-pop-migrate` with checklist and workflow
- Adds `migrate-pop-data.sh` to sync `servers/`, `rules/`, and **`ssl/`** without overwriting
- Gitignores local POP dump dirs (`Source POP/`, `Target POP/`, `Migration-to-copy/`)

## Test plan
- [ ] Review skill steps for completeness
- [ ] Dry-run: `scripts/migrate-pop-data.sh --help`

Made with [Cursor](https://cursor.com)