### PR TITLE
ci(acc): migrate acceptance deploys to dedicated LAN host 192.168.1.48

### DIFF
--- a/.github/workflows/deploy-single-environment.yml
+++ b/.github/workflows/deploy-single-environment.yml
@@ -6,11 +6,13 @@ name: Deploy Single Environment
 # Environments (Integration -> Test -> Acceptance -> Production):
 #   int  -> 192.168.1.193   (Integration)
 #   test -> 192.168.1.140   (Test)
-#   acc  -> 187.124.112.155 (Acceptance — "pop0")
+#   acc  -> 192.168.1.48    (Acceptance — LAN)
 #   prod -> 18.133.126.242  (Production  — "pop1")
 #
-# Each ENV maps to exactly ONE host, so acceptance (pop0) and production (pop1)
-# deploy independently. (The former lon1 host, 72.62.211.28, is no longer used.)
+# Each ENV maps to exactly ONE host, so acceptance and production deploy
+# independently. (The former acc/pop0 host, 187.124.112.155, is now used only
+# for prod-pop0 in the delivery pipeline; the former lon1 host, 72.62.211.28,
+# is no longer used.)
 #
 # WHY THIS EXISTS
 #   deploy-wslproxy-delivery-pipeline.yml is a cumulative promotion cascade and
@@ -20,8 +22,9 @@ name: Deploy Single Environment
 #   health check, auto-rolls-back THAT ring only — so it needs to deploy exactly
 #   one environment per dispatch, which is what this workflow provides.
 #
-# NOTE: acc and prod both run with env_name=prod (they are prod-profile hosts
-# served by the `prod` self-hosted runner); the ENV input selects which host.
+# NOTE: prod runs with env_name=prod (served by the `prod` self-hosted runner);
+# acc runs with env_name=acc on a dedicated LAN host with its own runner. int
+# and test also use env_name matching their runner labels.
 
 on:
   workflow_dispatch:
@@ -118,29 +121,31 @@ jobs:
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
   # ──────────────────────────────────────────────────────
-  # Acceptance — acc / "pop0" (187.124.112.155). vault-first with SOPS fallback
+  # Acceptance — acc (192.168.1.48, LAN). vault-first with SOPS fallback
   # (matches the delivery pipeline post-#1125; seed_from_host retired).
   # ──────────────────────────────────────────────────────
+  # Migrated off 187.124.112.155 (which was co-located with prod-pop0) — acc
+  # is now a dedicated host on the LAN, mirroring the int/test topology
+  # (self-hosted runner labeled `acc` on the target box, local ansible
+  # connection, local health check).
   acc:
     if: ${{ inputs.ENV == 'acc' }}
     uses: ./.github/workflows/deploy-environment.yml
     with:
-      env_name: prod            # prod-profile host, served by the `prod` runner
-      env_label: "Acceptance — pop0 (187.124.112.155)"
+      env_name: acc
+      env_label: "Acceptance (192.168.1.48)"
       stage_number: "acc"
-      host_ip: "187.124.112.155"
-      ssh_user: root
-      # The `prod` self-hosted runner IS pop0 (187.124.112.155), so this is a
-      # co-located deploy. deploy-environment.yml auto-detects host_ip == a
-      # local IP and downgrades this to a LOCAL connection (--connection=local
-      # + sudo, no SSH) — SSHing root@pop0 to itself was rejected with
-      # "Permission denied (publickey,password)". Kept as ssh_key so the same
-      # call site still works verbatim if this job ever moves to a runner that
-      # is genuinely remote from pop0.
-      connection_mode: ssh_key
+      host_ip: "192.168.1.48"
+      ssh_user: bwalia
+      # Mirrors int/test: a self-hosted runner labeled `acc` runs on
+      # 192.168.1.48 itself, so ansible connects with --connection=local
+      # (no SSH). If this ever moves to a runner remote from the target,
+      # switch connection_mode to ssh_key and provision an SSH key trust
+      # from that runner to bwalia@192.168.1.48.
+      connection_mode: local
       secrets_mode: vault_or_sops
-      health_endpoint: "https://prod-our-v1.wslproxy.com/healthz"
-      health_check_mode: external
+      health_endpoint: "http://localhost:8080/healthz"
+      health_check_mode: local
       docker_prune: true
       notify_success: true
       deploy_branch: ${{ inputs.DEPLOY_BRANCH }}

--- a/infra/ansible/host_vars/192.168.1.48/vars.yaml
+++ b/infra/ansible/host_vars/192.168.1.48/vars.yaml
@@ -1,0 +1,26 @@
+# Acceptance (acc) — LAN host.
+#
+# Mirrors the test host_vars pattern (LAN peer, bwalia SSH user, vault-or-sops
+# secrets). Populated when acc was migrated off 187.124.112.155 (which
+# co-hosted prod-pop0) to its own dedicated LAN box.
+#
+# Secrets: the calling workflow passes secrets_mode=vault_or_sops, so
+# local_settings_file_path/local_env_file_path are only consulted as an
+# emergency fallback when Vault is unreachable and SOPS also fails.
+local_settings_file_path: "/home/bwalia/.secrets/wslproxy/acc/settings.json"
+local_env_file_path: "/home/bwalia/.secrets/wslproxy/acc/.env"
+nginx_user_password: "!!REDACTED!!" # For www-data — encrypt via Ansible Vault before use.
+host_lan_ip: "192.168.1.48"
+nginx_web_ui_enabled: "yes"
+nginx_rest_api_server_enabled: ""
+nginx_data_sync_enabled: ""
+node_max_old_space_size: 1024
+nginx_s3_proxy_pass_host_ip: "192.168.1.200"
+nginx_s3_server_name: "s3.workstation.co.uk"
+nginx_s3_cli_server_name: "s3-cli.workstation.co.uk"
+nginx_k3s_dashboard_server_name: "k3s-dashboard.workstation.co.uk"
+nginx_default_server_frontend: "acc.wslproxy.com www.acc.wslproxy.com acc.wslproxy.org www.acc.wslproxy.org"
+nginx_default_server_backend: "192.168.1.48"
+nginx_default_server_backend_port: 8080
+letsencrypt_email: "balinder.walia@gmail.com"
+openresty_admin_secondary_color: "#D91656"

--- a/infra/ansible/hosts
+++ b/infra/ansible/hosts
@@ -1,12 +1,14 @@
 # ──────────────────────────────────────────────────────
 # WSLProxy Ansible Inventory
-# Pipeline: int → test → prod
-# (The `acc` tier on 187.77.179.206 was decommissioned.)
+# Pipeline: int → test → acc → prod
+# (acc historically shared pop0 on 187.124.112.155 and was earlier
+#  decommissioned on 187.77.179.206; it now lives on its own LAN box.)
 # ──────────────────────────────────────────────────────
 
 [openresty_native_cluster]
 192.168.1.193 ansible_user=bwalia
 192.168.1.140 ansible_user=bwalia
+192.168.1.48 ansible_user=bwalia
 187.124.112.155 ansible_user=root
 72.62.211.28 ansible_user=root
 18.133.126.242 ansible_user=admin
@@ -19,6 +21,9 @@
 [openresty_test]
 192.168.1.140 ansible_user=bwalia
 
+[openresty_acc]
+192.168.1.48 ansible_user=bwalia
+
 [openresty_prod]
 187.124.112.155 ansible_user=root
 72.62.211.28 ansible_user=root
@@ -29,4 +34,5 @@
 [openresty_servers:children]
 openresty_int
 openresty_test
+openresty_acc
 openresty_prod


### PR DESCRIPTION
## Summary

- Move the `acc` (Acceptance) environment off `187.124.112.155` (co-located with prod-pop0) onto its own LAN host `192.168.1.48`, mirroring the int/test topology (self-hosted runner on the target, `--connection=local`, local health check).
- `prod-pop0` stays on `187.124.112.155` — verified by grep that every remaining reference to that IP is prod-pop0 scope (delivery pipeline stage 5a, `openresty_prod` group, pops list, host_vars, README table, virtual-servers workflow, S3 sync workflow, diagram, install script).
- New Ansible inventory group `[openresty_acc]` and new `host_vars/192.168.1.48/vars.yaml` cloned from the test-host pattern with acc-specific hostnames + SOPS fallback path.

## Changes

**`.github/workflows/deploy-single-environment.yml`** — acc block:
| Field | Before | After |
|---|---|---|
| `env_name` | `prod` | `acc` |
| `host_ip` | `187.124.112.155` | `192.168.1.48` |
| `ssh_user` | `root` | `bwalia` |
| `connection_mode` | `ssh_key` | `local` |
| `health_endpoint` | `https://prod-our-v1.wslproxy.com/healthz` (external) | `http://localhost:8080/healthz` (local) |

Header docblock and inline comments updated. `secrets_mode: vault_or_sops` unchanged.

**`infra/ansible/hosts`**:
- Add `192.168.1.48 ansible_user=bwalia` to `[openresty_native_cluster]`.
- New `[openresty_acc]` group with `192.168.1.48`.
- Wire `openresty_acc` into `[openresty_servers:children]`.
- Header comment: pipeline is `int → test → acc → prod` again.

**`infra/ansible/host_vars/192.168.1.48/vars.yaml`** (new): mirrors `host_vars/192.168.1.140/` (test) with:
- `host_lan_ip: 192.168.1.48`
- `nginx_default_server_frontend: acc.wslproxy.com www.acc.wslproxy.com acc.wslproxy.org www.acc.wslproxy.org`
- `nginx_default_server_backend: 192.168.1.48`
- SOPS fallback path `/home/bwalia/.secrets/wslproxy/acc/`

## Operator prerequisites before the first `acc` deploy will succeed

1. **Runner** — register a self-hosted GitHub runner **labeled `acc`** on `192.168.1.48` (same setup as the int/test runners on their boxes). Until this exists, the acc job will queue.
2. **Secrets** — seed Vault at `wslproxy/acc/settings.json` + `wslproxy/acc/env`, or drop a SOPS file at `infra/secrets/acc/settings.sops.json`. `secrets_mode: vault_or_sops` tries Vault first and falls back to SOPS.
3. **DNS / TLS** — point `acc.wslproxy.com` (and its `www.`/`.org` siblings) at `192.168.1.48`, otherwise the Let's Encrypt ACME challenge on the default vhost will fail. Alternatively, blank the `nginx_default_server_frontend` line in the host_vars until DNS is ready.

## Non-goals

- Not touching the delivery pipeline (`deploy-wslproxy-delivery-pipeline.yml`) — acc isn't in that promotion chain (only `int → test → prod-pop0 → prod-pop1` is).
- Not migrating any acc-specific tenant data — `data/servers/acc/`, `data/rules/acc/`, `data/waf_policies/acc/` etc. do not exist yet. Operator seeds them post-deploy via the admin UI or by copying from another env.

## Test plan

- [ ] Register a self-hosted runner labeled `acc` on `192.168.1.48`.
- [ ] Seed acc secrets in Vault (or SOPS fallback).
- [ ] Dispatch **Deploy Single Environment** with `ENV=acc`. Job picks up on the new runner, ansible runs locally with `bwalia` user + `become`, nginx starts, `/healthz` returns 200.
- [ ] Verify prod-pop0 (`187.124.112.155`) still deploys cleanly via the delivery pipeline — no cross-impact.
- [ ] Grep confirms no acc reference at the old IP; every remaining `187.124.112.155` reference is prod-pop0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)