### PR TITLE
fix(ci): gate deploy-int on TARGET_HOST for lon1-only runs

### DIFF
--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -244,7 +244,14 @@ jobs:
   # ──────────────────────────────────────────────────────
   deploy-int:
     needs: [build-validate, preflight-int]
-    if: needs.preflight-int.outputs.runner_online == 'true'
+    # Honor TARGET_HOST on workflow_dispatch (same as test/prod stages) so a
+    # lon1-only / pop0-only / pop1-only run never touches int. Push events
+    # still deploy int when the runner is online.
+    if: >
+      needs.preflight-int.outputs.runner_online == 'true' &&
+      (github.event_name != 'workflow_dispatch' ||
+       github.event.inputs.TARGET_HOST == '192.168.1.193' ||
+       github.event.inputs.TARGET_HOST == 'all')
     uses: ./.github/workflows/deploy-environment.yml
     with:
       env_name: int

--- a/infra/ansible/host_vars/72.62.211.28/vars.yaml
+++ b/infra/ansible/host_vars/72.62.211.28/vars.yaml
@@ -2,7 +2,9 @@ local_settings_file_path: "/home/bwalia/.secrets/wslproxy/lon1/settings.json"
 local_env_file_path: "/home/bwalia/.secrets/wslproxy/lon1/.env"
 nginx_user_password: "!!REDACTED!!" # This is the password for the user www-data but must be encrypted using Ansible Vault
 host_lan_ip: "72.62.211.28"
-# Public eth0 only — Traefik-edge-lon1 keeps 127.0.0.1:80/443 for ingressClass traefik-edge
+# LON1 ONLY — do not set nginx_public_bind_ip in group_vars or other host_vars.
+# Public eth0 only so Traefik-edge-lon1 can keep 127.0.0.1:80/443 (traefik-edge).
+# Admin UI: https://lon1.pop0.uk → this bind → proxy to :7691
 nginx_public_bind_ip: "72.62.211.28"
 nginx_web_ui_enabled: "yes"
 nginx_rest_api_server_enabled: ""


### PR DESCRIPTION
## Summary
- `deploy-int` now respects `TARGET_HOST` on `workflow_dispatch`, matching test/prod stages, so a lon1-only run never touches int/pop0/pop1.
- Clarify in lon1 `host_vars` that `nginx_public_bind_ip` is lon1-only (for `https://lon1.pop0.uk`).

## Test plan
- [ ] Dispatch delivery pipeline with `TARGET_HOST=72.62.211.28`, `DEPLOY_MODE=nginx`, `DEPLOY_BRANCH=main`
- [ ] Confirm int/test/pop0/pop1 stages are skipped; only `deploy-prod-lon1` runs
- [ ] `https://lon1.pop0.uk/healthz` returns 200 after deploy


Made with [Cursor](https://cursor.com)