### PR TITLE
feat(gateway): X-WSL-Backend response header — which backend served this request

### DIFF
--- a/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
@@ -850,6 +850,20 @@ server {
               ngx.header["X-WSL-Rule"] = _gw.executableRule.name
             end
 
+            -- Surface WHICH backend the traffic router picked, so an
+            -- operator watching a multi-backend rule (weighted / round-
+            -- robin / least-conn / cookie-sticky) can see per-request
+            -- which endpoint actually served it — critical for
+            -- verifying canary weights, sticky sessions, and failover.
+            -- Populated by gateway_resp.lua whether the rule has one
+            -- backend or many; falls back to the redirect URI when the
+            -- rule has no named label.  Absent on cache HIT (that path
+            -- short-circuits before backend selection — check
+            -- X-WSL-Cache: HIT for that case).
+            if ngx.ctx.selected_backend_label then
+              ngx.header["X-WSL-Backend"] = ngx.ctx.selected_backend_label
+            end
+
             -- LLM protocol translation: normalise response headers
             local ok_llm, Llm = pcall(require, "llm_translator")
             if ok_llm then Llm.header_filter() end
@@ -1078,6 +1092,20 @@ server {
             local _gw = ngx.ctx.gateway
             if _gw and _gw.executableRule and _gw.executableRule.name then
               ngx.header["X-WSL-Rule"] = _gw.executableRule.name
+            end
+
+            -- Surface WHICH backend the traffic router picked, so an
+            -- operator watching a multi-backend rule (weighted / round-
+            -- robin / least-conn / cookie-sticky) can see per-request
+            -- which endpoint actually served it — critical for
+            -- verifying canary weights, sticky sessions, and failover.
+            -- Populated by gateway_resp.lua whether the rule has one
+            -- backend or many; falls back to the redirect URI when the
+            -- rule has no named label.  Absent on cache HIT (that path
+            -- short-circuits before backend selection — check
+            -- X-WSL-Cache: HIT for that case).
+            if ngx.ctx.selected_backend_label then
+              ngx.header["X-WSL-Backend"] = ngx.ctx.selected_backend_label
             end
 
             -- LLM protocol translation: normalise response headers

--- a/nginx-dev.conf.tmpl
+++ b/nginx-dev.conf.tmpl
@@ -1170,6 +1170,20 @@ server {
               ngx.header["X-WSL-Rule"] = _gw.executableRule.name
             end
 
+            -- Surface WHICH backend the traffic router picked, so an
+            -- operator watching a multi-backend rule (weighted / round-
+            -- robin / least-conn / cookie-sticky) can see per-request
+            -- which endpoint actually served it — critical for
+            -- verifying canary weights, sticky sessions, and failover.
+            -- Populated by gateway_resp.lua whether the rule has one
+            -- backend or many; falls back to the redirect URI when the
+            -- rule has no named label.  Absent on cache HIT (that path
+            -- short-circuits before backend selection — check
+            -- X-WSL-Cache: HIT for that case).
+            if ngx.ctx.selected_backend_label then
+              ngx.header["X-WSL-Backend"] = ngx.ctx.selected_backend_label
+            end
+
             -- LLM protocol translation: normalise response headers
             local ok_llm, Llm = pcall(require, "llm_translator")
             if ok_llm then Llm.header_filter() end


### PR DESCRIPTION
## Why

When a rule has multiple backends (weighted / round-robin / least-conn / header-match / cookie-sticky), operators had **no visible per-request signal** telling them which backend the traffic router actually picked. That's critical for verifying:

- Canary weights — "am I actually sending 10% here?"
- Sticky sessions — "did this cookie pin me correctly?"
- Failover — "did an unhealthy backend get skipped?"

Currently that info exists only in the internal `log_handler` traffic-stats aggregation, not on the response itself.

## What this adds

New response header `X-WSL-Backend`, populated by the existing `header_filter_by_lua_block` (same block that emits `X-WSL-Rule` and `X-WSL-Cache`). Value comes from `ngx.ctx.selected_backend_label` which [gateway_resp.lua](api/gateway_resp.lua#L101) already sets — **no new Lua wiring**, just the header emit.

| Rule shape | Header value |
|---|---|
| Multi-backend (weighted/rr/lc/header/cookie) | The backend's `label` field from the rule config (e.g. `canary-blue`) |
| Single-backend | The redirect URI (fallback set by gateway_resp.lua when router doesn't populate) |
| Cache HIT | Header **absent** — cache short-circuits before backend selection; `X-WSL-Cache: HIT` is the authoritative signal for that path |

## Files changed

- [nginx-dev.conf.tmpl](nginx-dev.conf.tmpl) (docker dev)
- [infra/ansible/roles/wslproxy/templates/nginx.conf.j2](infra/ansible/roles/wslproxy/templates/nginx.conf.j2) (prod)

Same two files as the X-WSL-Rule wire-up (PR #1108) so the two headers travel together. 4-line addition per `header_filter_by_lua_block` immediately after the X-WSL-Rule emit.

## Deliberately NOT in this PR

- **No gateway_resp.lua changes** — it already sets `selected_backend_label` on both multi- and single-backend paths (line 101 and 123). Only the header surface is new.
- **No cache-replay of backend label** — unlike rule_name (replayed for HIT responses since you always want to know which rule matched), the backend value on a cached response would be misleading. `X-WSL-Cache: HIT` is authoritative for that case.
- **No format tweaks** (address suffix, routing-mode annotation, health state). Kept single-value for symmetry with X-WSL-Rule. If richer metadata is wanted later, add `X-WSL-Backend-Mode` etc. in a follow-up.

## Not yet hot-patched on prod

Would normally direct-on-prod-patch first to prove the change (like X-WSL-Rule in PR #1108), but prod's `openresty.service` is currently `inactive (dead)` (stopped Jul 26 09:46 UTC) while nginx workers still run via some other mechanism — likely a manual start. Didn't want to `kill -HUP` a process systemd doesn't track from a shell script. **Land this PR + run an ansible `--tags nginx` deploy when ready**; the change is scoped to a single header emit and has zero risk.

## Sample response after this ships

```
$ curl -I https://your-canary-rule.example.com/
HTTP/2 200
x-wsl-rule: my-canary-rule
x-wsl-backend: canary-blue         ← NEW
x-wsl-cache: MISS
...
```

Curl 10 times, count occurrences of each backend value → verify weight distribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)