### PR TITLE
fix(secrets): test SOPS settings had env_profile=int leftover from int-template copy

### DIFF
--- a/infra/secrets/test/settings.sops.json
+++ b/infra/secrets/test/settings.sops.json
@@ -33,7 +33,7 @@
 			"secondary": "ENC[AES256_GCM,data:pQ2Yc7tckg==,iv:yZpZl7kOtttses+JEEEkYT960/U4VFh/wA2pxRKgu5w=,tag:LYTkprGD2njW1nAUIzk7TQ==,type:str]"
 		}
 	},
-	"env_profile": "ENC[AES256_GCM,data:S0iN,iv:0dCkR6uOKIOCC06LGuBdQMojO3nh1+FnqO5D0qJRcIM=,tag:HJGr/Pni1G0tiq/vxpoIZw==,type:str]",
+	"env_profile": "ENC[AES256_GCM,data:LJdOtg==,iv:UWQotmFDgAMq7DyDiWV38wXtU1mgIncZQVPDLAdkdYU=,tag:FTIlI1NwZA74e+eHZL/c8Q==,type:str]",
 	"env_vars": {
 		"API_PAGE_SIZE": "ENC[AES256_GCM,data:l3Pf2w==,iv:V5CuPF0bN9d9TI430jSZmwjRiMkXtUAAMkluaMtsOow=,tag:uGsQAxWxwTB7Ksd7rksDsQ==,type:float]",
 		"APP_NAME": "ENC[AES256_GCM,data:Mmbyz+suT28j,iv:lh84ZmpDNfWHAKOoiyAkcNI6F9q1LRa4hJOu1S3UgSk=,tag:U4qlzmuu86Z9bxF5ehzw6A==,type:str]",
@@ -99,8 +99,8 @@
 				"recipient": "age1n5h080hae9czwpsgfgz4vapxd86ud2742maxc5gezurlwzs9ee7s07e0k4"
 			}
 		],
-		"lastmodified": "2026-06-29T13:45:13Z",
-		"mac": "ENC[AES256_GCM,data:hsp5bWm1A3YR/brbQG98wNAPWerhed+ueYt2DCAFHiBPTJt+brCEzP3lP1JrVe+ozVaUQEMSp4AGaTQWz4ajDzfLyaTrsZXParX1odKXiOuETl6Uak4SGL3JVubju9ffXwakk8ES7y3e57bDdqObXlaXJFJujdfNxJy9BZVCuTE=,iv:853bsasfo1BDKK/nTTQpnslMPSD6hwHSOB2RTnyQPxE=,tag:rb9I20yYp6rFvNgP53AHNA==,type:str]",
+		"lastmodified": "2026-07-28T11:34:24Z",
+		"mac": "ENC[AES256_GCM,data:SPqJHqfM8coK9X7yGN2fQ3nHeq2IJ4DNbwm4fWxzukcPlWXOD75P/4cxJwTCohnQsmBL3pY637y7fV5pD+oSLjcIVfIH8nTIVrYbglNF/XkfzVbwKLV+BuDfpo/2tgnDPaQX//JWbqxO2nYTRoF/viGVgKS+R1jk27T1L1ziDyk=,iv:jTfZmAJ8ia9ei8GIr4YYxRYPdEu8fW+DaDpEQMlrlLM=,tag:s83tib2KdUXb72VUICUb+w==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.13.1"
 	}


### PR DESCRIPTION
## Summary

Follow-up to the failing test dispatch [30354236805](https://github.com/bwalia/wslproxy/actions/runs/30354236805/job/90258594006) after PR #1168 merged. `test` failed at the env_profile guard exactly as predicted in the go/no-go review:

```
ABORTING DEPLOY — env_profile mismatch.
infra/secrets/test/settings.sops.json decrypts to env_profile='int'
but the workflow's target_env='test'.
```

## Cause

Same shape as [#1166 (acc)](https://github.com/bwalia/wslproxy/pull/1166) and [#1133 (prod)](https://github.com/bwalia/wslproxy/pull/1133): the four SOPS bundles were seeded together on 2026-06-29 (commit af5e9fd8) from a single `data/settings-prod.json` template whose `env_profile` happened to be `"int"`. `int` matched by accident; `acc` and `prod` were later fixed explicitly; `test` was overlooked because it deployed via `runner_file` mode (which reads `/home/bwalia/.secrets/wslproxy/test/settings.json` on the LAN test runner — that file has `env_profile: test`) and never actually consulted the SOPS bundle.

PR #1168 switched test to `vault_or_sops` for portability across runners → SOPS bundle became the effective source of truth → guard fired.

## Fix

```bash
sops --set '["env_profile"] "test"' infra/secrets/test/settings.sops.json
```

Only the single string changes; every other encrypted key is preserved.

## Verified all 4 bundles after the fix

| Bundle | Decrypted env_profile |
|---|---|
| `infra/secrets/int/settings.sops.json`  | `int`  ✅ |
| `infra/secrets/test/settings.sops.json` | `test` ✅ (this PR) |
| `infra/secrets/acc/settings.sops.json`  | `acc`  ✅ (#1166) |
| `infra/secrets/prod/settings.sops.json` | `prod` ✅ (#1133) |

## Non-blocking findings from the same audit (for future cleanup)

The four `env.sops.env` files are byte-identical across all envs (verified — every var has the same SHA1 hash across int/test/acc/prod). Every variable in them is `NEXT_PUBLIC_*` (build-time overridden by ansible) or empty, so no runtime data poisoning. Worth deduping in a future PR but not blocking.

Also independently found + already reported: Vault at `vault.diytaxreturn.co.uk` is healthy but the CI pipeline gets HTTP 403 — the repo's `VAULT_ADDR` or `VAULT_TOKEN` secret is stale. Every deploy currently falls back to SOPS, which is why this bundle fix is load-bearing right now. Rotating those two GH secrets would restore Vault as primary.

## Test plan

- [ ] Merge, then re-dispatch **Deploy Single Environment** with `ENV=test` on `main`.
- [ ] Ansible passes the env_profile guard and proceeds past `SOPS: refuse deploy if settings.env_profile != target_env`.
- [ ] `/opt/nginx/data/settings.json` on 192.168.1.140 shows `env_profile: "test"` after deploy (already does — verified live pre-PR).
- [ ] int / acc / prod dispatches remain unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
