### PR TITLE
feat(lon1): coexist Traefik loopback with wslproxy on public IP

### DIFF
--- a/infra/ansible/host_vars/72.62.211.28/vars.yaml
+++ b/infra/ansible/host_vars/72.62.211.28/vars.yaml
@@ -2,6 +2,8 @@ local_settings_file_path: "/home/bwalia/.secrets/wslproxy/lon1/settings.json"
 local_env_file_path: "/home/bwalia/.secrets/wslproxy/lon1/.env"
 nginx_user_password: "!!REDACTED!!" # This is the password for the user www-data but must be encrypted using Ansible Vault
 host_lan_ip: "72.62.211.28"
+# Public eth0 only — Traefik-edge-lon1 keeps 127.0.0.1:80/443 for ingressClass traefik-edge
+nginx_public_bind_ip: "72.62.211.28"
 nginx_web_ui_enabled: "yes"
 nginx_rest_api_server_enabled: ""
 nginx_data_sync_enabled: ""

--- a/infra/ansible/roles/wslproxy/defaults/main.yml
+++ b/infra/ansible/roles/wslproxy/defaults/main.yml
@@ -1,5 +1,10 @@
 nginx_port: 80
 
+# When set (e.g. "72.62.211.28"), public HTTP/HTTPS listeners bind that IP
+# only — so Traefik (or anything else) can keep 127.0.0.1:80/443 on the same
+# host without EADDRINUSE. Empty = bind all interfaces (0.0.0.0 / *).
+nginx_public_bind_ip: ""
+
 # Default server frontend/backend hostnames for nginx
 # Override these in host_vars or group_vars for each environment
 # Frontend: public landing page (static HTML)

--- a/infra/ansible/roles/wslproxy/templates/default.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/default.conf.j2
@@ -2,6 +2,9 @@
     # Frontend: {{ nginx_default_server_frontend | default('') }}
     # Backend:  {{ nginx_default_server_backend | default('') }}
     # Let's Encrypt Email: {{ letsencrypt_email }}
+{% set _pub = nginx_public_bind_ip | default('') %}
+{% set _listen80 = (_pub ~ ':80') if (_pub | length > 0) else '80' %}
+{% set _listen443 = (_pub ~ ':443') if (_pub | length > 0) else '443' %}
 
 {% if nginx_default_server_frontend | default('') | length > 0 %}
     # ──────────────────────────────────────────────────────
@@ -10,7 +13,7 @@
 
     # HTTP (port 80) — serves landing page + ACME challenge
     server {
-        listen       80;
+        listen       {{ _listen80 }};
         server_name  {{ nginx_default_server_frontend }} {{ host_lan_ip | default('') }};
 
         location /.well-known/acme-challenge/ {
@@ -27,7 +30,7 @@
 
     # HTTPS (port 443) — landing page with auto-ssl
     server {
-        listen       443 ssl;
+        listen       {{ _listen443 }} ssl;
         server_name  {{ nginx_default_server_frontend }};
 
         http2 on;
@@ -70,7 +73,7 @@
 
     # HTTP (port 80) — redirect to HTTPS + ACME challenge
     server {
-        listen       80;
+        listen       {{ _listen80 }};
         server_name  {{ nginx_default_server_backend }};
 
         location /.well-known/acme-challenge/ {
@@ -86,7 +89,7 @@
 
     # HTTPS (port 443) — admin UI with auto-ssl
     server {
-        listen       443 ssl;
+        listen       {{ _listen443 }} ssl;
         server_name  {{ nginx_default_server_backend }};
 
         http2 on;
@@ -155,7 +158,7 @@
 
     # HTTP (port 80) — redirect to HTTPS + ACME challenge
     server {
-        listen       80;
+        listen       {{ _listen80 }};
         server_name  {{ nginx_default_server_backend_nextjs }};
 
         location /.well-known/acme-challenge/ {
@@ -171,7 +174,7 @@
 
     # HTTPS (port 443) — Next.js dashboard with auto-ssl
     server {
-        listen       443 ssl;
+        listen       {{ _listen443 }} ssl;
         server_name  {{ nginx_default_server_backend_nextjs }};
 
         http2 on;

--- a/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
@@ -740,9 +740,14 @@ http {
   # Internal server running on port 8999 for handling certificate tasks.
 
 # server any host 443 ssl and http2 port, http below this server block will be redirected to https
+{# nginx_public_bind_ip: bind public IP only (coexist with Traefik on 127.0.0.1) #}
 server {
+{% if nginx_public_bind_ip | default('') | length > 0 %}
+    listen {{ nginx_public_bind_ip }}:443 ssl default_server;
+{% else %}
     listen *:443 ssl default_server;
     listen [::]:443 ssl default_server;
+{% endif %}
     server_name _; # catch-all server block for HTTPS
     server_tokens off;
     http2 on;
@@ -991,7 +996,11 @@ server {
 
 # server any host http port 80
 server {
+{% if nginx_public_bind_ip | default('') | length > 0 %}
+        listen       {{ nginx_public_bind_ip }}:80 default_server;
+{% else %}
         listen       80 default_server;
+{% endif %}
         server_name _; # catch-all server block for HTTP requests (redirect to HTTPS or serve ACME challenges)
         server_tokens off;
         # enable

--- a/infra/k8s/traefik-edge-lon1/INFRA_ANSIBLE_PROMPT.md
+++ b/infra/k8s/traefik-edge-lon1/INFRA_ANSIBLE_PROMPT.md
@@ -1,0 +1,271 @@
+# Prompt: Codify lon1 Traefik loopback + wslproxy public IP bind (Ansible / main infra)
+
+> Copy everything below the line into an agent session opened on the **main infra repo**
+> (the GitOps / Ansible repo that owns `traefik-edge` and k3s edge nodes — historically applied as
+> `DaemonSet/traefik-edge` in `kube-system` with `last-applied-configuration`).
+>
+> Related live state was already applied ad-hoc; this prompt is to **make it durable via Ansible**.
+
+---
+
+## Mission
+
+On edge node **cloud001** (`72.62.211.28`, hostname `srv1494211`, also called **lon1 / prod lon1**):
+
+1. **Traefik** (`ingressClassName: traefik-edge`) must **not** bind the public NIC on `:80`/`:443`.
+2. Traefik on that node should listen only on **loopback TCP sockets**:
+   - `127.0.0.1:80`
+   - `127.0.0.1:443`
+   - `127.0.0.1:9080` (ping / traefik entrypoint)
+3. **Public IP** `72.62.211.28:80` and `:443` must be free for **OpenResty / wslproxy** so the control-plane UI at **`lon1.pop0.uk`** works.
+4. **Do not break** Traefik on other edge nodes (`cloud002` = `187.124.112.155`, `cloud003` = `77.68.126.63`) — they keep `*:80` / `*:443`.
+
+Also ensure wslproxy Ansible (repo `bwalia/wslproxy`) binds OpenResty to the **public IP only** on lon1. Linux returns `EADDRINUSE` if OpenResty binds `0.0.0.0:80` while Traefik holds `127.0.0.1:80`.
+
+---
+
+## Current / desired end state (verify after apply)
+
+On `root@72.62.211.28`:
+
+```text
+ss -lntp | grep -E ':(80|443|9080|7691)\b'
+```
+
+Expected:
+
+| Bind | Owner |
+|------|--------|
+| `127.0.0.1:80` | traefik (`traefik-edge-lon1`) |
+| `127.0.0.1:443` | traefik |
+| `127.0.0.1:9080` | traefik |
+| `72.62.211.28:80` | nginx / openresty |
+| `72.62.211.28:443` | nginx / openresty |
+| `0.0.0.0:7691` | openresty admin API |
+
+Smoke:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:9080/ping          # 200
+curl -sS -o /dev/null -w '%{http_code}\n' -H 'Host: lon1.pop0.uk' http://72.62.211.28/healthz
+# 200 or 301 to https — not connection refused
+systemctl is-active openresty   # active
+```
+
+Cluster (admin kubeconfig on control plane, e.g. `debian009` / `192.168.1.104`):
+
+```bash
+kubectl -n kube-system get ds,pods -o wide -l 'app.kubernetes.io/name in (traefik-edge,traefik-edge-lon1)'
+# traefik-edge on cloud002 + cloud003 only
+# traefik-edge-lon1 on cloud001 only
+```
+
+---
+
+## What already exists (ad-hoc; replace with Ansible)
+
+Live cluster (applied manually, not GitOps):
+
+1. Patched `DaemonSet/traefik-edge` with affinity **excluding** `kubernetes.io/hostname=cloud001`.
+2. Created `DaemonSet/traefik-edge-lon1` (hostNetwork, nodeSelector hostname=cloud001, entryPoints on `127.0.0.1`).
+3. In **wslproxy** repo (partial):
+   - `infra/k8s/traefik-edge-lon1/` — reference manifests + `apply.sh`
+   - `infra/ansible/host_vars/72.62.211.28/vars.yaml` → `nginx_public_bind_ip: "72.62.211.28"`
+   - Templates `nginx.conf.j2` / `default.conf.j2` honor `nginx_public_bind_ip`
+   - Live nginx.conf on lon1 was hot-patched the same way
+
+**Your job in the main infra repo:** own the Traefik DaemonSet split via Ansible (or Helm/kustomize that Ansible applies). Coordinate with wslproxy for the OpenResty bind (already started there).
+
+---
+
+## Implement in main infra repo
+
+### A. Inventory / host facts
+
+Document lon1:
+
+| Field | Value |
+|-------|--------|
+| Public IP | `72.62.211.28` |
+| k3s node name | `cloud001` |
+| Role label | `node-role.kubernetes.io/edge=true` |
+| SSH | `root@72.62.211.28` |
+| wslproxy admin host | `lon1.pop0.uk` → OpenResty → `127.0.0.1:7691` |
+| Cluster API | via k3s control plane (not local k3s server on cloud001; node runs `k3s-agent`) |
+
+### B. Ansible role tasks (suggested)
+
+Create or extend a role e.g. `roles/traefik_edge/` (or under existing `k3s` / `edge` role):
+
+1. **Template** `traefik-edge` DaemonSet (cluster-wide edge):
+   - Keep existing image/args/resources/SA `traefik`
+   - `hostNetwork: true`
+   - `nodeSelector: node-role.kubernetes.io/edge: "true"`
+   - **Add affinity** so it does **not** schedule on lon1:
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: node-role.kubernetes.io/edge
+              operator: In
+              values: ["true"]
+            - key: kubernetes.io/hostname
+              operator: NotIn
+              values: ["{{ traefik_edge_loopback_nodes | default(['cloud001']) | list | join('\",\"') }}"]
+# Prefer clean Jinja list for NotIn values — see example below
+```
+
+Better Jinja pattern:
+
+```yaml
+# group_vars or role defaults
+traefik_edge_loopback_hostnames:
+  - cloud001
+
+# in template
+            - key: kubernetes.io/hostname
+              operator: NotIn
+              values:
+{% for h in traefik_edge_loopback_hostnames %}
+                - {{ h }}
+{% endfor %}
+```
+
+   - EntryPoints stay `*:80` / `*:443` / `:9080` (or `0.0.0.0`) for non-lon1 edges.
+
+2. **Template** second DaemonSet `traefik-edge-lon1` (or generic name `traefik-edge-loopback`):
+   - `nodeSelector: kubernetes.io/hostname: cloud001` (or loop over `traefik_edge_loopback_hostnames` with one DS per host, or a single DS with `nodeSelector` / affinity In list)
+   - Same `ingressclass=traefik-edge`, same SA, same image
+   - Args **must** be:
+
+```text
+--entryPoints.web.address=127.0.0.1:80/tcp
+--entryPoints.websecure.address=127.0.0.1:443/tcp
+--entryPoints.traefik.address=127.0.0.1:9080/tcp
+--providers.kubernetesingress
+--providers.kubernetesingress.ingressclass=traefik-edge
+```
+
+   - Probes: `httpGet` against `127.0.0.1:9080/ping` (set `host: 127.0.0.1` on probe)
+   - **Do not** use `hostPort` mapping to all interfaces; with `hostNetwork`, Traefik’s listen address is what matters
+   - Toleration for `node-role.kubernetes.io/edge=true:NoSchedule`
+
+3. **Apply** with `kubernetes.core.k8s` or `kubectl apply` from a controller that has admin kubeconfig (control-plane host or CI with kubeconfig secret).
+
+4. **Handlers:** wait for `rollout status` on both DaemonSets; fail the play if cloud001 still has the old `*:80` Traefik.
+
+5. **Idempotency:** if ad-hoc objects already exist, Ansible apply must reconcile to the templated desired state (not fight GitOps). If Argo/Flux owns this, put the manifests in the GitOps path instead of one-shot kubectl.
+
+### C. Reference DaemonSet (lon1 loopback) — already proven live
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: traefik-edge-lon1
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/component: ingress
+    app.kubernetes.io/name: traefik-edge-lon1
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: traefik-edge-lon1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ingress
+        app.kubernetes.io/name: traefik-edge-lon1
+    spec:
+      serviceAccountName: traefik
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: system-node-critical
+      nodeSelector:
+        kubernetes.io/hostname: cloud001
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/edge
+          operator: Equal
+          value: "true"
+      containers:
+        - name: traefik
+          image: rancher/mirrored-library-traefik:3.7.4
+          args:
+            - --global.checknewversion=false
+            - --global.sendanonymoususage=false
+            - --entryPoints.web.address=127.0.0.1:80/tcp
+            - --entryPoints.websecure.address=127.0.0.1:443/tcp
+            - --entryPoints.traefik.address=127.0.0.1:9080/tcp
+            - --api.dashboard=false
+            - --ping=true
+            - --providers.kubernetesingress
+            - --providers.kubernetesingress.ingressclass=traefik-edge
+            - --log.level=INFO
+            - --accesslog=true
+            - --entryPoints.web.transport.respondingTimeouts.readTimeout=1800s
+            - --entryPoints.websecure.transport.respondingTimeouts.readTimeout=1800s
+          ports:
+            - { name: web, containerPort: 80 }
+            - { name: websecure, containerPort: 443 }
+            - { name: traefik, containerPort: 9080 }
+          livenessProbe:
+            httpGet: { path: /ping, port: 9080, host: 127.0.0.1 }
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet: { path: /ping, port: 9080, host: 127.0.0.1 }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
+              drop: ["ALL"]
+            runAsUser: 0
+```
+
+Copy of working files also lives in **wslproxy**:
+`infra/k8s/traefik-edge-lon1/traefik-edge-lon1-daemonset.yaml` and `apply.sh`.
+
+### D. wslproxy side (ensure / PR if missing)
+
+In `bwalia/wslproxy` (may already be local; commit/PR if not on main):
+
+- `nginx_public_bind_ip: "72.62.211.28"` in `infra/ansible/host_vars/72.62.211.28/vars.yaml`
+- `nginx.conf.j2` / `default.conf.j2`: when set, `listen {{ ip }}:80` / `listen {{ ip }}:443` (skip `[::]:443` catch-all)
+- Deploy tag `nginx` (or full) to lon1 so templates replace the hot-patch
+
+Do **not** remove Traefik from the cluster; coexistence is intentional.
+
+### E. Out of scope / anti-goals
+
+- Do **not** change Traefik binds on cloud002/cloud003.
+- Do **not** remove `node-role.kubernetes.io/edge` from cloud001 unless you intentionally want zero Traefik there (loopback Traefik is preferred so `traefik-edge` Ingress still works for local/mesh clients).
+- Do **not** move Traefik to random high ports without documenting Ingress clients.
+- Do **not** leave OpenResty listening on `0.0.0.0:80` on lon1.
+
+---
+
+## Acceptance checklist
+
+- [ ] Ansible (or GitOps) is source of truth for both DaemonSets
+- [ ] Re-running the play is idempotent
+- [ ] cloud001: Traefik on `127.0.0.1` only for 80/443/9080
+- [ ] cloud001: OpenResty on `72.62.211.28:80/443`, service active
+- [ ] `lon1.pop0.uk` HTTP/HTTPS reachable on public IP
+- [ ] cloud002/cloud003: Traefik still on public `:80`/`:443`
+- [ ] Ingress class name remains `traefik-edge`
+- [ ] Docs: short README in infra repo describing lon1 coexistence
+
+---
+
+## First deliverable
+
+1. Find where `traefik-edge` is defined (or create the role if it only existed as `kubectl apply`).
+2. Add Ansible templates + vars for the split DaemonSets.
+3. Apply against the cluster and verify the `ss` / curl checklist above.
+4. Link or PR the matching `nginx_public_bind_ip` change in wslproxy if not already merged.
+5. Remove reliance on the one-off `apply.sh` in wslproxy once infra owns it (keep a pointer in docs).

--- a/infra/k8s/traefik-edge-lon1/README.md
+++ b/infra/k8s/traefik-edge-lon1/README.md
@@ -1,0 +1,28 @@
+# traefik-edge on lon1 (cloud001 / 72.62.211.28)
+
+On this edge node, public `:80`/`:443` are owned by **OpenResty / wslproxy**
+(`lon1.pop0.uk`). The cluster-wide `traefik-edge` DaemonSet binds `*:80`/`*:443`
+via `hostNetwork`, which blocks OpenResty from starting.
+
+## Change
+
+1. `traefik-edge` (cluster DS) — affinity **excludes** `cloud001`.
+2. `traefik-edge-lon1` — runs only on `cloud001`, listens on **loopback**:
+   - `127.0.0.1:80` / `127.0.0.1:443` (Ingress still works for local/mesh clients)
+   - `127.0.0.1:9080` (ping / admin entrypoint)
+
+Public IP `72.62.211.28:80/443` is then free for wslproxy. Other edge nodes
+(`cloud002`, `cloud003`) keep public Traefik binds unchanged.
+
+**Important:** Linux treats `0.0.0.0:80` as conflicting with `127.0.0.1:80`.
+OpenResty on lon1 must bind the public IP only via Ansible
+`nginx_public_bind_ip: "72.62.211.28"` (see `host_vars/72.62.211.28`).
+
+## Apply (from k3s control plane)
+
+```bash
+kubectl apply -f exclude-cloud001-patch.yaml   # see apply.sh
+kubectl apply -f traefik-edge-lon1-daemonset.yaml
+```
+
+Or: `./apply.sh` on a host with admin kubeconfig.

--- a/infra/k8s/traefik-edge-lon1/apply.sh
+++ b/infra/k8s/traefik-edge-lon1/apply.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Exclude cloud001 from cluster-wide traefik-edge; run loopback Traefik on lon1.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+KUBECTL="${KUBECTL:-kubectl}"
+
+echo "==> Patch traefik-edge: exclude kubernetes.io/hostname=cloud001"
+$KUBECTL -n kube-system patch daemonset traefik-edge --type=strategic -p '
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/edge
+                    operator: In
+                    values: ["true"]
+                  - key: kubernetes.io/hostname
+                    operator: NotIn
+                    values: ["cloud001"]
+'
+
+echo "==> Apply traefik-edge-lon1 (loopback binds on cloud001)"
+$KUBECTL apply -f "$ROOT/traefik-edge-lon1-daemonset.yaml"
+
+echo "==> Wait for rollout"
+$KUBECTL -n kube-system rollout status ds/traefik-edge --timeout=120s
+$KUBECTL -n kube-system rollout status ds/traefik-edge-lon1 --timeout=120s
+
+echo "==> Pods"
+$KUBECTL -n kube-system get pods -o wide -l 'app.kubernetes.io/name in (traefik-edge,traefik-edge-lon1)'
+echo "Done. On cloud001, public :80/:443 should be free for openresty."

--- a/infra/k8s/traefik-edge-lon1/traefik-edge-lon1-daemonset.yaml
+++ b/infra/k8s/traefik-edge-lon1/traefik-edge-lon1-daemonset.yaml
@@ -1,0 +1,90 @@
+# Lon1-only Traefik edge: bind loopback so public 72.62.211.28:80/443
+# can be used by OpenResty / wslproxy (lon1.pop0.uk).
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: traefik-edge-lon1
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/component: ingress
+    app.kubernetes.io/name: traefik-edge-lon1
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: traefik-edge-lon1
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: ingress
+        app.kubernetes.io/name: traefik-edge-lon1
+    spec:
+      serviceAccountName: traefik
+      automountServiceAccountToken: true
+      priorityClassName: system-node-critical
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector:
+        kubernetes.io/hostname: cloud001
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/edge
+          operator: Equal
+          value: "true"
+      containers:
+        - name: traefik
+          image: rancher/mirrored-library-traefik:3.7.4
+          imagePullPolicy: IfNotPresent
+          args:
+            - --global.checknewversion=false
+            - --global.sendanonymoususage=false
+            # Loopback only — frees 72.62.211.28:80/443 for wslproxy
+            - --entryPoints.web.address=127.0.0.1:80/tcp
+            - --entryPoints.websecure.address=127.0.0.1:443/tcp
+            - --entryPoints.traefik.address=127.0.0.1:9080/tcp
+            - --api.dashboard=false
+            - --ping=true
+            - --providers.kubernetesingress
+            - --providers.kubernetesingress.ingressclass=traefik-edge
+            - --log.level=INFO
+            - --accesslog=true
+            - --entryPoints.web.transport.respondingTimeouts.readTimeout=1800s
+            - --entryPoints.websecure.transport.respondingTimeouts.readTimeout=1800s
+          ports:
+            - name: web
+              containerPort: 80
+              protocol: TCP
+            - name: websecure
+              containerPort: 443
+              protocol: TCP
+            - name: traefik
+              containerPort: 9080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 9080
+              host: 127.0.0.1
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 9080
+              host: 127.0.0.1
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            capabilities:
+              add: ["NET_BIND_SERVICE"]
+              drop: ["ALL"]
+            runAsNonRoot: false
+            runAsUser: 0


### PR DESCRIPTION
## Summary
- Bind OpenResty on lon1 (`72.62.211.28`) to the public IP only via `nginx_public_bind_ip`, so it can share the host with Traefik on loopback.
- Add `traefik-edge-lon1` DaemonSet manifests, apply script, README, and an Ansible/GitOps prompt for the main infra repo.

## Test plan
- [ ] Confirm lon1 host_vars sets `nginx_public_bind_ip: "72.62.211.28"`
- [ ] Ansible nginx deploy (or config render) listens on `72.62.211.28:80/443`, not `0.0.0.0`
- [ ] On cloud001: Traefik on `127.0.0.1:80/443/9080`; OpenResty on public IP; `lon1.pop0.uk` reachable
- [ ] cloud002/cloud003 Traefik public binds unchanged


Made with [Cursor](https://cursor.com)