### PR TITLE
fix(secrets): acc SOPS settings had env_profile=int leftover from int-template copy

### DIFF
--- a/infra/secrets/acc/settings.sops.json
+++ b/infra/secrets/acc/settings.sops.json
@@ -33,7 +33,7 @@
 			"secondary": "ENC[AES256_GCM,data:lGLdC42ijg==,iv:/fDLd86h4ego+8UYv6Q8OmBoLPfst23y+b7F/yCai4A=,tag:ZFJQnhtjsT6T46zKkATv1Q==,type:str]"
 		}
 	},
-	"env_profile": "ENC[AES256_GCM,data:kUMA,iv:88QMgkImuaHB6NlrO8JDy98EMm/SvmNtElcFvUCvtgg=,tag:NyuHow/yX8j1fBoR3dLGmA==,type:str]",
+	"env_profile": "ENC[AES256_GCM,data:D3uY,iv:dmhgbhKyYQgvbFh3EX+K7SJrqL7HUZ2tv+aIq0nNufE=,tag:h9NlKHDYVeagd7uJLjFUKw==,type:str]",
 	"env_vars": {
 		"API_PAGE_SIZE": "ENC[AES256_GCM,data:8xWL4w==,iv:4wIZnSFExK6RjUgkCoT5m1CAL786dPKTLVu6fZKe8BM=,tag:TPj2dd+WiD06ywgjKmwn+Q==,type:float]",
 		"APP_NAME": "ENC[AES256_GCM,data:UxS4GpaCs7jI,iv:SNVJ6SBsLSoDGeIL/s4SR5ewIkOZrm02nUIvAkqNET8=,tag:LBAWce29walr4aQwwavUoQ==,type:str]",
@@ -99,8 +99,8 @@
 				"recipient": "age1n5h080hae9czwpsgfgz4vapxd86ud2742maxc5gezurlwzs9ee7s07e0k4"
 			}
 		],
-		"lastmodified": "2026-06-29T13:45:13Z",
-		"mac": "ENC[AES256_GCM,data:4PcourKPMhIgnkcBMANgeQGiOPBq1qzU5shyCeoH+kNDUXlQxvAZPA92pK/Z3FJf/qnbyYo30mQfYNptDvClaIMpGt74o5U3PXkjeA3WLa7qmE7CWstPFdVyJYQsvCQ/6ZNheQB34Jv5Nww50DivOT6Z+9DuAqZTHVCmlGZlFWk=,iv:SgwaVWG4TfmVV/oZLwM6553xD22gLSYvByk1gFF+YEc=,tag:3WqBBIpt8czUDwpQ84HxfA==,type:str]",
+		"lastmodified": "2026-07-28T06:13:04Z",
+		"mac": "ENC[AES256_GCM,data:UGOCC4RGbL0f1pwnGq/v2RCuZLtXvO/dmM9zKzOTmEWgQDfT+lVADOwsLekjy+Sj3iY/lKI1ubYHM2S3axH70fbNqrKLt/RJFraS0gRrS9servKFAGru2CAKb6sZqFiQ+f30jLpjDkcwiEmBM4eS7Xg8+tWOzVjKehZFnuyzHJQ=,iv:eQM0ZHx3OE0gUJStrC65ttmVfmYQV2tdMrsJEwGUTTI=,tag:4S4t8sXTzbJlAnf8rNp36w==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.13.1"
 	}


### PR DESCRIPTION
## Summary

Follow-up to #1163 and #1164. The acc deploy on branch `fix/acc-connection-mode-ssh-key` got past SSH + ansible setup (66 tasks green) and failed at the deliberate env_profile guard:

```
ABORTING DEPLOY — env_profile mismatch.
infra/secrets/acc/settings.sops.json decrypts to env_profile='int'
but the workflow's target_env='acc'.
```

That check ([deploy_data.yml:248](infra/ansible/roles/wslproxy/tasks/deploy_data.yml#L248)) is the guard we added after the 2026-06-29 prod outage — it's doing exactly what it was written for.

## Cause

`infra/secrets/acc/settings.sops.json` was seeded on 2026-06-30 by copying int's template and nobody bumped `env_profile` inside the payload before re-encrypting.

## Fix

```bash
export SOPS_AGE_KEY_FILE=~/.sops-age-key.txt
sops --set '["env_profile"] "acc"' infra/secrets/acc/settings.sops.json
sops -d --extract '["env_profile"]' infra/secrets/acc/settings.sops.json  # → acc
```

Only the one string changes; every other encrypted key is preserved.

## Failure logs

- Failing run (before this fix): [30319575780](https://github.com/bwalia/wslproxy/actions/runs/30319575780/job/90152432336)

## Test plan

- [ ] Merge this + #1164, then re-dispatch **Deploy Single Environment** with `ENV=acc` on `main`.
- [ ] Ansible passes the env_profile guard and continues past `SOPS: refuse deploy if settings.env_profile != target_env`.
- [ ] `/opt/nginx/data/settings.json` on 192.168.1.48 shows `env_profile: "acc"` after deploy.

## Follow-ups worth eyeballing on acc

The seed also brought int-specific values across for other fields. Consider — separately from this PR — auditing `infra/secrets/acc/settings.sops.json` and `env.sops.env` for:
- `super_user.email` (currently likely `int.sops@wslproxy.com`?) → `acc.sops@wslproxy.com`
- `env_vars.REDIS_HOST`, `POSTGRES_HOST` — if they point at int's infra, acc data will collide with int data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
