### PR TITLE
chore(ansible): add wslproxy uninstall playbook

### DIFF
--- a/infra/ansible/roles/wslproxy/tasks/uninstall.yml
+++ b/infra/ansible/roles/wslproxy/tasks/uninstall.yml
@@ -1,0 +1,229 @@
+---
+# Reverse of the wslproxy install path (wslproxy-ops / deploy-wslproxy).
+# Included by infra/ansible/wslproxy-uninstall.yml
+#
+# Order: stop services → remove automation → remove units → remove files.
+# Safe defaults: keeps /opt/nginx/data unless purge_data=true.
+
+# ── 1. Services ────────────────────────────────────────────────────────────
+
+- name: "Uninstall: stop and disable OpenResty"
+  ansible.builtin.systemd:
+    name: openresty
+    state: stopped
+    enabled: false
+  failed_when: false
+  tags: [services, all]
+
+- name: "Uninstall: stop and disable Next.js dashboard"
+  ansible.builtin.systemd:
+    name: wslproxy-nextjs-dashboard
+    state: stopped
+    enabled: false
+  failed_when: false
+  tags: [services, all]
+
+- name: "Uninstall: stop and disable IP2Location refresh timer"
+  ansible.builtin.systemd:
+    name: wslproxy-ip2location-refresh.timer
+    state: stopped
+    enabled: false
+  failed_when: false
+  tags: [services, all]
+
+- name: "Uninstall: stop IP2Location refresh service (if running)"
+  ansible.builtin.systemd:
+    name: wslproxy-ip2location-refresh.service
+    state: stopped
+  failed_when: false
+  tags: [services, all]
+
+- name: "Uninstall: stop and disable Varnish (if present)"
+  ansible.builtin.systemd:
+    name: varnish
+    state: stopped
+    enabled: false
+  failed_when: false
+  tags: [services, all]
+
+- name: "Uninstall: kill leftover nginx/openresty processes"
+  ansible.builtin.shell: |
+    set +e
+    # Prefer graceful stop via binary; fall back to pkill of our install only.
+    if [ -x /usr/local/openresty/bin/openresty ]; then
+      /usr/local/openresty/bin/openresty -s quit 2>/dev/null || true
+      sleep 1
+      /usr/local/openresty/bin/openresty -s stop 2>/dev/null || true
+    fi
+    # Do NOT use killall nginx — that can kill k3s/container nginx on the same host.
+    pkill -f '/usr/local/openresty/nginx/sbin/nginx' 2>/dev/null || true
+    exit 0
+  args:
+    executable: /bin/bash
+  changed_when: false
+  tags: [services, all]
+
+# ── 2. Cron ────────────────────────────────────────────────────────────────
+
+- name: "Uninstall: remove nginx_restart cron"
+  ansible.builtin.cron:
+    name: nginx_restart
+    user: root
+    state: absent
+  tags: [cron, all]
+
+- name: "Uninstall: remove nginx_data_sync cron"
+  ansible.builtin.cron:
+    name: nginx_data_sync
+    user: root
+    state: absent
+  tags: [cron, all]
+
+- name: "Uninstall: remove helper scripts"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /usr/sbin/nginx_restart_if_required.sh
+    - /usr/sbin/nginx-data-sync-required.sh
+    - /usr/sbin/fix-permissions.sh
+    - /usr/local/bin/wslproxy-ip2location-refresh.sh
+  tags: [cron, all]
+
+# ── 3. Systemd units ───────────────────────────────────────────────────────
+
+- name: "Uninstall: remove systemd unit files"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /etc/systemd/system/openresty.service
+    - /etc/systemd/system/openresty.service.d
+    - /etc/systemd/system/wslproxy-nextjs-dashboard.service
+    - /etc/systemd/system/wslproxy-ip2location-refresh.service
+    - /etc/systemd/system/wslproxy-ip2location-refresh.timer
+    - /etc/systemd/system/varnish.service
+  tags: [systemd, all]
+
+- name: "Uninstall: systemd daemon-reload"
+  ansible.builtin.systemd:
+    daemon_reload: true
+  tags: [systemd, all]
+
+# ── 4. Config / OS tweaks (reverse of nginx_config + systemd_limits) ───────
+
+- name: "Uninstall: remove openresty logrotate"
+  ansible.builtin.file:
+    path: /etc/logrotate.d/openresty
+    state: absent
+  tags: [config, all]
+
+- name: "Uninstall: remove openresty sysctl drop-in"
+  ansible.builtin.file:
+    path: /etc/sysctl.d/99-openresty.conf
+    state: absent
+  tags: [config, all]
+
+- name: "Uninstall: reload sysctl after drop-in removal"
+  ansible.builtin.command: sysctl --system
+  failed_when: false
+  changed_when: false
+  tags: [config, all]
+
+- name: "Uninstall: remove OpenResty block from limits.conf"
+  ansible.builtin.blockinfile:
+    path: /etc/security/limits.conf
+    marker: "# {mark} ANSIBLE MANAGED - OpenResty file descriptor limits"
+    state: absent
+  failed_when: false
+  tags: [config, all]
+
+- name: "Uninstall: remove nginx config dirs under /opt/nginx (not data)"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ nginx_config_dir }}/conf.d"
+    - "{{ nginx_config_dir }}/base.d"
+    - "{{ nginx_config_dir }}/conf.d.predeploy"
+    - "{{ nginx_config_dir }}/prod_cache"
+  tags: [config, all]
+
+- name: "Uninstall: remove runtime/cache/log dirs"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /tmp/nginx
+    - /var/run/nginx
+    - /var/cache/nginx
+    - /var/log/nginx
+  tags: [config, all]
+
+# ── 5. Binaries / app tree ─────────────────────────────────────────────────
+
+- name: "Uninstall: remove OpenResty install prefix {{ openresty_prefix }}"
+  ansible.builtin.file:
+    path: "{{ openresty_prefix }}"
+    state: absent
+  tags: [binaries, all]
+
+- name: "Uninstall: remove leftover build scripts in /tmp"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - /tmp/bootstrap.sh
+    - /tmp/openresty.sh
+    - /tmp/.env
+  tags: [binaries, all]
+
+# ── 6. Data (opt-in) ───────────────────────────────────────────────────────
+
+- name: "Uninstall: remove {{ nginx_config_dir }}/data (purge_data=true)"
+  ansible.builtin.file:
+    path: "{{ nginx_config_dir }}/data"
+    state: absent
+  when: purge_data | bool
+  tags: [data, all]
+
+- name: "Uninstall: remove {{ nginx_config_dir }} root (purge_data + purge_nginx_root)"
+  ansible.builtin.file:
+    path: "{{ nginx_config_dir }}"
+    state: absent
+  when:
+    - purge_data | bool
+    - purge_nginx_root | default(true) | bool
+  tags: [data, all]
+
+- name: "Uninstall: note data preserved"
+  ansible.builtin.debug:
+    msg: >-
+      Kept {{ nginx_config_dir }}/data (and parent if non-empty).
+      Re-run with -e purge_data=true to delete live servers/rules/ssl/certs.
+  when: not (purge_data | bool)
+  tags: [data, all]
+
+# ── 7. Verify ──────────────────────────────────────────────────────────────
+
+- name: "Uninstall: verify openresty binary gone"
+  ansible.builtin.stat:
+    path: "{{ openresty_prefix }}/bin/openresty"
+  register: _openresty_bin
+  tags: [verify, all]
+
+- name: "Uninstall: verify openresty service inactive"
+  ansible.builtin.command: systemctl is-active openresty
+  register: _openresty_active
+  failed_when: false
+  changed_when: false
+  tags: [verify, all]
+
+- name: "Uninstall: summary"
+  ansible.builtin.debug:
+    msg:
+      - "openresty binary present: {{ _openresty_bin.stat.exists | default(false) }}"
+      - "openresty systemd active: {{ _openresty_active.stdout | default('unknown') }}"
+      - "purge_data: {{ purge_data | bool }}"
+      - "Done. OS packages / Node.js / www-data user were intentionally left in place."
+  tags: [verify, all]

--- a/infra/ansible/wslproxy-uninstall.yml
+++ b/infra/ansible/wslproxy-uninstall.yml
@@ -1,0 +1,44 @@
+---
+# Uninstall WSL Proxy / OpenResty — reverse of wslproxy-ops.yml / deploy-wslproxy.yml
+#
+# Stops services, removes cron/systemd/scripts/binaries, and optionally purges
+# /opt/nginx data. Does NOT remove OS packages, Node.js, or the www-data user
+# (those may be shared with other workloads).
+#
+# Usage:
+#   ansible-playbook -i hosts -l <host> wslproxy-uninstall.yml \
+#     -e confirm_uninstall=true
+#
+#   # Also delete /opt/nginx (servers, rules, ssl, certs):
+#   ansible-playbook -i hosts -l <host> wslproxy-uninstall.yml \
+#     -e confirm_uninstall=true -e purge_data=true
+#
+# Tags (optional filters):
+#   services | cron | systemd | config | binaries | data | verify | all
+
+- name: Uninstall WSL Proxy / OpenResty
+  hosts: openresty_native_cluster
+  become: yes
+  gather_facts: yes
+
+  vars:
+    openresty_prefix: /usr/local/openresty
+    nginx_config_dir: /opt/nginx
+    # Safety gate — must pass confirm_uninstall=true on the CLI
+    confirm_uninstall: false
+    # Delete live data under /opt/nginx/data (servers, rules, ssl, certs)
+    purge_data: false
+    # When purge_data=true, also remove the /opt/nginx directory itself
+    purge_nginx_root: true
+
+  tasks:
+    - name: Refuse to run without confirm_uninstall=true
+      ansible.builtin.assert:
+        that:
+          - confirm_uninstall | bool
+        fail_msg: >-
+          Refusing to uninstall. Re-run with -e confirm_uninstall=true
+          (and optionally -e purge_data=true to delete /opt/nginx/data).
+
+    - name: Run uninstall tasks (reverse of wslproxy role install)
+      ansible.builtin.include_tasks: roles/wslproxy/tasks/uninstall.yml


### PR DESCRIPTION
## Summary
- Adds `infra/ansible/wslproxy-uninstall.yml` — reverse of `wslproxy-ops.yml` / `deploy-wslproxy.yml`
- Adds `roles/wslproxy/tasks/uninstall.yml` with tagged steps (services, cron, systemd, config, binaries, data)
- Requires `-e confirm_uninstall=true`; data purge requires `-e purge_data=true`
- Does not remove OS packages, Node.js, or `www-data` (shared resources)
- Avoids `killall nginx` (k3s-safe; only targets `/usr/local/openresty`)

## Usage
```bash
ansible-playbook -i hosts -l <host> wslproxy-uninstall.yml -e confirm_uninstall=true
ansible-playbook -i hosts -l <host> wslproxy-uninstall.yml -e confirm_uninstall=true -e purge_data=true
```

## Test plan
- [ ] Dry-run syntax: `ansible-playbook --syntax-check wslproxy-uninstall.yml`
- [ ] Run without `confirm_uninstall` → assert fails
- [ ] Run with confirm on a disposable host → openresty gone, data kept
- [ ] Run with `purge_data=true` → `/opt/nginx` removed

Made with [Cursor](https://cursor.com)