### PR TITLE
chore(ci): retire phantom pop0 (187.124.112.155) deploy target

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -6,7 +6,7 @@ WSLProxy uses two deployment pipelines and a shared reusable workflow:
 
 | Pipeline | File | Branch | Environments | Purpose |
 |----------|------|--------|-------------|---------|
-| **Delivery** | `deploy-wslproxy-delivery-pipeline.yml` | `release` | int → test → prod (pop0 + lon1) | Production releases |
+| **Delivery** | `deploy-wslproxy-delivery-pipeline.yml` | `release` | int → test → prod (lon1 + pop1) | Production releases |
 | **Promotion** | `deploy-wslproxy-promotion-pipeline.yml` | `main` | int → test | CI/CD for config/server changes |
 | **Reusable** | `deploy-environment.yml` | — | (called by both pipelines) | Parameterized per-environment deploy logic |
 
@@ -26,13 +26,13 @@ WSLProxy uses two deployment pipelines and a shared reusable workflow:
 
 ## Delivery Pipeline (`deploy-wslproxy-delivery-pipeline.yml`)
 
-Full production release pipeline with fail-fast behavior and Slack notifications at every gate. Code promotes through **int → test → prod (pop0 + lon1)** — each environment must pass before the next deploys.
+Full production release pipeline with fail-fast behavior and Slack notifications at every gate. Code promotes through **int → test → prod (lon1 + pop1)** — each environment must pass before the next deploys.
 
 ### Triggers
 
 | Trigger | Branches | Behavior |
 |---------|----------|----------|
-| Push | `release` | Runs full pipeline: int → test → prod (pop0 + lon1) |
+| Push | `release` | Runs full pipeline: int → test → prod (lon1 + pop1) |
 | Manual (`workflow_dispatch`) | any | Choose target host, environment, and deploy mode |
 
 ### Deploy Modes
@@ -88,9 +88,9 @@ Selected via `DEPLOY_MODE` dropdown (default: `code` for manual, `full` for push
                             │ pass
                             ▼
  ┌──────────────────────────────────────────────────────────────────────┐
- │  STAGE 5a: Deploy Prod pop0             [self-hosted, SSH+key]      │
+ │  STAGE 5a: Deploy Prod lon1             [self-hosted, SSH+key]      │
  │  Uses deploy-environment.yml (connection_mode: ssh_key)             │
- │  ✓ Success → Slack: "deployed to production (pop0)"                 │
+ │  ✓ Success → Slack: "deployed to production (lon1)"                 │
  │  ✗ Failure → Slack alert + manual rollback                          │
  └──────────────────────────┬───────────────────────────────────────────┘
                             │ pass
@@ -184,8 +184,10 @@ Shared parameterized workflow called by both pipelines via `workflow_call`. Hand
 |-------------|---------|----------|--------------------|----------------|---------------------|-----------------|
 | int | 192.168.1.193 | (local) | `local` | `github_secret` | `local` | `http://localhost:8080/health` |
 | test | 192.168.1.140 | bwalia | `ssh` | `runner_file` | `ssh` | `http://localhost:8080/health` |
-| prod (pop0) | 187.124.112.155 | root | `ssh_key` | `github_secret` | `external` | `https://prod-our-v1.wslproxy.com/health` |
-| prod (lon1) | 72.62.211.28 | root | `ssh_key` | `runner_file` | `external` | `http://72.62.211.28:7691/health` |
+| prod (lon1) | 72.62.211.28 | root | `ssh_key` | `vault_or_sops` | `external` | `https://lon1.pop0.uk/healthz` |
+| prod (pop1) | 18.133.126.242 | admin | `ssh_key` | `vault_or_sops` | `external` | `https://pop1.diytaxreturn.co.uk/healthz` |
+
+> **Retired:** `prod (pop0)` / `187.124.112.155` was removed as a deploy target — that host is a k3s node where traefik owns `:80`/`:443` (no wslproxy edge, no DNS). Live prod edges are lon1 + pop1.
 
 ### Steps (conditional per environment)
 
@@ -224,8 +226,8 @@ The `DEPLOY_MODE` value maps to Ansible tags that control which tasks run:
 |--------|---------|-------------|
 | `DOT_WSLPROXY_SETTINGS_INT` | Int deploy | Base64-encoded settings.json for int |
 | `DOT_WSLPROXY_ENV_CREDS_INT` | Int deploy | Base64-encoded .env for int |
-| `DOT_WSLPROXY_SETTINGS_PROD` | Prod pop0 deploy | Base64-encoded settings.json for prod |
-| `DOT_WSLPROXY_ENV_CREDS_PROD` | Prod pop0 deploy | Base64-encoded .env for prod |
+| `DOT_WSLPROXY_SETTINGS_PROD` | Prod deploy (lon1/pop1) | Base64-encoded settings.json for prod |
+| `DOT_WSLPROXY_ENV_CREDS_PROD` | Prod deploy (lon1/pop1) | Base64-encoded .env for prod |
 | `SLACK_WEBHOOK` | All stages | Slack incoming webhook URL |
 
 Runner-local secrets (on 192.168.1.193):
@@ -291,8 +293,8 @@ Stage 1 fails  → "Build & Validate FAILED"              → pipeline stops
 Stage 2 fails  → "Deploy Int FAILED"                    → pipeline stops
 Stage 3 fails  → "Smoke Test Int FAILED"                → pipeline stops (before test)
 Stage 4 fails  → "Deploy Test FAILED"                   → pipeline stops (before prod)
-Stage 5a fails → "Production Deployment FAILED (pop0)"  → alert + manual rollback
-Stage 5b fails → "LON1 Deployment FAILED"               → alert + manual rollback
+Stage 5a fails → "Production Deployment FAILED (lon1)"  → alert + manual rollback
+Stage 5b fails → "Production Deployment FAILED (pop1)"  → alert + manual rollback
 ```
 
 ### Promotion Pipeline

--- a/.github/workflows/deploy-single-environment.yml
+++ b/.github/workflows/deploy-single-environment.yml
@@ -9,7 +9,7 @@ name: Deploy Single Environment
 #   acc       -> 192.168.1.48    (Acceptance — LAN)
 #   prod      -> 18.133.126.242  (Production — "pop1", AWS)
 #   prod-lon1 -> 72.62.211.28    (Production — "lon1" / lon1.pop0.uk)
-#   prod-pop0 -> 187.124.112.155 (Production — "pop0"; also in delivery pipeline)
+#   (prod-pop0 / 187.124.112.155 retired: k3s/traefik node, not a wslproxy edge)
 #
 # Each ENV maps to exactly ONE host, so rings deploy independently.
 #
@@ -39,7 +39,6 @@ on:
           - acc
           - prod
           - prod-lon1
-          - prod-pop0
       DEPLOY_BRANCH:
         type: string
         description: "Git ref to deploy (branch, tag or commit SHA)"
@@ -234,30 +233,5 @@ jobs:
       VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
       SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
 
-  # ──────────────────────────────────────────────────────
-  # Production — prod / "pop0" (187.124.112.155). Single-host entry for
-  # the same target as delivery Stage 5a (no cascade).
-  # ──────────────────────────────────────────────────────
-  prod-pop0:
-    if: ${{ inputs.ENV == 'prod-pop0' }}
-    uses: ./.github/workflows/deploy-environment.yml
-    with:
-      env_name: prod
-      env_label: "Production — pop0 (187.124.112.155)"
-      stage_number: "prod-pop0"
-      host_ip: "187.124.112.155"
-      ssh_user: root
-      connection_mode: ssh_key
-      secrets_mode: vault_or_sops
-      health_endpoint: "https://prod-our-v1.wslproxy.com/healthz"
-      health_check_mode: external
-      docker_prune: true
-      notify_success: true
-      deploy_branch: ${{ inputs.DEPLOY_BRANCH }}
-      deploy_mode: ${{ inputs.DEPLOY_MODE }}
-    secrets:
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-      VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
-      SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+  # (Production "pop0" / 187.124.112.155 retired — that host is a k3s/traefik
+  #  node, not a wslproxy edge, so it was removed as a deploy target.)

--- a/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
+++ b/.github/workflows/deploy-wslproxy-delivery-pipeline.yml
@@ -1,5 +1,8 @@
 name: Full Build and Deploy WSLProxy Delivery Pipeline
-# Pipeline: Validate → Int → Smoke Test → Test → Acc → Prod (pop0 + lon1)
+# Pipeline: Validate → Int → Smoke Test → Test → Prod (lon1 + pop1)
+# NOTE: the former "pop0" edge (187.124.112.155) was retired — that host is a
+# k3s node where traefik owns :80/:443, no DNS points to it, and it has no
+# wslproxy data dir, so it is not a live edge. Live prod edges are lon1 + pop1.
 # Promotion pipeline: each environment must pass before the next deploys
 # Deploy modes: code (default for manual) | nginx | servers | dashboard | os_deps | build | full (default for push)
 
@@ -39,8 +42,8 @@ on:
           - all
           - 192.168.1.193
           - 192.168.1.140
-          # 187.77.179.206 (acc) was decommissioned.
-          - 187.124.112.155
+          # 187.77.179.206 (acc) and 187.124.112.155 (pop0) were retired.
+          # pop0 is a k3s/traefik node, not a wslproxy edge.
           - 72.62.211.28
           - 18.133.126.242
 
@@ -420,55 +423,14 @@ jobs:
   # gates production behind a successful non-prod deploy.
 
   # ──────────────────────────────────────────────────────
-  # Stage 5a: Deploy Prod pop0 (187.124.112.155)
-  # ──────────────────────────────────────────────────────
-  deploy-prod-pop0:
-    # Full upstream chain — see deploy-test. Any failure up to here blocks prod.
-    needs: [build-validate, deploy-int, test-int, deploy-test]
-    if: >
-      always() && !failure() && !cancelled() &&
-      ((github.event_name == 'push' && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/main')) ||
-      (github.event_name == 'workflow_dispatch' &&
-      (github.event.inputs.TARGET_HOST == '187.124.112.155' || github.event.inputs.TARGET_HOST == 'all')))
-    uses: ./.github/workflows/deploy-environment.yml
-    with:
-      env_name: prod
-      env_label: "Prod pop0 (187.124.112.155)"
-      stage_number: "5a"
-      host_ip: "187.124.112.155"
-      ssh_user: root
-      connection_mode: ssh_key
-      # vault_or_sops: probe Vault first (see the resolve_mode step in
-      # deploy-environment.yml).  If Vault has the settings at
-      # secret/data/wslproxy/prod/settings.json, use it; otherwise fall
-      # back to the SOPS-encrypted infra/secrets/prod/settings.sops.json
-      # already committed to the repo.  Replaces the old runner_file +
-      # seed_from_host mode that failed on 2026-07-02 when the runner's
-      # SSH key stopped authenticating against the prod host (root@…
-      # permission denied) and there was no fallback.
-      secrets_mode: vault_or_sops
-      health_endpoint: "https://prod-our-v1.wslproxy.com/healthz"
-      health_check_mode: external
-      docker_prune: true
-      notify_success: true
-      deploy_branch: ${{ github.event.inputs.DEPLOY_BRANCH || github.ref_name }}
-      deploy_mode: ${{ github.event.inputs.DEPLOY_MODE || 'full' }}
-    secrets:
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-      SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      # Provide BOTH — the resolver picks Vault if VAULT_ADDR/VAULT_TOKEN
-      # are set AND the settings path is populated; otherwise it uses
-      # SOPS_AGE_KEY.  Deploy only fails if BOTH are unavailable.
-      VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
-      VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
-      SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
-
-  # ──────────────────────────────────────────────────────
-  # Stage 5b: Deploy Prod lon1 (72.62.211.28)
+  # Stage 5a: Deploy Prod lon1 (72.62.211.28)
+  # (The former Stage 5a "pop0" / 187.124.112.155 was retired: that host is a
+  #  k3s/traefik node with no wslproxy edge and no DNS, so it never served
+  #  prod traffic. Live prod edges are lon1 (5a) and pop1 (5b).)
   # ──────────────────────────────────────────────────────
   deploy-prod-lon1:
     # Full upstream chain — see deploy-test.
-    needs: [build-validate, deploy-int, test-int, deploy-test, deploy-prod-pop0]
+    needs: [build-validate, deploy-int, test-int, deploy-test]
     if: >
       always() && !failure() && !cancelled() &&
       ((github.event_name == 'push' && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/main')) ||
@@ -482,7 +444,7 @@ jobs:
       # (dispatch 31281281402: "SSH connection failed to root@72.62.211.28").
       runner_label: acc
       env_label: "Prod lon1 (72.62.211.28)"
-      stage_number: "5b"
+      stage_number: "5a"
       host_ip: "72.62.211.28"
       ssh_user: root
       connection_mode: ssh_key
@@ -508,13 +470,13 @@ jobs:
       SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
 
   # ──────────────────────────────────────────────────────
-  # Stage 5c: Deploy Prod pop1 (18.133.126.242) — AWS eu-west-2, ssh user admin
-  # Runs LAST, after pop0 + lon1, only when they (and all prior stages) pass.
+  # Stage 5b: Deploy Prod pop1 (18.133.126.242) — AWS eu-west-2, ssh user admin
+  # Runs LAST, after lon1, only when it (and all prior stages) pass.
   # Dashboard domain: pop1.diytaxreturn.co.uk
   # ──────────────────────────────────────────────────────
   deploy-prod-pop1:
     # Full upstream chain — see deploy-test.
-    needs: [build-validate, deploy-int, test-int, deploy-test, deploy-prod-pop0, deploy-prod-lon1]
+    needs: [build-validate, deploy-int, test-int, deploy-test, deploy-prod-lon1]
     if: >
       always() && !failure() && !cancelled() &&
       ((github.event_name == 'push' && (github.ref == 'refs/heads/release' || github.ref == 'refs/heads/main')) ||
@@ -530,7 +492,7 @@ jobs:
       # ansible target_env / Vault path / SOPS payload profile are prod.
       runner_label: acc
       env_label: "Prod pop1 (18.133.126.242)"
-      stage_number: "5c"
+      stage_number: "5b"
       host_ip: "18.133.126.242"
       ssh_user: admin
       connection_mode: ssh_key
@@ -567,7 +529,6 @@ jobs:
         deploy-int,
         test-int,
         deploy-test,
-        deploy-prod-pop0,
         deploy-prod-lon1,
         deploy-prod-pop1,
       ]
@@ -583,9 +544,8 @@ jobs:
           echo "  Stage 2  — Deploy Int:           ${{ needs.deploy-int.result }}"
           echo "  Stage 3  — Smoke Test Int:       ${{ needs.test-int.result }}"
           echo "  Stage 4  — Deploy Test:          ${{ needs.deploy-test.result }}"
-          echo "  Stage 5a — Deploy Prod (pop0):   ${{ needs.deploy-prod-pop0.result }}"
-          echo "  Stage 5b — Deploy Prod (lon1):   ${{ needs.deploy-prod-lon1.result }}"
-          echo "  Stage 5c — Deploy Prod (pop1):   ${{ needs.deploy-prod-pop1.result }}"
+          echo "  Stage 5a — Deploy Prod (lon1):   ${{ needs.deploy-prod-lon1.result }}"
+          echo "  Stage 5b — Deploy Prod (pop1):   ${{ needs.deploy-prod-pop1.result }}"
           echo ""
           echo "  Commit:  ${{ github.sha }}"
           echo "  Branch:  ${{ github.ref_name }}"
@@ -596,7 +556,6 @@ jobs:
              [[ "${{ needs.deploy-int.result }}" == "failure" ]] || \
              [[ "${{ needs.test-int.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-test.result }}" == "failure" ]] || \
-             [[ "${{ needs.deploy-prod-pop0.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-prod-lon1.result }}" == "failure" ]] || \
              [[ "${{ needs.deploy-prod-pop1.result }}" == "failure" ]]; then
               echo "::error::Pipeline failed — see stage results above"

--- a/.github/workflows/deploy-wslproxy-virtual-servers.yml
+++ b/.github/workflows/deploy-wslproxy-virtual-servers.yml
@@ -30,11 +30,13 @@ on:
       TARGET_HOST:
         type: choice
         description: "Target host"
-        default: "187.124.112.155"
+        default: "72.62.211.28"
         required: true
         options:
-          - 187.124.112.155
-          # 187.77.179.206 (acc) was decommissioned.
+          # 187.77.179.206 (acc) and 187.124.112.155 (pop0) were retired —
+          # pop0 is a k3s/traefik node, not a wslproxy edge.
+          - 72.62.211.28
+          - 18.133.126.242
           - 192.168.1.193
 
       DEPLOY_NGINX_CONF:
@@ -49,7 +51,7 @@ on:
 
 env:
   TARGET_ENV: ${{ github.event.inputs.TARGET_ENV || 'prod' }}
-  TARGET_HOST: ${{ github.event.inputs.TARGET_HOST || '187.124.112.155' }}
+  TARGET_HOST: ${{ github.event.inputs.TARGET_HOST || '72.62.211.28' }}
   DEPLOY_NGINX_CONF: ${{ github.event.inputs.DEPLOY_NGINX_CONF || 'false' }}
   DRY_RUN: ${{ github.event.inputs.DRY_RUN || 'false' }}
   INT_HOST: 192.168.1.193


### PR DESCRIPTION
## Why
`187.124.112.155` ("pop0") is **not a live wslproxy edge**:
- traefik owns the public `:80`/`:443` there (it's a k3s node),
- it has **no wslproxy data dir**, and
- **no DNS** points to it — `prod-our.wslproxy.com` / `pop0.wslproxy.com` both resolve to `18.133.126.242` (**pop1**). Its delivery stage even health-checked pop1's domain.

So the pop0 deploy target was dead weight whose CI job could never meaningfully deploy. Live prod edges are **lon1** (`72.62.211.28`) and **pop1** (`18.133.126.242`) — both already run WAF v2.

## Changes
- **Delivery pipeline:** remove the `deploy-prod-pop0` job (Stage 5a); re-label lon1 → 5a, pop1 → 5b; drop `deploy-prod-pop0` from every `needs:` chain and from the summary report + failure gate; remove `187.124.112.155` from `TARGET_HOST`.
- **Deploy Single Environment:** remove the `prod-pop0` ENV option and job.
- **Virtual servers:** default `TARGET_HOST` `187.124.112.155` → `72.62.211.28`.
- **README:** flow, diagram, host table, secrets + failure notes now reflect prod = lon1 + pop1, with a retirement note.

## Safety
- No remaining job depends on `deploy-prod-pop0` (lon1/pop1 run on the `acc` runner), so the promotion chain stays intact — verified the job graph has zero dangling `needs`.
- All three workflow YAMLs parse.
- The pop0 **runner** and backup references are infra (not deploy targets) and were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)