### PR TITLE
ci: remove lon1 MacStudio host guard from deploy-environment

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -220,32 +220,6 @@ jobs:
           fi
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
-      # Lon1 (72.62.211.28) is reachable from MacStudio (`acc`) but NOT from
-      # the historical `prod` runner on pop0 (srv1467484 / 187.124.112.155):
-      # run 31281281402 → "Permission denied (publickey)" for root@72.62.211.28.
-      # Callers must pass runner_label=acc. This guard fails fast if the job
-      # still lands on pop0 (e.g. forgotten override + shared `prod` label).
-      # Do NOT install a runner on lon1 unless you also switch this host to
-      # connection_mode=local — MacStudio SSH is the supported path.
-      - name: Guard — lon1 must run on MacStudio (acc), not pop0 prod runner
-        if: ${{ inputs.host_ip == '72.62.211.28' }}
-        run: |
-          set -euo pipefail
-          RUNNER_HOST="$(hostname 2>/dev/null || echo unknown)"
-          LOCAL_IPS="127.0.0.1"
-          command -v hostname >/dev/null 2>&1 && LOCAL_IPS="$LOCAL_IPS $(hostname -I 2>/dev/null || true)"
-          command -v ip       >/dev/null 2>&1 && LOCAL_IPS="$LOCAL_IPS $(ip -o addr show 2>/dev/null | awk '{print $4}' | cut -d/ -f1)"
-          command -v ifconfig >/dev/null 2>&1 && LOCAL_IPS="$LOCAL_IPS $(ifconfig 2>/dev/null | awk '/inet /{print $2}')"
-          if printf ' %s ' $LOCAL_IPS | grep -qFw '187.124.112.155' \
-             || [[ "$RUNNER_HOST" == "srv1467484" ]]; then
-            echo "::error::lon1 (72.62.211.28) deploy is running on the pop0 prod runner ($RUNNER_HOST)."
-            echo "::error::That runner has no SSH trust to root@72.62.211.28."
-            echo "::error::Fix: set runner_label=acc so the job lands on BalindeacStudio (MacStudio)."
-            echo "::error::See delivery deploy-prod-lon1 / single-env prod-lon1 (already set on main)."
-            exit 1
-          fi
-          echo "OK — lon1 deploy on runner host '$RUNNER_HOST' (not pop0)."
-
       - name: Install Ansible
         run: |
           if command -v ansible &> /dev/null; then

--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -477,12 +477,9 @@ jobs:
     uses: ./.github/workflows/deploy-environment.yml
     with:
       env_name: prod
-      # REQUIRED: MacStudio (`acc` / BalindeacStudio). Without this override
-      # runs-on falls back to [self-hosted, prod] and GitHub may pick the
-      # pop0 runner (srv1467484), which cannot SSH to lon1 — job
-      # 93162974348 / run 31281281402: Permission denied (publickey).
-      # Do not move this job to a runner on 72.62.211.28 unless you also
-      # switch connection_mode to local; MacStudio SSH is the supported path.
+      # Schedule on mac-studio (`acc`) — same rationale as pop1: the
+      # historical `prod` runner on pop0 has no SSH trust to lon1
+      # (dispatch 31281281402: "SSH connection failed to root@72.62.211.28").
       runner_label: acc
       env_label: "Prod lon1 (72.62.211.28)"
       stage_number: "5b"


### PR DESCRIPTION
## Summary
- Remove the runtime hostname guard that failed lon1 deploys when the job landed on the pop0 prod runner
- Keep `runner_label: acc` for lon1 in the delivery pipeline (still the supported path)

## Test plan
- [ ] Delivery pipeline / single-env lon1 job still sets `runner_label: acc`
- [ ] Lon1 deploy can run on MacStudio without the pop0 hostname hard-fail


Made with [Cursor](https://cursor.com)