### PR TITLE
fix(ci,dashboard): remaining acc blockers — Next.js env enum + ansible target_env assert

### DIFF
--- a/infra/ansible/deploy-configs.yml
+++ b/infra/ansible/deploy-configs.yml
@@ -61,8 +61,8 @@
     - name: Validate target environment
       assert:
         that:
-          - target_env in ['dev', 'int', 'test', 'prod', 'lon1', 'diytaxreturn', 'diytaxreturn_wsl1']
-        fail_msg: "Invalid target_env: {{ target_env }}. Must be one of: dev, int, test, prod, lon1, diytaxreturn, diytaxreturn_wsl1"
+          - target_env in ['dev', 'int', 'test', 'acc', 'prod', 'lon1', 'diytaxreturn', 'diytaxreturn_wsl1']
+        fail_msg: "Invalid target_env: {{ target_env }}. Must be one of: dev, int, test, acc, prod, lon1, diytaxreturn, diytaxreturn_wsl1"
         success_msg: "Target environment validated: {{ target_env }}"
 
     - name: Ensure remote directories exist

--- a/openresty-admin-next/src/components/layout/Footer.tsx
+++ b/openresty-admin-next/src/components/layout/Footer.tsx
@@ -33,6 +33,7 @@ const ENV_PALETTE: Record<
   { dotClass: string; label: string }
 > = {
   prod: { dotClass: "bg-red-500", label: "PROD" },
+  acc: { dotClass: "bg-amber-500", label: "ACC" },
   test: { dotClass: "bg-blue-500", label: "TEST" },
   int: { dotClass: "bg-sky-400", label: "INT" },
   local: { dotClass: "bg-slate-400", label: "LOCAL" },

--- a/openresty-admin-next/src/lib/config/env.ts
+++ b/openresty-admin-next/src/lib/config/env.ts
@@ -25,7 +25,7 @@ const clientEnvSchema = z.object({
   // looking at prod or a staging tier.  `local` covers laptop /
   // docker compose; the rest map 1:1 to the deploy pipeline tiers.
   NEXT_PUBLIC_ENV_NAME: z
-    .enum(["local", "int", "test", "prod"])
+    .enum(["local", "int", "test", "acc", "prod"])
     .default("local"),
   // Full git SHA of the deployed commit — empty in dev.  The footer
   // renders the first 7 chars and links to the GitHub commit page.


### PR DESCRIPTION
## Summary

Two independently-blocking fixes to make the acc deploy actually reach a green health check. Failing run [30338419830](https://github.com/bwalia/wslproxy/actions/runs/30338419830/job/90208309178) died at the first of these; the second would have caught it one step later even if the first were fixed alone.

## The two gates

### 1. Next.js build — `NEXT_PUBLIC_ENV_NAME` Zod enum missing `"acc"`

Ansible passes `NEXT_PUBLIC_ENV_NAME={{ target_env }}` at build time ([service.j2:31](infra/ansible/roles/wslproxy/templates/wslproxy-nextjs-dashboard.service.j2#L31), [deploy_nextjs_admin_ui.yml:129](infra/ansible/roles/wslproxy/tasks/deploy_nextjs_admin_ui.yml#L129)). For acc that resolves to `NEXT_PUBLIC_ENV_NAME=acc`, but [env.ts:27-29](openresty-admin-next/src/lib/config/env.ts#L27-L29) only accepted `local|int|test|prod`:

```
Error: Invalid client environment variables:
  - NEXT_PUBLIC_ENV_NAME: Invalid option:
    expected one of "local"|"int"|"test"|"prod"
```

**Fix:**
- [env.ts:28](openresty-admin-next/src/lib/config/env.ts#L28) — add `"acc"` to the enum.
- [Footer.tsx:36](openresty-admin-next/src/components/layout/Footer.tsx#L36) — add matching `ENV_PALETTE[acc]`. Required by TS (Record is keyed on the enum union), not cosmetic. Amber dot to sit visually between prod-red and test-blue.

### 2. Ansible — `deploy-configs.yml` target_env assert missing `"acc"`

The reusable workflow runs two playbooks in sequence:
1. [`wslproxy-ops.yml`](.github/workflows/deploy-environment.yml#L754) (this is the one that got 116 tasks in on run 30338419830)
2. [`deploy-configs.yml`](.github/workflows/deploy-environment.yml#L777) (never reached yet — fails immediately after because…)

[deploy-configs.yml:64](infra/ansible/deploy-configs.yml#L64) asserts:
```yaml
- target_env in ['dev', 'int', 'test', 'prod', 'lon1', 'diytaxreturn', 'diytaxreturn_wsl1']
```

`acc` isn't in the list, so the assert would fail. **Fix:** add `'acc'` to the allowlist and the fail_msg.

## Sanity check — everything else that could gate on acc

Verified there are no other acc-shaped holes on the deploy path:
- `wslproxy-ops.yml` — no target_env assert
- Ansible role tasks — only reference `target_env` for path building (auto-creates `data/servers/acc/`, `data/rules/acc/`) — no whitelists
- Lua request-path code (`rule_matcher.lua`, `version_manager.lua`, `api.lua`) — profile_id is free-form; only doc comments hard-code "int/prod"
- `sync-configs.sh`, `reconcile-super-user.sh`, `kubeseal_automation.sh` — all already list `acc` in their case statements
- `deploy-single-environment.yml` — `ENV` choice list already contains `acc` (added in #1163)
- Ansible inventory — `[openresty_acc]` group exists (added in #1163)
- Host_vars — `infra/ansible/host_vars/192.168.1.48/vars.yaml` exists (added in #1163)
- SOPS payload — `env_profile: "acc"` set (fixed in #1166)
- `data/servers/acc/` and `data/rules/acc/` — already populated in the repo

## Non-blocking follow-ups (out of scope for this PR)

Other workflows' choice lists have `int|test|prod` but no `acc`; they don't run in the deploy path so they're not blockers, but you'll want them updated before dispatching `ENV=acc` on any of these:
- [add-domain.yml:34-38](.github/workflows/add-domain.yml#L34-L38)
- [backup-wslproxy-data.yml:14-16](.github/workflows/backup-wslproxy-data.yml#L14-L16)

## Test plan

- [ ] Merge, then re-dispatch **Deploy Single Environment** with `ENV=acc` on `main`.
- [ ] `next build` completes without Zod error.
- [ ] `deploy-configs.yml` assert passes.
- [ ] Health gate returns 200 from `http://localhost:8080/healthz` on 192.168.1.48.
- [ ] Loading the acc dashboard shows an amber "ACC" badge in the footer.
- [ ] int / test / prod dispatches on the same workflow are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)