### PR TITLE
Add wslproxy-cli Docker image for CI/CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,23 +1,31 @@
-# Keep docker build context lean when building from repo root
-# (docker build -f cmd/wslproxy-cli/Dockerfile .)
-.git
-.github
-**/*_test.go
-**/testdata
-bin
-dist
-release
-node_modules
-openresty-admin
-openresty-admin-next
-dashboard
-data
-QA
-wslproxy-cache-tests
-ingress-controller
-infra
-demos-origins
-html
-api
-*.md
-!docs/wslproxy-cli.md
+# Files and directories to ignore when copying to the Docker image
+
+# Node.js dependencies
+openresty-admin/node_modules
+
+# Build output
+openresty-admin/dist
+
+# Development-specific files
+openresty-admin/*.log
+openresty-admin/.DS_Store
+openresty-admin/.env.local
+openresty-admin/.env.development.local
+openresty-admin/.env.test.local
+openresty-admin/.env.production.local
+
+# Legacy stub files — empty placeholders under html/openresty-admin that
+# shadow the real admin source when `COPY ./html` runs before
+# `COPY ./openresty-admin`.  The real admin source lives in /openresty-admin/.
+html/openresty-admin
+
+# Next.js admin — its own image handles this, not needed in the main image
+openresty-admin-next/node_modules
+openresty-admin-next/.next
+openresty-admin-next/.env.local
+
+# Docker build artifacts and local-only state
+.next
+data/cache
+data/varnish
+data/servers/*/conf

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,31 +1,23 @@
-# Files and directories to ignore when copying to the Docker image
-
-# Node.js dependencies
-openresty-admin/node_modules
-
-# Build output
-openresty-admin/dist
-
-# Development-specific files
-openresty-admin/*.log
-openresty-admin/.DS_Store
-openresty-admin/.env.local
-openresty-admin/.env.development.local
-openresty-admin/.env.test.local
-openresty-admin/.env.production.local
-
-# Legacy stub files — empty placeholders under html/openresty-admin that
-# shadow the real admin source when `COPY ./html` runs before
-# `COPY ./openresty-admin`.  The real admin source lives in /openresty-admin/.
-html/openresty-admin
-
-# Next.js admin — its own image handles this, not needed in the main image
-openresty-admin-next/node_modules
-openresty-admin-next/.next
-openresty-admin-next/.env.local
-
-# Docker build artifacts and local-only state
-.next
-data/cache
-data/varnish
-data/servers/*/conf
+# Keep docker build context lean when building from repo root
+# (docker build -f cmd/wslproxy-cli/Dockerfile .)
+.git
+.github
+**/*_test.go
+**/testdata
+bin
+dist
+release
+node_modules
+openresty-admin
+openresty-admin-next
+dashboard
+data
+QA
+wslproxy-cache-tests
+ingress-controller
+infra
+demos-origins
+html
+api
+*.md
+!docs/wslproxy-cli.md

--- a/.github/workflows/build-wslproxy-cli.yml
+++ b/.github/workflows/build-wslproxy-cli.yml
@@ -12,6 +12,8 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'
+      - 'cmd/wslproxy-cli/Dockerfile'
+      - '.dockerignore'
       - '.github/workflows/build-wslproxy-cli.yml'
   pull_request:
     paths:
@@ -23,11 +25,15 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'
+      - 'cmd/wslproxy-cli/Dockerfile'
+      - '.dockerignore'
       - '.github/workflows/build-wslproxy-cli.yml'
   workflow_dispatch:
 
 permissions:
   contents: write
+  packages: write
+  id-token: write
 
 jobs:
   test:
@@ -88,9 +94,91 @@ jobs:
           path: wslproxy-cli_*
           if-no-files-found: error
 
+  docker:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/wslproxy-cli
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build args
+        id: args
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "version=${GITHUB_REF_NAME}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "commit=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+            type=ref,event=pr
+      - name: Build and push multi-arch (main / dispatch)
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: cmd/wslproxy-cli/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.args.outputs.version }}
+            COMMIT=${{ steps.args.outputs.commit }}
+            DATE=${{ steps.args.outputs.date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build PR image (amd64, local load)
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: cmd/wslproxy-cli/Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: ${{ env.IMAGE }}:pr
+          build-args: |
+            VERSION=${{ steps.args.outputs.version }}
+            COMMIT=${{ steps.args.outputs.commit }}
+            DATE=${{ steps.args.outputs.date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke test image
+        if: github.event_name == 'pull_request'
+        run: |
+          docker run --rm "${IMAGE}:pr" version
+          docker run --rm --entrypoint bash "${IMAGE}:pr" -lc \
+            'command -v jq && command -v curl && wslproxy-cli version && ls /opt/wslproxy-cli/examples'
+      - name: Smoke test published image
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        run: |
+          docker pull "${IMAGE}:sha-${GITHUB_SHA::7}"
+          docker run --rm "${IMAGE}:sha-${GITHUB_SHA::7}" version
+
   release-latest:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build
+    needs: [build, docker]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-wslproxy-cli.yml
+++ b/.github/workflows/build-wslproxy-cli.yml
@@ -13,7 +13,7 @@ on:
       - 'go.sum'
       - 'Makefile'
       - 'cmd/wslproxy-cli/Dockerfile'
-      - '.dockerignore'
+      - 'cmd/wslproxy-cli/dockerignore'
       - '.github/workflows/build-wslproxy-cli.yml'
   pull_request:
     paths:
@@ -26,7 +26,7 @@ on:
       - 'go.sum'
       - 'Makefile'
       - 'cmd/wslproxy-cli/Dockerfile'
-      - '.dockerignore'
+      - 'cmd/wslproxy-cli/dockerignore'
       - '.github/workflows/build-wslproxy-cli.yml'
   workflow_dispatch:
 
@@ -132,6 +132,10 @@ jobs:
             type=sha,prefix=sha-,format=short
             type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
             type=ref,event=pr
+      - name: Use CLI-scoped dockerignore for this build
+        run: |
+          cp .dockerignore .dockerignore.wslproxy-main.bak
+          cp cmd/wslproxy-cli/dockerignore .dockerignore
       - name: Build and push multi-arch (main / dispatch)
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
@@ -164,6 +168,12 @@ jobs:
             DATE=${{ steps.args.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Restore root dockerignore
+        if: always()
+        run: |
+          if [ -f .dockerignore.wslproxy-main.bak ]; then
+            mv .dockerignore.wslproxy-main.bak .dockerignore
+          fi
       - name: Smoke test image
         if: github.event_name == 'pull_request'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
-.PHONY: build test vet tidy cli install clean
+IMAGE ?= ghcr.io/bwalia/wslproxy-cli
+DOCKERFILE := cmd/wslproxy-cli/Dockerfile
+
+.PHONY: build test vet tidy cli install clean docker docker-push
 
 build cli:
 	mkdir -p bin
@@ -23,6 +26,20 @@ vet:
 
 tidy:
 	go mod tidy
+
+docker:
+	docker build \
+		-f $(DOCKERFILE) \
+		--build-arg VERSION=$(VERSION) \
+		--build-arg COMMIT=$(COMMIT) \
+		--build-arg DATE=$(DATE) \
+		-t $(IMAGE):$(VERSION) \
+		-t $(IMAGE):latest \
+		.
+
+docker-push: docker
+	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE):latest
 
 clean:
 	rm -rf bin

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ tidy:
 docker:
 	docker build \
 		-f $(DOCKERFILE) \
+		--ignorefile cmd/wslproxy-cli/dockerignore \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg COMMIT=$(COMMIT) \
 		--build-arg DATE=$(DATE) \

--- a/cmd/wslproxy-cli/Dockerfile
+++ b/cmd/wslproxy-cli/Dockerfile
@@ -1,0 +1,63 @@
+# syntax=docker/dockerfile:1
+# Minimal image with wslproxy-cli + bash/jq for CI/CD pipelines.
+# Build from repo root:
+#   docker build -f cmd/wslproxy-cli/Dockerfile -t ghcr.io/bwalia/wslproxy-cli:latest .
+#
+# Run:
+#   docker run --rm -e WSLPROXY_BASE_URL=https://lon1.pop0.uk \
+#     -e WSLPROXY_TOKEN -e WSLPROXY_ASSUME_YES=1 \
+#     ghcr.io/bwalia/wslproxy-cli:latest check nginx
+
+ARG GO_VERSION=1.25
+
+FROM golang:${GO_VERSION}-alpine AS build
+RUN apk add --no-cache git ca-certificates
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd/wslproxy-cli ./cmd/wslproxy-cli
+COPY internal ./internal
+
+ARG VERSION=dev
+ARG COMMIT=none
+ARG DATE=unknown
+ENV CGO_ENABLED=0
+RUN go build -trimpath \
+      -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+      -o /out/wslproxy-cli ./cmd/wslproxy-cli
+
+# Runtime: alpine so pipelines can use bash + jq + curl alongside the CLI.
+FROM alpine:3.21
+
+RUN apk add --no-cache \
+      bash \
+      ca-certificates \
+      curl \
+      jq \
+      git \
+      tzdata \
+    && adduser -D -u 10001 -h /home/wslproxy wslproxy \
+    && mkdir -p /home/wslproxy/.config/wslproxy /work \
+    && chown -R wslproxy:wslproxy /home/wslproxy /work
+
+COPY --from=build /out/wslproxy-cli /usr/local/bin/wslproxy-cli
+COPY examples/wslproxy-cli/ /opt/wslproxy-cli/examples/
+
+# Convenience aliases for scripts that expect `wslproxy-cli` on PATH (already set).
+ENV HOME=/home/wslproxy \
+    XDG_CONFIG_HOME=/home/wslproxy/.config \
+    WSLPROXY_CLI=/usr/local/bin/wslproxy-cli
+
+WORKDIR /work
+USER wslproxy
+
+ENTRYPOINT ["wslproxy-cli"]
+CMD ["version"]
+
+# Override entrypoint for shell automation:
+#   docker run --rm -it --entrypoint bash ghcr.io/bwalia/wslproxy-cli:latest
+LABEL org.opencontainers.image.title="wslproxy-cli" \
+      org.opencontainers.image.description="WSLProxy admin CLI (REST + MCP) for CI/CD" \
+      org.opencontainers.image.source="https://github.com/bwalia/wslproxy"

--- a/cmd/wslproxy-cli/dockerignore
+++ b/cmd/wslproxy-cli/dockerignore
@@ -1,0 +1,25 @@
+# Scoped ignorefile for: docker build -f cmd/wslproxy-cli/Dockerfile --ignorefile cmd/wslproxy-cli/dockerignore .
+# Do not replace the repo-root .dockerignore used by the main WSLProxy Dockerfile.
+
+.git
+.github
+bin
+dist
+release
+node_modules
+openresty-admin
+openresty-admin-next
+dashboard
+data
+QA
+wslproxy-cache-tests
+ingress-controller
+infra
+demos-origins
+html
+api
+site
+docs
+*.md
+**/*_test.go
+**/testdata

--- a/docs/wslproxy-cli.md
+++ b/docs/wslproxy-cli.md
@@ -45,10 +45,13 @@ Pipeline examples:
 - GitHub Actions: [`examples/wslproxy-cli/ci-github-actions.yml`](../examples/wslproxy-cli/ci-github-actions.yml)
 - GitLab CI: [`examples/wslproxy-cli/ci-gitlab-ci.yml`](../examples/wslproxy-cli/ci-gitlab-ci.yml)
 
-Local image build (repo root):
+Local image build (repo root; uses CLI-scoped ignorefile so the main app `.dockerignore` stays untouched):
 
 ```bash
-docker build -f cmd/wslproxy-cli/Dockerfile -t ghcr.io/bwalia/wslproxy-cli:dev .
+make docker
+# or:
+docker build -f cmd/wslproxy-cli/Dockerfile --ignorefile cmd/wslproxy-cli/dockerignore \
+  -t ghcr.io/bwalia/wslproxy-cli:dev .
 ```
 
 ## Auth

--- a/docs/wslproxy-cli.md
+++ b/docs/wslproxy-cli.md
@@ -7,9 +7,49 @@ Go CLI to administer WSLProxy over the Admin REST API and MCP HTTP surface. Pref
 ```bash
 make build          # → bin/wslproxy-cli
 make test
+make docker         # → ghcr.io/bwalia/wslproxy-cli:latest (local tag)
 ```
 
-CI: [`.github/workflows/build-wslproxy-cli.yml`](../.github/workflows/build-wslproxy-cli.yml) builds multi-arch artifacts on `main` (path-filtered) and updates the rolling release `wslproxy-cli-latest`.
+CI: [`.github/workflows/build-wslproxy-cli.yml`](../.github/workflows/build-wslproxy-cli.yml) builds multi-arch binaries **and** publishes the container image to GHCR on `main` / `workflow_dispatch`. Rolling binary release tag: `wslproxy-cli-latest`.
+
+## Docker image (CI/CD)
+
+Published image (linux/amd64 + linux/arm64):
+
+```text
+ghcr.io/bwalia/wslproxy-cli:latest
+ghcr.io/bwalia/wslproxy-cli:main
+ghcr.io/bwalia/wslproxy-cli:sha-<short>
+```
+
+Contents: `wslproxy-cli` on `PATH`, plus `bash`, `jq`, `curl`, `git`, and example scripts under `/opt/wslproxy-cli/examples/`.
+
+```bash
+# one-shot CLI
+docker run --rm \
+  -e WSLPROXY_BASE_URL=https://lon1.pop0.uk \
+  -e WSLPROXY_TOKEN \
+  ghcr.io/bwalia/wslproxy-cli:latest check nginx -o json
+
+# bash automation (override entrypoint)
+docker run --rm -it \
+  -e WSLPROXY_BASE_URL -e WSLPROXY_TOKEN -e WSLPROXY_ASSUME_YES=1 \
+  -v "$PWD:/work" \
+  --entrypoint bash \
+  ghcr.io/bwalia/wslproxy-cli:latest \
+  -lc 'wslproxy-cli pull -d /work/cfg --resources rules && jq . /work/cfg/rules/*/*.json | head'
+```
+
+Pipeline examples:
+
+- GitHub Actions: [`examples/wslproxy-cli/ci-github-actions.yml`](../examples/wslproxy-cli/ci-github-actions.yml)
+- GitLab CI: [`examples/wslproxy-cli/ci-gitlab-ci.yml`](../examples/wslproxy-cli/ci-gitlab-ci.yml)
+
+Local image build (repo root):
+
+```bash
+docker build -f cmd/wslproxy-cli/Dockerfile -t ghcr.io/bwalia/wslproxy-cli:dev .
+```
 
 ## Auth
 

--- a/examples/wslproxy-cli/ci-github-actions.yml
+++ b/examples/wslproxy-cli/ci-github-actions.yml
@@ -1,0 +1,58 @@
+# Example: use the published wslproxy-cli image in a GitHub Actions job.
+# Image: ghcr.io/bwalia/wslproxy-cli:latest
+#
+# Required secrets/vars:
+#   WSLPROXY_BASE_URL  — e.g. https://lon1.pop0.uk
+#   WSLPROXY_TOKEN     — admin JWT (or login with WSLPROXY_EMAIL + WSLPROXY_PASSWORD)
+
+name: WSLProxy config check
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  check-nginx:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/bwalia/wslproxy-cli:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        WSLPROXY_BASE_URL: ${{ vars.WSLPROXY_BASE_URL }}
+        WSLPROXY_TOKEN: ${{ secrets.WSLPROXY_TOKEN }}
+        WSLPROXY_ASSUME_YES: '1'
+    steps:
+      - name: Health + nginx check
+        run: |
+          wslproxy-cli status health -o json
+          wslproxy-cli check nginx -o json
+
+  pull-push-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Pull → jq tweak → dry-run push
+        run: |
+          docker run --rm \
+            -e WSLPROXY_BASE_URL \
+            -e WSLPROXY_TOKEN \
+            -e WSLPROXY_ASSUME_YES=1 \
+            -v "$PWD/cfg:/work/cfg" \
+            --entrypoint bash \
+            ghcr.io/bwalia/wslproxy-cli:latest \
+            -lc '
+              set -euo pipefail
+              wslproxy-cli pull -d /work/cfg --resources rules -o json
+              # example mutate (noop if no files)
+              shopt -s nullglob
+              for f in /work/cfg/rules/*/*.json; do
+                jq "." "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+              done
+              wslproxy-cli push -d /work/cfg --resources rules --dry-run -o json
+            '
+        env:
+          WSLPROXY_BASE_URL: ${{ vars.WSLPROXY_BASE_URL }}
+          WSLPROXY_TOKEN: ${{ secrets.WSLPROXY_TOKEN }}

--- a/examples/wslproxy-cli/ci-gitlab-ci.yml
+++ b/examples/wslproxy-cli/ci-gitlab-ci.yml
@@ -1,0 +1,40 @@
+# Example GitLab CI job using the wslproxy-cli container image.
+# Image: ghcr.io/bwalia/wslproxy-cli:latest
+#
+# CI/CD variables (masked/protected as needed):
+#   WSLPROXY_BASE_URL
+#   WSLPROXY_TOKEN
+# Optional for private GHCR pull:
+#   CI_REGISTRY / DOCKER_AUTH_CONFIG, or deploy token for ghcr.io
+
+stages:
+  - verify
+
+variables:
+  WSLPROXY_CLI_IMAGE: "ghcr.io/bwalia/wslproxy-cli:latest"
+  WSLPROXY_ASSUME_YES: "1"
+
+wslproxy-check-nginx:
+  stage: verify
+  image:
+    name: $WSLPROXY_CLI_IMAGE
+    entrypoint: [""]
+  script:
+    - wslproxy-cli version
+    - wslproxy-cli status health -o json
+    - wslproxy-cli check nginx -o json
+
+wslproxy-pull-dry-run:
+  stage: verify
+  image:
+    name: $WSLPROXY_CLI_IMAGE
+    entrypoint: [""]
+  script:
+    - set -euo pipefail
+    - wslproxy-cli pull -d ./cfg --resources servers,rules -o json
+    - wslproxy-cli push -d ./cfg --resources servers,rules --dry-run -o json
+  artifacts:
+    paths:
+      - cfg/
+    expire_in: 1 day
+    when: always


### PR DESCRIPTION
## Summary
- Multi-stage `cmd/wslproxy-cli/Dockerfile` (static Go binary on Alpine with bash/jq/curl)
- CI builds and pushes `ghcr.io/bwalia/wslproxy-cli:{latest,main,sha-*}` (linux/amd64 + arm64)
- GitHub Actions + GitLab CI usage examples
- `make docker` helper and docs update

## Test plan
- [ ] PR docker job builds amd64 image and smoke-tests `version` + jq
- [ ] After merge / workflow_dispatch: image appears on GHCR
- [ ] `docker run --rm ghcr.io/bwalia/wslproxy-cli:latest version`
- [ ] GitLab/GitHub example jobs can pull image and run `check nginx` with token secrets


Made with [Cursor](https://cursor.com)