### PR TITLE
fix(ci): acc runner is not on the target — use ssh_key mode

### DIFF
--- a/.github/workflows/deploy-single-environment.yml
+++ b/.github/workflows/deploy-single-environment.yml
@@ -124,10 +124,13 @@ jobs:
   # Acceptance — acc (192.168.1.48, LAN). vault-first with SOPS fallback
   # (matches the delivery pipeline post-#1125; seed_from_host retired).
   # ──────────────────────────────────────────────────────
-  # Migrated off 187.124.112.155 (which was co-located with prod-pop0) — acc
-  # is now a dedicated host on the LAN, mirroring the int/test topology
-  # (self-hosted runner labeled `acc` on the target box, local ansible
-  # connection, local health check).
+  # Migrated off 187.124.112.155 (which was co-located with prod-pop0). acc
+  # now runs on a dedicated LAN box (192.168.1.48 / debian002); the `acc`
+  # self-hosted runner lives on the shared mac (hh193 / BalindeacStudio,
+  # LAN peer) and SSHes into acc as bwalia — its ~/.ssh/id_rsa is already
+  # trusted on the target. connection_mode=local would have `sudo`'d on
+  # the runner box (macOS, no passwordless sudo) instead of on acc, which
+  # is what failed run 30267669485.
   acc:
     if: ${{ inputs.ENV == 'acc' }}
     uses: ./.github/workflows/deploy-environment.yml
@@ -137,15 +140,13 @@ jobs:
       stage_number: "acc"
       host_ip: "192.168.1.48"
       ssh_user: bwalia
-      # Mirrors int/test: a self-hosted runner labeled `acc` runs on
-      # 192.168.1.48 itself, so ansible connects with --connection=local
-      # (no SSH). If this ever moves to a runner remote from the target,
-      # switch connection_mode to ssh_key and provision an SSH key trust
-      # from that runner to bwalia@192.168.1.48.
-      connection_mode: local
+      # ssh_key: ansible SSHes from the runner (mac, LAN peer) into acc
+      # using the runner's ~/.ssh/id_rsa. If the `acc` runner is ever
+      # moved onto 192.168.1.48 itself, drop this to `local`.
+      connection_mode: ssh_key
       secrets_mode: vault_or_sops
       health_endpoint: "http://localhost:8080/healthz"
-      health_check_mode: local
+      health_check_mode: ssh
       docker_prune: true
       notify_success: true
       deploy_branch: ${{ inputs.DEPLOY_BRANCH }}


### PR DESCRIPTION
## Summary

Follow-up to #1163. That PR set `connection_mode: local` on the acc block on the assumption that the `acc` self-hosted runner would live on `192.168.1.48` itself (mirroring int/test). It doesn't — the runner is on the shared mac (`BalindeacStudio`, LAN peer at `192.168.1.177 / .143`), so `local` mode sudo'd on the runner box instead of on the target and failed.

## Failure evidence

Run [30267669485](https://github.com/bwalia/wslproxy/actions/runs/30267669485/job/89982184852):
```
Full deploy to Acceptance (192.168.1.48)
sudo: a terminal is required to read the password;
either use the -S option to read from standard input
or configure an askpass helper
sudo: a password is required
```

## Verified on the runner box (`ssh -p 2225 balinderwalia@hh193.workstation.co.uk`)

| Check | Result |
|---|---|
| Runner hostname | `BalindeacStudio.powerhub` (macOS, `/opt/homebrew/bin/bash`) |
| Runner LAN IPs | `en0: 192.168.1.177`, `en1: 192.168.1.143` — not `.48` |
| `ssh -o BatchMode=yes bwalia@192.168.1.48` | ✅ succeeds, target is `debian002` |
| `sudo -n id` on acc | ✅ `uid=0(root)` — passwordless sudo works on target |
| Runner `~/.ssh/id_rsa` | ✅ present (mode 600), trusted by target |

## Fix

acc block in [deploy-single-environment.yml](.github/workflows/deploy-single-environment.yml):
- `connection_mode: local` → `ssh_key`
- `health_check_mode: local` → `ssh`
- Comment updated to reflect actual runner topology (LAN peer, not on-target).

[deploy-environment.yml:655-663](.github/workflows/deploy-environment.yml#L655-L663) already reuses `~/.ssh/id_rsa` when `secrets.SSH_PRIVATE_KEY` is empty, so **no new secret needs to be added** — the trust that lets `ssh bwalia@192.168.1.48` succeed today is the exact trust the deploy will use.

## Non-goals

- Not touching the runner topology itself. If you later move the `acc` runner onto `192.168.1.48` (matching int/test), drop `connection_mode` back to `local` and `health_check_mode` back to `local` in a single revert-shaped edit.
- Not touching int/test/prod blocks — they already work.

## Test plan

- [ ] Re-dispatch **Deploy Single Environment** with `ENV=acc` on this branch.
- [ ] Ansible connects to `192.168.1.48` over SSH (no more sudo-password error on the runner).
- [ ] `curl http://192.168.1.48:8080/healthz` from the runner via SSH returns 200.
- [ ] int/test/prod dispatches on the same workflow are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)