### PR TITLE
fix(ci): schedule prod-pop1 on mac-studio + purge runner_file secrets

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -9,6 +9,17 @@ on:
         description: "Ansible target_env value (int, test, acc, prod)"
         type: string
         required: true
+      runner_label:
+        description: >-
+          Self-hosted runner label to schedule this job on.  Defaults to
+          env_name so the historical "one runner per env, labelled after
+          the env" convention still works.  Set explicitly when the box
+          that has SSH+key access to the target isn't the box tagged
+          with env_name — e.g. prod (pop1, AWS eu-west-2) is deployed
+          from the mac-studio runner tagged `acc` because the historical
+          `prod` runner on pop0 has no SSH trust to pop1.
+        type: string
+        default: ""
       env_label:
         description: "Human-readable label for logs and Slack (e.g. 'Int (192.168.1.193)')"
         type: string
@@ -135,10 +146,14 @@ on:
 jobs:
   deploy:
     name: "Deploy ${{ inputs.env_label }}"
-    # OS-agnostic: match any self-hosted runner carrying the env label,
-    # whether it is Linux or macOS. Hardcoding `Linux` here left the `acc`
-    # job queued forever because the only `acc` runner is macOS.
-    runs-on: [self-hosted, "${{ inputs.env_name }}"]
+    # OS-agnostic: match any self-hosted runner carrying the target
+    # label, whether it is Linux or macOS. Hardcoding `Linux` here left
+    # the `acc` job queued forever because the only `acc` runner is
+    # macOS.  The label defaults to env_name (historical convention:
+    # one runner per env, labelled after the env), but the caller can
+    # override via `runner_label` when the box with the right SSH keys
+    # / network reach doesn't match the env — see input docs.
+    runs-on: [self-hosted, "${{ inputs.runner_label != '' && inputs.runner_label || inputs.env_name }}"]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/deploy-single-environment.yml
+++ b/.github/workflows/deploy-single-environment.yml
@@ -107,9 +107,11 @@ jobs:
       host_ip: "192.168.1.140"
       ssh_user: bwalia
       connection_mode: ssh
-      secrets_mode: runner_file
-      settings_file_path: "/home/bwalia/.secrets/wslproxy/test/settings.json"
-      env_file_path: "/home/bwalia/.secrets/wslproxy/test/.env"
+      # vault_or_sops so the deploy works from ANY runner — the previous
+      # runner_file mode read /home/bwalia/.secrets/wslproxy/test/{...}
+      # which only exists on the LAN test runner; moving the job to the
+      # mac-studio runner (as we did for prod-pop1) would have broken it.
+      secrets_mode: vault_or_sops
       health_endpoint: "http://localhost:8080/healthz"
       health_check_mode: ssh
       docker_prune: false
@@ -119,6 +121,9 @@ jobs:
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+      SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
 
   # ──────────────────────────────────────────────────────
   # Acceptance — acc (192.168.1.48, LAN). vault-first with SOPS fallback
@@ -162,11 +167,20 @@ jobs:
   # Production — prod / "pop1" (18.133.126.242, AWS eu-west-2, ssh user admin).
   # vault-first with SOPS fallback (matches the delivery pipeline post-#1125).
   # ──────────────────────────────────────────────────────
+  # Runner: the historical `prod` runner lives on pop0 (Linux) and has no
+  # SSH trust to pop1 — every prod dispatch failed at "SSH connection
+  # failed to admin@18.133.126.242" (run 30341173054). Schedule this job
+  # on the mac-studio runner tagged `acc` instead — it already has an
+  # id_rsa that pop1 trusts (verified: `ssh admin@18.133.126.242 hostname`
+  # returns ip-10-0-0-207 with passwordless sudo). env_name stays `prod`
+  # so ansible target_env, Vault secret path, and SOPS payload profile
+  # all remain prod.
   prod:
     if: ${{ inputs.ENV == 'prod' }}
     uses: ./.github/workflows/deploy-environment.yml
     with:
       env_name: prod
+      runner_label: acc
       env_label: "Production — pop1 (18.133.126.242)"
       stage_number: "prod"
       host_ip: "18.133.126.242"

--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -390,9 +390,11 @@ jobs:
       host_ip: "192.168.1.140"
       ssh_user: bwalia
       connection_mode: ssh
-      secrets_mode: runner_file
-      settings_file_path: "/home/bwalia/.secrets/wslproxy/test/settings.json"
-      env_file_path: "/home/bwalia/.secrets/wslproxy/test/.env"
+      # vault_or_sops so any runner can deploy; runner_file (previous
+      # value) required /home/bwalia/.secrets/wslproxy/test/{...} to
+      # exist on the runner FS, which pinned the job to the LAN test
+      # runner and broke portability.
+      secrets_mode: vault_or_sops
       health_endpoint: "http://localhost:8080/healthz"
       health_check_mode: ssh
       docker_prune: false
@@ -402,6 +404,9 @@ jobs:
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+      SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
 
   # Stage 5 (acc / 187.77.179.206) was decommissioned.  Prod stages
   # below now depend directly on `deploy-test` so the pipeline still
@@ -499,6 +504,12 @@ jobs:
     uses: ./.github/workflows/deploy-environment.yml
     with:
       env_name: prod
+      # Schedule on the mac-studio runner (labelled `acc`) rather than the
+      # historical `prod` runner on pop0 — pop0 has no SSH trust to pop1
+      # and every dispatch failed at "SSH connection failed to
+      # admin@18.133.126.242" (run 30341173054). env_name stays `prod` so
+      # ansible target_env / Vault path / SOPS payload profile are prod.
+      runner_label: acc
       env_label: "Prod pop1 (18.133.126.242)"
       stage_number: "5c"
       host_ip: "18.133.126.242"

--- a/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-nightly-pipeline.yml
@@ -281,9 +281,9 @@ jobs:
       host_ip: "192.168.1.140"
       ssh_user: bwalia
       connection_mode: ssh
-      secrets_mode: runner_file
-      settings_file_path: "/home/bwalia/.secrets/wslproxy/test/settings.json"
-      env_file_path: "/home/bwalia/.secrets/wslproxy/test/.env"
+      # vault_or_sops so any runner can deploy — see delivery pipeline
+      # test stage for the full rationale.
+      secrets_mode: vault_or_sops
       health_endpoint: "http://localhost:8080/healthz"
       health_check_mode: ssh
       docker_prune: false
@@ -293,6 +293,9 @@ jobs:
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+      SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
 
   # ──────────────────────────────────────────────────────
   # Stage 5: Nightly Summary (always runs)

--- a/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-promotion-pipeline.yml
@@ -311,9 +311,9 @@ jobs:
       host_ip: "192.168.1.140"
       ssh_user: bwalia
       connection_mode: ssh
-      secrets_mode: runner_file
-      settings_file_path: "/home/bwalia/.secrets/wslproxy/test/settings.json"
-      env_file_path: "/home/bwalia/.secrets/wslproxy/test/.env"
+      # vault_or_sops so any runner can deploy — see delivery pipeline
+      # test stage for the full rationale.
+      secrets_mode: vault_or_sops
       health_endpoint: "http://localhost:8080/healthz"
       health_check_mode: ssh
       docker_prune: false
@@ -326,6 +326,9 @@ jobs:
     secrets:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+      VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+      SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
 
   # ──────────────────────────────────────────────────────
   # Summary


### PR DESCRIPTION
## Summary

Failing run [30341173054](https://github.com/bwalia/wslproxy/actions/runs/30341173054/job/90216871610) — prod-pop1 dispatch died with:

```
##[error]SSH connection failed to admin@18.133.126.242
```

The historical `prod` runner lives on pop0 (Linux) and has no SSH trust to pop1 (AWS eu-west-2). Verified live from the mac-studio runner (labelled `acc`, `hh193.workstation.co.uk:2225`):

```
$ ssh admin@18.133.126.242 'hostname; whoami; sudo -n id | head -1'
ip-10-0-0-207
admin
uid=0(root) gid=0(root) groups=0(root)
```

So mac-studio → pop1 already works — just needed to route the job there.

## The reusable-workflow change

`env_name` in [deploy-environment.yml](.github/workflows/deploy-environment.yml) does triple duty: runner label, ansible `target_env`, Vault path. Simply setting `env_name: acc` on the prod job would corrupt secrets and data paths. Added a new optional `runner_label` input that defaults to `env_name` — this decouples \"which runner runs the job\" from \"what environment is being deployed\".

```yaml
runs-on: [self-hosted, \"\${{ inputs.runner_label != '' && inputs.runner_label || inputs.env_name }}\"]
```

Backward-compatible: every existing caller keeps its historical behaviour because the fallback is `env_name`.

## Applied overrides

| Stage | env_name | runner_label | Why |
|---|---|---|---|
| **prod-pop1** in `deploy-wslproxy-delivery-pipeline.yml` (stage 5c) | `prod` | **`acc`** | pop0 runner can't SSH to pop1 |
| **prod** in `deploy-single-environment.yml` | `prod` | **`acc`** | Same reason (same target) |

Everything else keeps its current runner assignment.

## Secrets automation — purge `runner_file` where possible

Complementary hardening so every stage's secrets come from GitHub Actions env vars (Vault or SOPS), not from files on a specific runner's filesystem:

| Stage | Was | Now |
|---|---|---|
| `deploy-single-environment.yml` — test | `runner_file` (`/home/bwalia/.secrets/wslproxy/test/`) | `vault_or_sops` |
| `deploy-wslproxy-delivery-pipeline.yml` — test (stage 4) | `runner_file` | `vault_or_sops` |
| `deploy-wslproxy-promotion-pipeline.yml` — test (stage 4) | `runner_file` | `vault_or_sops` |
| `deploy-wslproxy-nightly-pipeline.yml` — test (stage 4) | `runner_file` | `vault_or_sops` |

For each, dropped `settings_file_path` / `env_file_path` and added `VAULT_ADDR` / `VAULT_TOKEN` / `SOPS_AGE_KEY` to the secrets block. `vault_or_sops` probes Vault first and falls back to the `infra/secrets/test/` SOPS bundle (already present, verified).

## Known gaps (out of scope — operator action needed)

1. **prod-lon1** still uses `runner_file` in the delivery pipeline. No `infra/secrets/lon1/` bundle exists. Migrating requires seeding SOPS payload first — happy to do that in a follow-up if lon1 is still in-use (or delete the stage if it's actually decommissioned).
2. **int-from-MacStudio** — `bwalia@192.168.1.193` rejects the mac-studio runner's `~/.ssh/id_rsa` (verified: `Permission denied (publickey,password)`). If you want int to also run from MacStudio, add the pubkey to `bwalia@192.168.1.193:~/.ssh/authorized_keys` and set `runner_label: acc` on the int stages the same way.

## SSH matrix from mac-studio runner (verified live)

| Target | Result |
|---|---|
| `bwalia@192.168.1.193` (int) | ❌ Permission denied |
| `bwalia@192.168.1.140` (test) | ✅ ok |
| `bwalia@192.168.1.48` (acc) | ✅ ok |
| `root@187.124.112.155` (prod-pop0) | ✅ ok |
| `admin@18.133.126.242` (prod-pop1) | ✅ ok — the fix |
| `root@72.62.211.28` (prod-lon1) | ✅ ok |

## Test plan

- [ ] Merge, then dispatch **Deploy Single Environment** with `ENV=prod` on `main`. Job schedules on mac-studio (acc-labelled runner), SSH to pop1 succeeds, deploy completes to `https://pop1.diytaxreturn.co.uk/healthz` 200.
- [ ] Dispatch `ENV=test` — verify vault_or_sops picks up secrets from Vault (or SOPS fallback) rather than the previous runner-local files.
- [ ] `ENV=int`, `ENV=acc`, `ENV=prod-pop0` still work unchanged (no override applied).
- [ ] Trigger the full delivery pipeline via a push to main / release — stages 4 (test) and 5c (prod-pop1) both use their new modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)