### PR TITLE
fix(ci): run lon1 deploy on mac-studio (acc) runner

### DIFF
--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -477,6 +477,10 @@ jobs:
     uses: ./.github/workflows/deploy-environment.yml
     with:
       env_name: prod
+      # Schedule on mac-studio (`acc`) — same rationale as pop1: the
+      # historical `prod` runner on pop0 has no SSH trust to lon1
+      # (dispatch 31281281402: "SSH connection failed to root@72.62.211.28").
+      runner_label: acc
       env_label: "Prod lon1 (72.62.211.28)"
       stage_number: "5b"
       host_ip: "72.62.211.28"


### PR DESCRIPTION
## Summary
- Lon1 deploy uses `runner_label: acc` (mac-studio) so SSH to `root@72.62.211.28` works.
- Keeps vault_or_sops + `https://lon1.pop0.uk/healthz` from #1174.

## Test plan
- [ ] Dispatch with `TARGET_HOST=72.62.211.28`, `DEPLOY_MODE=nginx`
- [ ] Only lon1 runs; SSH succeeds; healthz 200


Made with [Cursor](https://cursor.com)