### PR TITLE
feat(nginx): nginx_public_bind_ip — bind public 80/443 to one IP (lon1)

### DIFF
--- a/infra/ansible/host_vars/72.62.211.28/vars.yaml
+++ b/infra/ansible/host_vars/72.62.211.28/vars.yaml
@@ -14,3 +14,9 @@ nginx_default_server_backend: "lon1.pop0.uk"
 nginx_default_server_backend_port: 7691
 letsencrypt_email: "balinder.walia@gmail.com"
 openresty_admin_secondary_color: "#D91656"
+# lon1 shares its netns with the k3s loopback Traefik (DaemonSet
+# traefik-edge-lon1 binds 127.0.0.1:80/:443). OpenResty must therefore bind
+# the public IP explicitly or the two race for :80/:443 (EADDRINUSE).
+# Owned end-to-end by diy-tax-return-infra: ansible/traefik-edge.yml +
+# clusters/k3s/edge/README.md.
+nginx_public_bind_ip: "72.62.211.28"

--- a/infra/ansible/roles/wslproxy/defaults/main.yml
+++ b/infra/ansible/roles/wslproxy/defaults/main.yml
@@ -113,3 +113,9 @@ wslproxy_pops:
       - production
       - secondary
     metadata: {}
+
+# When set to a host public IP, nginx binds its public 80/443 server blocks to
+# that IP only (no wildcard, no [::] catch-all). Used on nodes where a loopback
+# Traefik shares the host network namespace (see lon1 / cloud001). Empty keeps
+# the historical wildcard binds.
+nginx_public_bind_ip: ""

--- a/infra/ansible/roles/wslproxy/templates/default.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/default.conf.j2
@@ -1,3 +1,9 @@
+{# nginx_public_bind_ip: when set (e.g. lon1 = 72.62.211.28), public 80/443
+   server blocks bind that IP explicitly instead of the wildcard, leaving
+   127.0.0.1:80/:443 free for the loopback Traefik (traefik-edge-lon1) that
+   coexists on the node. Empty (default) keeps wildcard binds. #}
+{% set pub_bind = nginx_public_bind_ip | default('') %}
+{% set pub_prefix = (pub_bind ~ ':') if pub_bind else '' %}
     # Default server configuration — works independently of Lua gateway
     # Frontend: {{ nginx_default_server_frontend | default('') }}
     # Backend:  {{ nginx_default_server_backend | default('') }}
@@ -10,7 +16,7 @@
 
     # HTTP (port 80) — serves landing page + ACME challenge
     server {
-        listen       80;
+        listen       {{ pub_prefix }}80;
         server_name  {{ nginx_default_server_frontend }} {{ host_lan_ip | default('') }};
 
         location /.well-known/acme-challenge/ {
@@ -27,7 +33,7 @@
 
     # HTTPS (port 443) — landing page with auto-ssl
     server {
-        listen       443 ssl;
+        listen       {{ pub_prefix }}443 ssl;
         server_name  {{ nginx_default_server_frontend }};
 
         http2 on;
@@ -70,7 +76,7 @@
 
     # HTTP (port 80) — redirect to HTTPS + ACME challenge
     server {
-        listen       80;
+        listen       {{ pub_prefix }}80;
         server_name  {{ nginx_default_server_backend }};
 
         location /.well-known/acme-challenge/ {
@@ -86,7 +92,7 @@
 
     # HTTPS (port 443) — admin UI with auto-ssl
     server {
-        listen       443 ssl;
+        listen       {{ pub_prefix }}443 ssl;
         server_name  {{ nginx_default_server_backend }};
 
         http2 on;
@@ -155,7 +161,7 @@
 
     # HTTP (port 80) — redirect to HTTPS + ACME challenge
     server {
-        listen       80;
+        listen       {{ pub_prefix }}80;
         server_name  {{ nginx_default_server_backend_nextjs }};
 
         location /.well-known/acme-challenge/ {
@@ -171,7 +177,7 @@
 
     # HTTPS (port 443) — Next.js dashboard with auto-ssl
     server {
-        listen       443 ssl;
+        listen       {{ pub_prefix }}443 ssl;
         server_name  {{ nginx_default_server_backend_nextjs }};
 
         http2 on;

--- a/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
+++ b/infra/ansible/roles/wslproxy/templates/nginx.conf.j2
@@ -1,3 +1,9 @@
+{# nginx_public_bind_ip: when set (e.g. lon1 = 72.62.211.28), public 80/443
+   server blocks bind that IP explicitly instead of the wildcard, leaving
+   127.0.0.1:80/:443 free for the loopback Traefik (traefik-edge-lon1) that
+   coexists on the node. Empty (default) keeps wildcard binds. #}
+{% set pub_bind = nginx_public_bind_ip | default('') %}
+{% set pub_prefix = (pub_bind ~ ':') if pub_bind else '' %}
 # source: infra/ansible/roles/luarocks/templates/nginx.conf.j2
 user  www-data;
 worker_processes  1;
@@ -741,8 +747,10 @@ http {
 
 # server any host 443 ssl and http2 port, http below this server block will be redirected to https
 server {
-    listen *:443 ssl default_server;
+    listen {{ pub_bind if pub_bind else '*' }}:443 ssl default_server;
+{% if not pub_bind %}
     listen [::]:443 ssl default_server;
+{% endif %}
     server_name _; # catch-all server block for HTTPS
     server_tokens off;
     http2 on;
@@ -991,7 +999,7 @@ server {
 
 # server any host http port 80
 server {
-        listen       80 default_server;
+        listen       {{ pub_prefix }}80 default_server;
         server_name _; # catch-all server block for HTTP requests (redirect to HTTPS or serve ACME challenges)
         server_tokens off;
         # enable


### PR DESCRIPTION
Companion to [diy-tax-return-infra#50](https://github.com/bwalia/diy-tax-return-infra/pull/50) — makes the lon1 OpenResty/Traefik coexistence durable on the wslproxy side.

## Why
lon1 (cloud001, `72.62.211.28`) runs a loopback-only k3s Traefik (`traefik-edge-lon1`, binds `127.0.0.1:80/:443`) alongside OpenResty, which owns the public `ip:80/:443` for the control-plane UI (`lon1.pop0.uk`). The live nginx.conf was hot-patched on 2026-08-07; **any deploy would revert it to wildcard binds and fail with EADDRINUSE**.

## What
- New role default `nginx_public_bind_ip: ""` — empty keeps wildcard binds, so **every other pop is untouched** (unset render verified byte-identical).
- When set: public 80/443 `server` blocks in `nginx.conf.j2` + `default.conf.j2` bind that IP explicitly; the `[::]:443` catch-all is skipped.
- `host_vars/72.62.211.28/vars.yaml`: `nginx_public_bind_ip: "72.62.211.28"`.

## Verified
Jinja render tested both ways — lon1 output matches the running hot-patched config exactly. The infra repo's `ansible/traefik-edge.yml` verify play asserts this socket layout on the node after every apply.

## After merge
Deploy the `nginx` tag (or full) to lon1 so the templates replace the hot-patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)