### PR TITLE
Refresh README and landing page for modern WSLProxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,585 +1,233 @@
 # WSLProxy
 
-**Enterprise-Grade API Gateway & Reverse Proxy with Automated Management**
+**Dynamic API gateway & reverse proxy** on OpenResty — route, secure, and observe traffic from JSON/MCP configs that take effect **without reloading nginx** for rules.
 
-WSLProxy is a high-performance, cloud-native API gateway and reverse proxy built on OpenResty (Nginx with Lua scripting). Designed for modern DevOps workflows, it provides automatic SSL/TLS management, dynamic routing configuration, and comprehensive monitoring capabilities—all fully API-driven for seamless CI/CD integration.
+Operators manage virtual hosts, rules, WAF, cache, traffic splits, and edge POPs from an Admin UI, REST API, MCP tools, or the `wslproxy-cli` container. Built for multi-POP edges, GitOps-style config, and AI agents.
 
-## Key Features
+| | |
+|---|---|
+| Site | [wslproxy.com](https://wslproxy.com) |
+| Swagger | [/swagger/](https://wslproxy.com/swagger/) |
+| Repo | [github.com/bwalia/wslproxy](https://github.com/bwalia/wslproxy) |
+| CLI image | `ghcr.io/bwalia/wslproxy-cli:latest` |
 
-- **🔒 Automatic SSL/TLS Management** - Let's Encrypt integration with zero-downtime certificate renewal
-- **⚙️ API-First Architecture** - Configure everything via REST API, perfect for infrastructure-as-code and pipelines
-- **🚀 High Performance** - OpenResty-based with Lua scripting for custom logic without proxy limitations
-- **📊 Built-in Monitoring** - Prometheus metrics, traffic analytics, and admin dashboard out of the box
-- **🔄 Dynamic Routing** - Hot-reload configuration without restarting the proxy
-- **🏗️ Multi-Deployment Ready** - Docker, Kubernetes, Docker Swarm, and bare metal support
-- **🔌 Service Mesh Ready** - Consul integration for service discovery and health checks
-- **📦 Zero Dependencies** - Lightweight container (~150MB) with everything included
-- **🌍 POPs + Cloudflare DNS** - Declare your edge locations once, provision A records automatically — with safety guardrails so wslproxy never touches a record it didn't create. See **[POPS_AND_DNS_GUIDE.md](POPS_AND_DNS_GUIDE.md)**
-- **🤖 MCP / AI Agent Integration** - Manage servers, rules, POPs, and DNS via natural language from Claude Desktop / Claude Code / Cursor. See **[api/mcp/README.md](api/mcp/README.md)**
+---
 
-## Quick Start (Choose Your Deployment)
+## What it is
 
-### Option 1: Docker (Fastest Way)
+WSLProxy sits in front of your origins and decides **per request** what happens: proxy (305), redirect, static block, CAPTCHA, WAF, cache, canary split, geo/IP/JWT match — using rules loaded live from disk or Redis.
 
-```bash
-# Pull latest image
-docker pull bwalia/wslproxy:latest
-
-# Run with default config
-docker run -d \
-  --name wslproxy \
-  -p 80:80 \
-  -p 443:443 \
-  -p 8080:8080 \
-  bwalia/wslproxy:latest
-
-# Access admin dashboard
-open http://localhost:8080
+```mermaid
+flowchart LR
+  C[Clients] --> E[WSLProxy edge<br/>OpenResty + Lua]
+  E --> O[Origins / k3s / APIs]
+  A[Admin UI · REST · MCP · CLI] -.-> E
+  subgraph live["Hot path — no nginx reload"]
+    R[Rules JSON]
+    W[WAF policies]
+    T[Traffic split]
+  end
+  R -.-> E
+  W -.-> E
+  T -.-> E
 ```
 
-### Option 2: Docker Compose (Development)
+**Reload only when server-level nginx conf changes** (new listen/SSL block). Rules, WAF, and most routing are evaluated every request.
 
-```bash
-# Clone and start
-git clone https://github.com/wslproxy/wslproxy.git && cd wslproxy
-docker-compose -f docker-compose-dev.yml up
+---
 
-# Access dashboard
-open http://localhost:8080
+## Capabilities (today)
 
-# Hot-reload changes to Lua API files instantly
+| Area | What you get |
+|------|----------------|
+| **Routing** | Path / IP / country / JWT / S3 / cookie match → proxy, redirect, HTML, CAPTCHA; priority + specificity tie-break |
+| **Traffic** | Weighted / RR / header canary / cookie sticky / least-conn; promote & rollback backends |
+| **WAF** | Policy packs, anomaly scoring, monitor/block, events API — see [docs/WAF_ENGINE_V2.md](docs/WAF_ENGINE_V2.md) |
+| **SSL** | auto-ssl / Let's Encrypt, per-domain SSL JSON, force HTTPS |
+| **Cache** | Edge static cache + optional Docker blob cache; Varnish hooks |
+| **POPs + DNS** | Declare edge locations; Cloudflare A-record provisioning with safety guardrails — [POPS_AND_DNS_GUIDE.md](POPS_AND_DNS_GUIDE.md) |
+| **Control plane** | React Admin + Next.js dashboard, Swagger REST, MCP (Claude/Cursor), `wslproxy-cli` |
+| **Deploy** | Docker Compose (dev), Ansible (bare metal / VM), Helm ingress-controller (k3s) |
+| **Observability** | `/health` `/healthz` `/ready` `/metrics`, traffic stats, AI log analysis hooks |
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TB
+  subgraph clients["Clients"]
+    B[Browser / API / Agents]
+  end
+
+  subgraph edge["WSLProxy POP"]
+    direction TB
+    NGX[OpenResty]
+    ACK[gateway_ack.lua<br/>match rules]
+    RESP[gateway_resp.lua<br/>backend + timeouts]
+    BAL[balancer_by_lua]
+    NGX --> ACK --> RESP --> BAL
+  end
+
+  subgraph control["Control plane"]
+    UI[Admin UI]
+    API["/api/*"]
+    MCP["/mcp/*"]
+    CLI[wslproxy-cli]
+    UI --> API
+    CLI --> API
+    CLI --> MCP
+    MCP --> API
+  end
+
+  subgraph data["Config store"]
+    D["data/servers · rules · waf_* · ssl"]
+  end
+
+  B --> NGX
+  control --> D
+  ACK --> D
+  BAL --> ORG[Origins / ingress / apps]
 ```
 
-### Option 3: Kubernetes Helm (Production)
+**Two-layer prod pattern (common):** public POP → k3s NodePort → `wslproxy-ingress` Helm chart → app pods. Tune timeouts on **both** layers.
+
+More diagrams (Draw.io): [docs/diagrams/](docs/diagrams/).
+
+---
+
+## Quick start
+
+### Docker (local)
 
 ```bash
-# Deploy to K8s cluster
-helm install wslproxy ./infra/helm-charts/wslproxy \
-  -n wslproxy \
-  --create-namespace \
-  -f values-prod.yaml
-
-# Monitor deployment
-kubectl -n wslproxy get pods -w
+git clone https://github.com/bwalia/wslproxy.git && cd wslproxy
+./dev.sh -n -j "$(openssl rand -hex 24)"
+# Admin: http://localhost:8280   API: http://localhost:8280/api   Health: /health
 ```
 
-## Local Development
+Or compose: `docker-compose -f docker-compose-local.yml up` (see [DOCKER.md](DOCKER.md)).
 
-Single command to start the entire development environment with hot-reload and unique ports (no conflicts with common local services).
-
-### Prerequisites
-
-- Docker (with Docker Compose)
-- Node.js 16+
-- Yarn (`npm install -g yarn`)
-
-### Quick Start
+### CLI in CI (no Go install)
 
 ```bash
-# Start everything - prompts for JWT secret, builds admin inside container, attaches to logs
-./start.sh
-
-# Pass JWT secret directly (skips interactive prompt)
-./start.sh --jwt-secret YOUR_SECRET_KEY
-
-# With auto git stash + pull (no prompts)
-./start.sh -a
-
-# Skip git prompts entirely
-./start.sh -n
-
-# With admin dashboard auto-rebuild on file save
-./start.sh -w
-
-# Combine flags
-./start.sh -n -j YOUR_SECRET_KEY -w
-
-# Press Ctrl+C to stop everything
+docker run --rm \
+  -e WSLPROXY_BASE_URL=https://your-pop.example \
+  -e WSLPROXY_TOKEN \
+  ghcr.io/bwalia/wslproxy-cli:latest check nginx -o json
 ```
 
-### JWT Secret Key
+Docs: [docs/wslproxy-cli.md](docs/wslproxy-cli.md) · examples under `examples/wslproxy-cli/`.
 
-The JWT secret is required for token signing/validation. The script will always ask for it interactively unless provided via CLI argument:
+### Login + pull / push config
 
 ```bash
-# Option 1: Pass as argument (recommended for CI/scripts)
-./start.sh --jwt-secret YOUR_SECRET_KEY
-
-# Option 2: Interactive prompt (press Enter to auto-generate a random key)
-./start.sh
-# > Enter JWT secret key (or press Enter to generate a random one):
+wslproxy-cli auth login --base-url https://lon1.pop0.uk -u you@example.com
+wslproxy-cli pull -d ./cfg --resources servers,rules,waf_rules,waf_policies
+# edit JSON or jq …
+wslproxy-cli push -d ./cfg --dry-run --diff
+wslproxy-cli push -d ./cfg --yes --verify
 ```
 
-The script injects the JWT secret into `openresty-admin/.env` as `VITE_JWT_SECURITY_PASSPHRASE` before the Vite build runs inside the container.
+---
 
-### Environment Variables
+## Request pipeline (simplified)
 
-The admin dashboard uses Vite environment variables defined in `openresty-admin/.env`. This file is committed to the repo with safe defaults for local Docker development. The JWT secret is the only value injected at runtime by `start.sh`.
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant N as OpenResty
+  participant A as gateway_ack
+  participant R as gateway_resp
+  participant U as Upstream
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `VITE_API_URL` | Backend API URL | `http://localhost:8280/api` |
-| `VITE_FRONT_URL` | Frontend URL | `http://localhost:8280` |
-| `VITE_APP_NAME` | Application identifier | `wslproxy` |
-| `VITE_APP_DISPLAY_NAME` | Display name in UI | `WSL Proxy` |
-| `VITE_APP_VERSION` | App version | `dev` |
-| `VITE_APP_BUILD_NUMBER` | Build number | `local` |
-| `VITE_DEPLOYMENT_TIME` | Deployment timestamp | `local-dev` |
-| `VITE_THEME_PRIMARY_COLOR` | Primary theme color (hex without #) | `2E3A3C` |
-| `VITE_THEME_SECONDARY_COLOR` | Secondary theme color (hex without #) | `45A049` |
-| `VITE_THEME_HOVER_COLOR` | Hover state color (hex without #) | `036408` |
-| `VITE_TARGET_PLATFORM` | Platform type (`DOCKER` or `KUBERNETES`) | `DOCKER` |
-| `VITE_JWT_SECURITY_PASSPHRASE` | JWT secret key (injected by `start.sh`) | *(empty - set at runtime)* |
+  C->>N: HTTPS request
+  N->>A: rewrite_by_lua
+  A->>A: load server + rules<br/>match + WAF / rate limit
+  A->>R: selectedRule in ngx.ctx
+  R->>R: 200/301/302/305/306/403
+  alt code 305 proxy
+    R->>U: balancer peer + timeouts
+    U-->>C: origin response
+  else redirect / block / captcha
+    R-->>C: terminal response
+  end
+```
 
-> **Note:** `VITE_JWT_SECURITY_PASSPHRASE` is left empty in the committed `.env` file. Never hardcode secrets in files pushed to GitHub. The `start.sh` script handles injecting this value at runtime.
+---
 
-### Access URLs
+## Repository map
+
+| Path | Role |
+|------|------|
+| `api/` | Lua gateway + REST + MCP (hot-reloaded) |
+| `data/` | Servers, rules, WAF, SSL JSON (per env profile) |
+| `openresty-admin/` | React Admin UI |
+| `openresty-admin-next/` | Next.js ops dashboard |
+| `html/` | Public landing + swagger |
+| `cmd/wslproxy-cli/` | Go CLI + Dockerfile |
+| `infra/ansible/` | Production deploy (OpenResty build, nginx, data, UIs) |
+| `ingress-controller/` | k3s Helm ingress chart |
+| `docs/` | Guides (MCP, WAF, CLI, diagrams) |
+
+Developer deep-dive: [CLAUDE.md](CLAUDE.md).
+
+---
+
+## Deploy paths
+
+```mermaid
+flowchart LR
+  DEV[Docker Compose<br/>./dev.sh] --> INT[Ansible → int]
+  INT --> TEST[Ansible → test]
+  TEST --> PROD[Ansible → prod POPs]
+  K3S[Helm wslproxy-ingress<br/>manual upgrade] --> APPS[App Ingresses]
+  PROD --> K3S
+```
+
+- **Delivery pipeline:** `.github/workflows/deploy-wslproxy-delivery-pipeline.yml` (int → smoke → test → prod)
+- **CLI binaries + image:** `.github/workflows/build-wslproxy-cli.yml` → GHCR + release `wslproxy-cli-latest`
+- Ansible playbook: `infra/ansible/wslproxy-ops.yml`
+
+---
+
+## MCP (AI agents)
+
+Enable in `data/settings.json` → `mcp`. Endpoints: `/mcp/manifest`, `/mcp/tools`, `/mcp/jsonrpc`.
+
+Tools include `validate_config`, CRUD for servers/rules, WAF bind, traffic promote/rollback, POPs/DNS — see [docs/mcp.md](docs/mcp.md) and [api/mcp/README.md](api/mcp/README.md).
+
+---
+
+## Documentation index
+
+| Doc | Topic |
+|-----|--------|
+| [docs/wslproxy-cli.md](docs/wslproxy-cli.md) | CLI + Docker CI usage |
+| [docs/WAF_ENGINE_V2.md](docs/WAF_ENGINE_V2.md) | WAF engine |
+| [docs/mcp.md](docs/mcp.md) / [mcp-gateway.md](docs/mcp-gateway.md) | MCP |
+| [POPS_AND_DNS_GUIDE.md](POPS_AND_DNS_GUIDE.md) | POPs & Cloudflare DNS |
+| [DOCKER.md](DOCKER.md) / [DOCKER-DEPLOYMENT.md](DOCKER-DEPLOYMENT.md) | Containers |
+| [docs/diagrams/](docs/diagrams/) | Draw.io architecture set |
+| [examples/wslproxy-waf-demo/](examples/wslproxy-waf-demo/) | WAF demo pack |
+
+---
+
+## Local URLs (`./dev.sh`)
 
 | Service | URL |
 |---------|-----|
-| Admin Dashboard | http://localhost:8280 |
-| API | http://localhost:8280/api |
-| Health Check | http://localhost:8280/health |
-| Health Check (detailed) | http://localhost:8280/health?detailed=true |
-| HTTP Proxy | http://localhost:8180 |
-| HTTPS Proxy | https://localhost:8443 |
-| Prometheus Metrics | http://localhost:8280/metrics |
-| Demo Node App | http://localhost:3009 |
-| Redis | localhost:6479 |
+| Admin | http://localhost:8280 |
+| API / Swagger | http://localhost:8280/api · /swagger/ |
+| Health | http://localhost:8280/health |
+| Proxy HTTP/HTTPS | http://localhost:8180 · https://localhost:8443 |
 
-### Options
+---
 
-| Flag | Description |
-|------|-------------|
-| `-n, --no-git` | Skip git stash/pull prompts |
-| `-a, --auto` | Auto mode: stash + pull without prompts |
-| `-j, --jwt-secret KEY` | Set JWT secret key (skips interactive prompt) |
-| `-w, --watch` | Auto-rebuild admin dashboard on file changes |
-| `-s, --skip-build` | Skip admin build (use existing dist) |
-| `-r, --reset` | Fresh start - remove all volumes/data |
-| `-d, --detach` | Run in background (don't attach to logs) |
-| `--stop` | Stop all running services |
-| `--reload` | Reload nginx config without restart |
-| `--status` | Show running services |
-| `--clean` | Stop and remove all volumes |
+## Contributing
 
-### Hot-Reload (No Restart Needed)
+PRs against `main`. Prefer small, focused changes. Do not commit real `settings.json` secrets or `.env` credentials.
 
-| Component | How it syncs |
-|-----------|-------------|
-| Lua API files (`./api/`) | Volume-mounted, OpenResty re-reads per request |
-| Static HTML (`./html/`) | Volume-mounted, changes reflect immediately |
-| Nginx config | Volume-mounted, run `./start.sh --reload` to apply |
-| Admin dashboard | Use `-w` flag for auto-rebuild on save |
+## License
 
-## Documentation
-
-- **[Docker Deployment Guide](./DOCKER-DEPLOYMENT.md)** - Step-by-step deployment for all scenarios
-- **[Docker Reference](./DOCKER.md)** - Configuration, monitoring, troubleshooting
-- **[Kubernetes Helm Charts](./infra/helm-charts/wslproxy/)** - K8s deployment manifests
-
-## Use Cases
-
-### API Gateway for Microservices
-Route, authenticate, and monitor traffic to multiple backend services with automatic certificate management and request/response transformation.
-
-### CDN & Reverse Proxy
-Cache static content, optimize images, and serve from edge locations with dynamic routing rules and traffic analytics.
-
-### Service Mesh Ingress
-Integrate with Consul for automatic service discovery, health checks, and dynamic upstream configuration.
-
-### Multi-Tenant Platform
-Isolate and manage multiple tenants with per-tenant SSL certificates, rate limiting, and traffic rules.
-
-## Development Environment Requirements
-
-- **Bash** - For deployment scripts
-- **Docker** - For containerized deployment
-- **Node.js** - Version 16+ (for admin dashboard development)
-- **Yarn** - For package management
-
-## Advanced Deployment
-
-### Docker - Full Automation Script
-
-For complete automated setup with environment configuration:
-
-```bash
-# Development environment
-sudo ./deploy-to-docker.sh "dev" "wslproxy" "$JWT_TOKEN" && ./show.sh
-
-# Production environment
-sudo ./deploy-to-docker.sh "prod" "wslproxy" "$JWT_TOKEN"
-```
-
-**Windows Users** (with Git Bash):
-
-```bash
-bash ./deploy-to-docker-windows.sh "dev" "wslproxy" "$JWT_TOKEN"
-```
-
-### Docker - Build Locally
-
-To build the Docker image from source:
-
-```bash
-./build.sh "dev" "wslproxy" "$JWT_TOKEN"
-```
-
-### Docker - Bootstrap Deployment
-
-For fresh deployments with automatic configuration:
-
-```bash
-./bootstrap.sh "dev" "wslproxy" "$JWT_TOKEN" "DOCKER"
-```
-
-### Kubernetes Deployment
-
-**Prerequisites:**
-- Kubernetes cluster 1.20+ running
-- Helm 3+ installed
-- KubeSeal installed for secret management (optional but recommended)
-
-**Step 1: Create environment configuration**
-
-Create a `.env` file with your deployment details:
-
-```
-VITE_API_URL=https://YOUR-DOMAIN/api
-VITE_FRONT_URL=https://YOUR-FRONT-DOMAIN
-VITE_NGINX_CONFIG_DIR=/opt/nginx/
-VITE_APP_NAME=YOUR_APP_NAME
-VITE_APP_DISPLAY_NAME="YOUR APP NAME TO DISPLAY"
-VITE_APP_VERSION: 1.0.0
-VITE_DEPLOYMENT_TIME=20231206025957
-VITE_APP_BUILD_NUMBER=025957
-VITE_JWT_SECURITY_PASSPHRASE=YOUR-JWT-TOKEN
-VITE_TARGET_PLATFORM=KUBERNETES
-MINIO_ENDPOINT=<MINIO_ENDPOINT>
-MINIO_ACCESS_KEY=<MINIO_ACCESS_KEY>
-MINIO_SECRET_KEY=<MINIO_SECRET_KEY>
-```
-
-**Step 2: Create Kubernetes secrets**
-
-Encode and create the secret manifests:
-
-```bash
-# Encode the .env file
-cat .env | base64 > env.b64
-```
-
-**Step 3: Create secret manifests**
-
-Create `api-secrets.yaml`:
-
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: wf-api-secret-<NAMESPACE>
-  namespace: <NAMESPACE>
-data:
-  env_file: <BASE64 ENCODED ENV FILE>
-```
-
-Also create `front-secrets.yaml` for the admin dashboard:
-
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: wf-front-secret-<NAMESPACE>
-  namespace: <NAMESPACE>
-data:
-  env_file: <BASE64 ENCODED ENV FILE>
-```
-
-**Step 4: Seal secrets (optional, for enhanced security)**
-
-```bash
-kubeseal --format=yaml < api-secrets.yaml > api-sealed-secret.yaml
-kubeseal --format=yaml < front-secrets.yaml > front-sealed-secret.yaml
-# Use the sealed secrets in your Helm values instead
-```
-
-**Step 5: Create settings.json for backend configuration**
-
-The WSLProxy backend requires a `settings.json` file for initialization. Here's a minimal working example:
-
-```json
-{
-  "instance_id": "prod-wslproxy-01",
-  "instance_name": "Production WSLProxy",
-  "env_profile": "prod",
-  "redis_host": "redis-service.svc.cluster.local",
-  "redis_port": 6379,
-  "roles": [
-    "release_manager",
-    "admin",
-    "read_only",
-    "read_write"
-  ],
-  "env_vars": {
-    "FRONT_URL": "https://your-domain.com",
-    "CONTROL_PLANE_API_URL": "https://api.your-domain.com",
-    "JWT_SECURITY_PASSPHRASE": "your-jwt-token",
-    "APP_NAME": "WSLProxy"
-  },
-  "storage_type": "disk",
-  "instance_locked": false,
-    "ip2location_path": "<ADD IP2LOCATION-LITE-DB11.IPV6.BIN file Path>",
-    "dns_resolver": {
-      "nameservers": {
-        "primary": "8.8.8.8",
-        "secondary": "8.8.4.4",
-        "port": "53"
-      }
-    },
-    "super_user": {
-      "username": "<username>",
-      "email": "<email for login into the gateway>",
-      "password": "<Password for gateway must be SHA256>"
-    },
-    "storage_type": "disk",
-    "redis_host": "<REDIS_HOST>",
-    "redis_port": "<REDIS_PORT>",
-    "consul": {
-      "dns_server_host": "<Consul DNS Resolver host>",
-      "dns_server_port": <Consule DNS Resolver Port>
-    },
-    "nginx": {
-      "default": {
-        "no_server": "PCFET0NUWVBFIGh0bWw+CjxodG1sPgo8aGVhZD4KICA8dGl0bGU+Tm8gUnVsZXM8L3RpdGxlPgogIDxzdHlsZT4KICAgIGJvZHkgewogICAgICBmb250LWZhbWlseTogQXJpYWwsIHNhbnMtc2VyaWY7CiAgICAgIGJhY2tncm91bmQtY29sb3I6ICNmNGY0ZjQ7CiAgICAgIG1hcmdpbjogMDsKICAgICAgcGFkZGluZzogMDsKICAgICAgZGlzcGxheTogZmxleDsKICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjsKICAgICAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7CiAgICAgIGhlaWdodDogMTAwdmg7CiAgICB9CiAgICAKICAgIC5jb250YWluZXIgewogICAgICBtYXgtd2lkdGg6IDQwMHB4OwogICAgICBwYWRkaW5nOiA0MHB4OwogICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmOwogICAgICBib3gtc2hhZG93OiAwIDAgMTBweCByZ2JhKDAsIDAsIDAsIDAuMSk7CiAgICAgIHRleHQtYWxpZ246IGNlbnRlcjsKICAgIH0KICAgIAogICAgaDEgewogICAgICBmb250LXNpemU6IDI0cHg7CiAgICAgIG1hcmdpbi1ib3R0b206IDIwcHg7CiAgICAgIGNvbG9yOiAjMzMzOwogICAgfQogICAgCiAgICBwIHsKICAgICAgZm9udC1zaXplOiAxOHB4OwogICAgICBjb2xvcjogIzY2NjsKICAgICAgbWFyZ2luLWJvdHRvbTogMzBweDsKICAgIH0KICAgIAogICAgLmJ0biB7CiAgICAgIGRpc3BsYXk6IGlubGluZS1ibG9jazsKICAgICAgcGFkZGluZzogMTBweCAyMHB4OwogICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA3YmZmOwogICAgICBjb2xvcjogI2ZmZjsKICAgICAgZm9udC1zaXplOiAxNnB4OwogICAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7CiAgICAgIGJvcmRlci1yYWRpdXM6IDRweDsKICAgICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAwLjNzIGVhc2U7CiAgICB9CiAgICAKICAgIC5idG46aG92ZXIgewogICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA1NmIzOwogICAgfQogIDwvc3R5bGU+CjwvaGVhZD4KPGJvZHk+CiAgPGRpdiBjbGFzcz0iY29udGFpbmVyIj4KICAgIDxoMT5ObyBOZ2lueCBTZXJ2ZXIgQ29uZmlnIGZvdW5kITwvaDE+CiAgICA8cD5QbGVhc2UgYXNrIFdlYk9wcyB0byBDb25maWd1cmUgaXQuPC9wPgogICAgPGEgaHJlZj0iIyIgY2xhc3M9ImJ0biI+Q29udGFjdCBBZG1pbmlzdHJhdG9yPC9hPgogIDwvZGl2Pgo8L2JvZHk+CjwvaHRtbD4K",
-        "conf_mismatch": "PCFET0NUWVBFIGh0bWw+CjxodG1sPgo8aGVhZD4KICA8dGl0bGU+Tm8gUnVsZXM8L3RpdGxlPgogIDxzdHlsZT4KICAgIGJvZHkgewogICAgICBmb250LWZhbWlseTogQXJpYWwsIHNhbnMtc2VyaWY7CiAgICAgIGJhY2tncm91bmQtY29sb3I6ICNmNGY0ZjQ7CiAgICAgIG1hcmdpbjogMDsKICAgICAgcGFkZGluZzogMDsKICAgICAgZGlzcGxheTogZmxleDsKICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjsKICAgICAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7CiAgICAgIGhlaWdodDogMTAwdmg7CiAgICB9CiAgICAKICAgIC5jb250YWluZXIgewogICAgICBtYXgtd2lkdGg6IDQwMHB4OwogICAgICBwYWRkaW5nOiA0MHB4OwogICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmOwogICAgICBib3gtc2hhZG93OiAwIDAgMTBweCByZ2JhKDAsIDAsIDAsIDAuMSk7CiAgICAgIHRleHQtYWxpZ246IGNlbnRlcjsKICAgIH0KICAgIAogICAgaDEgewogICAgICBmb250LXNpemU6IDI0cHg7CiAgICAgIG1hcmdpbi1ib3R0b206IDIwcHg7CiAgICAgIGNvbG9yOiAjMzMzOwogICAgfQogICAgCiAgICBwIHsKICAgICAgZm9udC1zaXplOiAxOHB4OwogICAgICBjb2xvcjogIzY2NjsKICAgICAgbWFyZ2luLWJvdHRvbTogMzBweDsKICAgIH0KICAgIAogICAgLmJ0biB7CiAgICAgIGRpc3BsYXk6IGlubGluZS1ibG9jazsKICAgICAgcGFkZGluZzogMTBweCAyMHB4OwogICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA3YmZmOwogICAgICBjb2xvcjogI2ZmZjsKICAgICAgZm9udC1zaXplOiAxNnB4OwogICAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7CiAgICAgIGJvcmRlci1yYWRpdXM6IDRweDsKICAgICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAwLjNzIGVhc2U7CiAgICB9CiAgICAKICAgIC5idG46aG92ZXIgewogICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA1NmIzOwogICAgfQogIDwvc3R5bGU+CjwvaGVhZD4KPGJvZHk+CiAgPGRpdiBjbGFzcz0iY29udGFpbmVyIj4KICAgIDxoMT5Db25maWd1cmF0aW9uIG5vdCBtYXRjaCE8L2gxPgogICAgPHA+UGxlYXNlIGNoZWNrIHlvdXIgY29uZmlndXJhdGlvbnMgb3IgYXNrIFdlYk9wcyB0byBDb25maWd1cmUgaXQgcmlnaHQuPC9wPgogICAgPGEgaHJlZj0iIyIgY2xhc3M9ImJ0biI+Q29udGFjdCBBZG1pbmlzdHJhdG9yPC9hPgogIDwvZGl2Pgo8L2JvZHk+CjwvaHRtbD4K",
-        "no_rule": "PCFET0NUWVBFIGh0bWw+CjxodG1sPgo8aGVhZD4KICA8dGl0bGU+Tm8gUnVsZXM8L3RpdGxlPgogIDxzdHlsZT4KICAgIGJvZHkgewogICAgICBmb250LWZhbWlseTogQXJpYWwsIHNhbnMtc2VyaWY7CiAgICAgIGJhY2tncm91bmQtY29sb3I6ICNmNGY0ZjQ7CiAgICAgIG1hcmdpbjogMDsKICAgICAgcGFkZGluZzogMDsKICAgICAgZGlzcGxheTogZmxleDsKICAgICAgYWxpZ24taXRlbXM6IGNlbnRlcjsKICAgICAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7CiAgICAgIGhlaWdodDogMTAwdmg7CiAgICB9CiAgICAKICAgIC5jb250YWluZXIgewogICAgICBtYXgtd2lkdGg6IDQwMHB4OwogICAgICBwYWRkaW5nOiA0MHB4OwogICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjZmZmOwogICAgICBib3gtc2hhZG93OiAwIDAgMTBweCByZ2JhKDAsIDAsIDAsIDAuMSk7CiAgICAgIHRleHQtYWxpZ246IGNlbnRlcjsKICAgIH0KICAgIAogICAgaDEgewogICAgICBmb250LXNpemU6IDI0cHg7CiAgICAgIG1hcmdpbi1ib3R0b206IDIwcHg7CiAgICAgIGNvbG9yOiAjMzMzOwogICAgfQogICAgCiAgICBwIHsKICAgICAgZm9udC1zaXplOiAxOHB4OwogICAgICBjb2xvcjogIzY2NjsKICAgICAgbWFyZ2luLWJvdHRvbTogMzBweDsKICAgIH0KICAgIAogICAgLmJ0biB7CiAgICAgIGRpc3BsYXk6IGlubGluZS1ibG9jazsKICAgICAgcGFkZGluZzogMTBweCAyMHB4OwogICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA3YmZmOwogICAgICBjb2xvcjogI2ZmZjsKICAgICAgZm9udC1zaXplOiAxNnB4OwogICAgICB0ZXh0LWRlY29yYXRpb246IG5vbmU7CiAgICAgIGJvcmRlci1yYWRpdXM6IDRweDsKICAgICAgdHJhbnNpdGlvbjogYmFja2dyb3VuZC1jb2xvciAwLjNzIGVhc2U7CiAgICB9CiAgICAKICAgIC5idG46aG92ZXIgewogICAgICBiYWNrZ3JvdW5kLWNvbG9yOiAjMDA1NmIzOwogICAgfQogIDwvc3R5bGU+CjwvaGVhZD4KPGJvZHk+CiAgPGRpdiBjbGFzcz0iY29udGFpbmVyIj4KICAgIDxoMT5Db25maWd1cmF0aW9uIE1pc3NpbmchPC9oMT4KICAgIDxwPlBsZWFzZSBhc2sgV2ViT3BzIHRvIENvbmZpZ3VyZSB0aGlzIEFQSSBHYXRld2F5LjwvcD4KICAgIDxhIGhyZWY9IiMiIGNsYXNzPSJidG4iPkNvbnRhY3QgQWRtaW5pc3RyYXRvcjwvYT4KICA8L2Rpdj4KPC9ib2R5Pgo8L2h0bWw+Cg=="
-      },
-      "content_type": "text/html"
-    }
-  }
-```
-
-9. After creating settings.json you need to encode this file to base64.
-10. Create a new file with name api-setings-secrets.yaml with following details:
-
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: wf-api-settings-<NAMESPACE>
-  namespace: <NAMESPACE>
-data:
-  env_file: <BASE64 ENCODED ENV FILE>
-```
-
-11. Now, Run this command to generate the settings-sealed-secrets
-
-```
-kubeseal --format=yaml < api-setings-secrets.yaml > api-settings-sealed-secret.yaml
-```
-
-12. Open the api-settings-sealed-secret.yaml file copy the env_file: encrypted data.
-13. Put that encrypted data into the k3s values files under the 'settings_sec_env_file:'.
-
-14. After the secrets, you also need to update some following secrets in k3s api and front values file:
-
-```
-# NOTE: This is example when you are running kubernates clusters on local, For production you can put your domains of api and front door.
-
-api_url: http://wf-api-svc-<NAMESPACE>.<NAMESPACE>.svc.cluster.local/api
-front_url: http://wf-front-svc-<NAMESPACE>.<NAMESPACE>.svc.cluster.local
-```
-
-15. After updating env secrets, now you have to run these helm commands to run api-gateway on your kubernates:
-
-```
-helm upgrade -i wslproxy-api-<NAMESPACE> ./infra/helm-charts/wslproxy/ -f infra/helm-charts/wslproxy/values-<NAMESPACE>-api-<TARGET_CLUSTER>.yaml --set TARGET_ENV=<NAMESPACE> --namespace <NAMESPACE> --create-namespace
-helm upgrade -i wslproxy-front-<NAMESPACE> ./infra/helm-charts/wslproxy/ -f infra/helm-charts/wslproxy/values-<NAMESPACE>-front-<TARGET_CLUSTER>.yaml --set TARGET_ENV=<NAMESPACE> --namespace <NAMESPACE> --create-namespace
-helm upgrade -i wslproxy-nodeapp ./infra/helm-charts/node-app/ -f infra/helm-charts/node-app/values-<TARGET_CLUSTER>.yaml
-```
-
-16. Disaster Recovery
-
-```
-# NOTE: The nginx openresty configuration is backed on to S3 using kubernetes cronjob manifests. See online DR process documentation for more information.
-```
-
-## Usage
-
-To develop the admin dashboard locally, use the `start.sh` script which builds inside the Docker container. For watch mode (auto-rebuild on save):
-
-```bash
-./start.sh -w
-```
-
-Manual rebuild inside the running container:
-
-```bash
-docker exec wslproxy-local sh -c 'cd /usr/local/openresty/nginx/html/openresty-admin && yarn build'
-```
-
-## List of the environments:-
-
-| Environment | Link                             | Credentials         | IP addresses                                                                                                                                            | Ports         |
-| :---------- | :------------------------------- | :------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------ |
-| `dev`       | `http://localhost:8081/`         | `Ask administrator` | `wslproxy API :- localhost(127.0.0.1) `                                                                                                                 | ` 8081->8080` |
-|             |                                  |                     | `wslproxy Front :- localhost(127.0.0.1)`                                                                                                                | `8069->80`    |
-|             |                                  |                     | `Docker nodeapp :-localhost(127.0.0.1) -> host.docker.internal if using extra_hosts: - "host.docker.internal:host-gateway" in docker or docker compose` | `3009->3009`  |
-| `int`       | `http://api-int.wslproxy.com/`   | `Ask administrator` | `wslproxy API :- api-int.wslproxy.com`                                                                                                                  | `80 443`      |
-|             |                                  |                     | `wslproxy Front :- front-int.wslproxy.com`                                                                                                              | `80 443`      |
-|             |                                  |                     | `Node-app :-     `                                                                                                                                      | `3009->3009`  |
-|             | `http://api-int.wslproxy.com/`   | `Ask administrator` | `wslproxy API :- api-int.wslproxy.com`                                                                                                                  | `80 443`      |
-|             |                                  |                     | `wslproxy Front :- frontdoor-int.wslproxy.com`                                                                                                          | `80 443`      |
-|             |                                  |                     | `Node-app :- 	 `                                                                                                                                         | `3009->3009`  |
-|             | `http://api-int.wslproxy.com/`   | `Ask administrator` | `wslproxy API :- api-int.wslproxy.com`                                                                                                                  | `80 443`      |
-|             |                                  |                     | `wslproxy Front :- frontdoor-int.wslproxy.com`                                                                                                          | `80 443`      |
-|             |                                  |                     | `Node-app :-     `                                                                                                                                      | `3009->3009`  |
-| `test`      | `http://api.test2.wslproxy.com/` | `Ask administrator` | `wslproxy API :- api.test2.wslproxy.com`                                                                                                                | `80 443`      |
-|             |                                  |                     | `wslproxy Front :- front.test2.wslproxy.com`                                                                                                            | `80 443`      |
-|             |                                  |                     | `Node-app :-      `                                                                                                                                     | `3009->3009`  |
-|             | `http://api.test6.wslproxy.com/` | `Ask administrator` | `wslproxy API :- api.test6.wslproxy.com`                                                                                                                | `80 443`      |
-|             |                                  |                     | `wslproxy Front :- front.wslproxy.com`                                                                                                                  | `80 443`      |
-|             |                                  |                     | `Node-app :-      	`                                                                                                                                     | `3009->3009`  |
-
-## CI/CD Pipeline
-
-WSLProxy has two separate pipelines:
-
-| Pipeline | File | Purpose | Triggers |
-|----------|------|---------|----------|
-| **Promotion** | `deploy-wslproxy-promotion-pipeline.yml` | Deploys `main` → `int` → `test` (non-production) | Push to `main`, PRs, manual |
-| **Delivery** | `deploy-wslproxy-delivery-pipeline.yml` | Production releases from the `release` branch | Separate — not covered here |
-
-> The `acc` tier on 187.77.179.206 was decommissioned. Both pipelines now go test → prod directly.
-
-### Promotion Pipeline
-
-```
-main branch
-    │
-    ▼
-[Stage 1] Validate JSON configs (data/servers, data/rules, data/waf_rules, data/waf_policies)
-    │
-    ▼
-[Stage 2] Deploy → Int (192.168.1.193)   ← self-hosted runner, local connection
-    │
-    ▼
-[Stage 3] Smoke Test Int (Go tests + /health curl)
-    │         └─ fails here → stops, test never touched
-    ▼
-[Stage 4] Deploy → Test (192.168.1.140)  ← SSH
-    │
-    ▼
-[Summary] Print all stage results
-```
-
-Promotions are **sequential with a gate at each stage** — a failed health check or failed smoke test stops all subsequent environments. Concurrent pipeline runs are queued (not cancelled).
-
-### How to Trigger Manually
-
-Go to **Actions → CI/CD Promotion Pipeline → Run workflow** and choose:
-
-| Input | Options | Default | Description |
-|-------|---------|---------|-------------|
-| `DEPLOY_MODE` | `servers`, `nginx` | `servers` | What to deploy (see modes below) |
-| `TARGET_ENV` | `int`, `test` | `test` | How far to promote (stops after this env) |
-
-On a **push to `main`** or **PR**, the pipeline always runs with `deploy_mode=servers` all the way to `test`.
-
-### Deploy Modes
-
-| Mode | What it deploys |
-|------|----------------|
-| `servers` *(default)* | nginx `.j2` templates + virtual server/rule JSON configs |
-| `nginx` | nginx `.j2` templates + cron jobs + systemd limits + PAM config |
-| `dashboard` | nginx `.j2` templates + Lua API code + admin UI rebuild |
-| `full` | Everything above combined |
-| `build` | OS dependencies + compile OpenResty from source |
-
-> **Note:** The `deploy-configs.yml` playbook (server/rule JSON files) **always runs** on every deploy regardless of mode.
-
-### What Gets Deployed
-
-Each environment deploy runs two Ansible playbooks back-to-back:
-
-#### Playbook 1 — `wslproxy-ops.yml` (mode-controlled)
-
-Deploys nginx configuration and application code via the `wslproxy` Ansible role:
-
-| File / Task | Deployed when |
-|------------|---------------|
-| `nginx.conf.j2` → `/usr/local/openresty/nginx/conf/nginx.conf` | `servers`, `nginx`, `dashboard`, `code` |
-| `default.conf.j2` → `/opt/nginx/conf.d/default.conf` | `servers`, `nginx`, `dashboard`, `code` |
-| `servers-mixed-nginx.conf.j2` → `/opt/nginx/conf.d/servers-mixed-nginx.conf` | `servers`, `nginx`, `dashboard`, `code` |
-| Tenant nginx configs from `nginx-conf.d/` → `/opt/nginx/conf.d/` | `servers`, `nginx`, `dashboard`, `code` |
-| Lua API files (`api/`) | `code`, `dashboard` |
-| Admin dashboard (React build) | `dashboard` |
-| Cron jobs, systemd limits, PAM config | `nginx` |
-
-**Yes — `.j2` templates are deployed with the default `servers` mode.** They are rendered by Ansible (variables substituted) and written to the target host on every run.
-
-#### Playbook 2 — `deploy-configs.yml` (always runs)
-
-Syncs virtual server and routing rule JSON files from the repo to the target host:
-
-1. Validates all JSON with `jq` before copying (fails fast on syntax errors)
-2. Creates a timestamped backup at `/opt/nginx/backups/configs-<env>-<epoch>.tar.gz`
-3. Copies `data/servers/<env>/*.json` → `/opt/nginx/data/servers/<env>/`
-4. Copies `data/rules/<env>/*.json` → `/opt/nginx/data/rules/<env>/`
-5. Auto-generates SSL domain files for servers with `ssl_enabled: true`
-6. Runs `fix-permissions.sh` if any files changed
-7. Reloads OpenResty if server configs or SSL files changed
-8. Cleans up backups older than 7 days
-
-### Secrets Management
-
-| Environment | Connection | Secrets source |
-|-------------|-----------|----------------|
-| Int | Local (runner on same machine) | GitHub Secrets (`DOT_WSLPROXY_SETTINGS_INT`, `DOT_WSLPROXY_ENV_CREDS_INT`) decoded from base64 |
-| Test | SSH (password) | Runner filesystem at `/home/bwalia/.secrets/wslproxy/test/` |
-
-### Health Gate
-
-After each deploy, the pipeline:
-1. Runs `openresty -t` to validate the nginx config syntax
-2. Checks `systemctl is-active openresty` to confirm the service is running
-3. Polls `http://localhost:8080/health` (up to 12 retries × 5s = 60s) for HTTP 200
-
-If any of these fail, the stage fails and subsequent environments are not deployed.
-
-### Slack Notifications
-
-Failures at any stage send an alert to `#github-updates`. Success notifications are sent for **Test** and **ACC** only (Int is silent on success).
-
-### Running Ansible Manually
-
-```bash
-# Deploy server/rule configs to a specific environment
-ansible-playbook infra/ansible/deploy-configs.yml \
-  -i infra/ansible/hosts \
-  -l 192.168.1.193 \
-  -e "target_env=int local_data_dir=$(pwd)/data"
-
-# Full wslproxy deploy (all tags)
-ansible-playbook infra/ansible/wslproxy-ops.yml \
-  -i infra/ansible/hosts \
-  -l 192.168.1.193 \
-  -e "target_env=int local_settings_file_path=/path/to/settings.json local_env_file_path=/path/to/.env"
-
-# nginx configs only
-ansible-playbook infra/ansible/wslproxy-ops.yml \
-  -i infra/ansible/hosts \
-  -l 192.168.1.193 \
-  --tags nginx \
-  -e "target_env=int local_settings_file_path=/path/to/settings.json local_env_file_path=/path/to/.env"
-```
-
-## How to run Ansible for a workflow
-
-ansible-playbook infra/ansible/deploy-wslproxy.yml -i infra/ansible/hosts -l target_host_ip
-
-### Replace 'infra/ansible/hosts' with the required host file
-
-### Replace target_host_ip with the target host which you want to run the playbook
+See repository license file.

--- a/docs/diagrams/README.md
+++ b/docs/diagrams/README.md
@@ -1,135 +1,31 @@
-# WSL Proxy - Architecture Diagrams
+# WSL Proxy — Architecture Diagrams
 
-This folder contains Draw.io compatible diagrams documenting the WSL Proxy architecture, deployment pipelines, and request flows.
+Draw.io sources for architecture, CI/CD, Helm scaling, and request flow. The **canonical overview for GitHub** is the Mermaid diagrams in the root [README.md](../../README.md) (they render on github.com without PNG exports).
 
-## 📊 Available Diagrams
+## Draw.io files
 
-### 1. Platform Architecture ([wslproxy-architecture.drawio](wslproxy-architecture.drawio))
+| File | Topic |
+|------|--------|
+| [wslproxy-architecture.drawio](wslproxy-architecture.drawio) | Edge + control plane overview |
+| [request-flow.drawio](request-flow.drawio) | Per-request processing stages |
+| [cicd-pipeline.drawio](cicd-pipeline.drawio) | Build / deploy pipeline |
+| [helm-deployment-scaling.drawio](helm-deployment-scaling.drawio) | k8s / Helm / HPA |
+| [ingress-controller-architecture.drawio](ingress-controller-architecture.drawio) | k3s ingress layer |
 
-Complete overview of WSL Proxy's architecture including:
-- **Client Layer**: Web browsers, mobile apps, API clients, IoT devices
-- **Edge Layer**: WAF, SSL/TLS, API Gateway, Cache, Load Balancer, Router
-- **Data Layer**: Redis, Shared Dict, SSL Certs, Config stores
-- **Origin Servers**: Multi-region backend support
-- **Management**: Admin UI, REST API, Prometheus metrics
+Open on GitHub for a preview, or edit at [diagrams.net](https://app.diagrams.net/) / VS Code Draw.io extension.
 
-![Architecture](images/wslproxy-architecture.png)
+## PNG exports (optional)
 
-### 2. CI/CD Pipeline ([cicd-pipeline.drawio](cicd-pipeline.drawio))
+If you need images for slides or external docs:
 
-Full CI/CD integration workflow:
-- **Developer Flow**: Code changes → Git push → Pull request
-- **GitHub Actions**: Lint, Test, Security scan, Docker build, Push to registry
-- **Ansible Deployment**: Inventory, Vault, Roles, Playbooks for bare metal
-- **Kubernetes Deployment**: Helm charts, Values files, Rolling updates
-- **Environments**: Dev, Staging, Production, Bare Metal, Multi-Region
+1. Open a `.drawio` in diagrams.net  
+2. **File → Export as → PNG** (≈200% scale)  
+3. Save under `docs/diagrams/images/`
 
-![CI/CD Pipeline](images/cicd-pipeline.png)
+The root README no longer depends on these PNGs.
 
-### 3. Helm Deployment & Scaling ([helm-deployment-scaling.drawio](helm-deployment-scaling.drawio))
+## Related
 
-Kubernetes deployment architecture:
-- **Ingress Layer**: DNS, Cloud LB, Ingress Controller
-- **Service Layer**: ClusterIP service with multi-port support
-- **Deployment**: Pod replicas with resource limits
-- **HPA**: Horizontal Pod Autoscaler configuration
-- **Storage**: ConfigMaps, Secrets, PVCs
-- **External Services**: Redis cluster, Prometheus, Loki
-- **Helm Chart Structure**: Complete chart layout
-
-![Helm Deployment](images/helm-deployment-scaling.png)
-
-### 4. Request Flow ([request-flow.drawio](request-flow.drawio))
-
-Step-by-step request processing:
-
-```
-1. Client Request → 2. DNS Resolution → 3. SSL/TLS Termination
-→ 4. WAF Security Check → 5. Authentication → 6. Router Matching
-→ 7. Cache Check (HIT/MISS) → 8. Load Balancer → 9. Upstream Request
-→ 10. Origin Server → 11. Response Processing → 12. Metrics Update
-→ 13. Client Response
-```
-
-![Request Flow](images/request-flow.png)
-
-## 🛠️ How to Use
-
-### View Online
-Open any `.drawio` file directly on GitHub - it will render a preview.
-
-### Edit with Draw.io
-1. Go to [draw.io](https://app.diagrams.net/)
-2. Choose **Open Existing Diagram**
-3. Select **Device** and open the `.drawio` file
-4. Make your changes
-5. Export as `.drawio`, `.png`, or `.svg`
-
-### VS Code Extension
-Install the [Draw.io Integration](https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio) extension to edit diagrams directly in VS Code.
-
-## 📁 Folder Structure
-
-```
-docs/diagrams/
-├── README.md                       # This file
-├── wslproxy-architecture.drawio    # Platform architecture diagram
-├── cicd-pipeline.drawio            # CI/CD pipeline flow
-├── helm-deployment-scaling.drawio  # Kubernetes & Helm scaling
-├── request-flow.drawio             # Request processing flow
-└── images/                         # Exported PNG versions
-    ├── wslproxy-architecture.png
-    ├── cicd-pipeline.png
-    ├── helm-deployment-scaling.png
-    └── request-flow.png
-```
-
-## 🔗 Related Documentation
-
-- **API Documentation**: [wslproxy.com/swagger](https://wslproxy.com/swagger/swagger.html)
-- **GitHub Repository**: [github.com/bwalia/wslproxy](https://github.com/bwalia/wslproxy)
-- **Landing Page**: [wslproxy.com](https://wslproxy.com)
-
-## 📝 Export Instructions
-
-To generate PNG versions for the main README:
-
-1. Open each `.drawio` file in draw.io
-2. Go to **File → Export as → PNG**
-3. Set scale to 200% for high-resolution
-4. Save to `docs/diagrams/images/` folder
-5. Update main README.md with image references
-
-## 🏗️ Architecture Overview
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         WSL Proxy Edge Layer                         │
-├─────────────────────────────────────────────────────────────────────┤
-│  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐   │
-│  │   WAF   │→ │  SSL/   │→ │  API    │→ │  Cache  │→ │  Load   │   │
-│  │ Rules   │  │  TLS    │  │ Gateway │  │ Manager │  │ Balancer│   │
-│  └─────────┘  └─────────┘  └─────────┘  └─────────┘  └─────────┘   │
-│       │            │            │            │            │         │
-│       └────────────┴────────────┴────────────┴────────────┘         │
-│                              │                                       │
-│                      ┌───────┴───────┐                               │
-│                      │    Router     │                               │
-│                      │  (Lua/OpenResty)                              │
-│                      └───────┬───────┘                               │
-│                              │                                       │
-├──────────────────────────────┼──────────────────────────────────────┤
-│                              ▼                                       │
-│  ┌─────────────────────────────────────────────────────────────┐    │
-│  │                     Origin Servers                           │    │
-│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐     │    │
-│  │  │ Region 1 │  │ Region 2 │  │ Region 3 │  │ Region N │     │    │
-│  │  │ US-East  │  │ EU-West  │  │  Asia    │  │   ...    │     │    │
-│  │  └──────────┘  └──────────┘  └──────────┘  └──────────┘     │    │
-│  └─────────────────────────────────────────────────────────────┘    │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-## 📜 License
-
-These diagrams are part of the WSL Proxy project and are licensed under the same terms.
+- Landing page: [wslproxy.com](https://wslproxy.com) (`html/index.html`)  
+- Swagger: `/swagger/`  
+- Deep dive: [CLAUDE.md](../../CLAUDE.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,920 +1,645 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="WSL Proxy - Enterprise-grade reverse proxy, load balancer, AI gateway, and edge computing platform. Build your own CDN with multi-region failover, edge caching, WAF protection, and an OpenAI-compatible LLM gateway in front of Anthropic, OpenAI, and self-hosted models." />
-    <meta name="keywords" content="CDN, reverse proxy, load balancer, edge computing, WAF, SSL, cache, API gateway, AI gateway, LLM gateway, OpenAI-compatible, Anthropic, OpenAI, Ollama, OpenResty, Lua, nginx" />
-    <meta name="author" content="Workstation Solutions Limited" />
-    <meta property="og:title" content="WSL Proxy - Build Your Own AI Gateways, CDN & More" />
-    <meta property="og:description" content="Enterprise-grade reverse proxy, load balancer, and edge computing platform with multi-region failover, edge caching, and WAF protection." />
-    <meta property="og:type" content="website" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="WSL Proxy - Build Your Own AI Gateways, CDN & More" />
-    <meta name="twitter:description" content="Enterprise-grade reverse proxy and edge computing platform" />
-    <title>WSL Proxy - Build Your Own AI Gateways, CDN & More | Enterprise Edge Platform</title>
-    
-    <!-- CDN Dependencies for GitHub Pages -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
-    
-    <style>
-      :root {
-        --primary: #6366f1;
-        --primary-dark: #4f46e5;
-        --secondary: #0ea5e9;
-        --accent: #10b981;
-        --dark: #0f172a;
-        --dark-light: #1e293b;
-        --gray: #64748b;
-        --light: #f8fafc;
-        --white: #ffffff;
-        --gradient: linear-gradient(135deg, #6366f1 0%, #0ea5e9 50%, #10b981 100%);
-        --gradient-dark: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="WSLProxy — dynamic API gateway and reverse proxy on OpenResty. Live rules, WAF, multi-POP edge, MCP for AI agents, and a CLI for GitOps." />
+  <meta name="author" content="Workstation Solutions Limited" />
+  <meta property="og:title" content="WSLProxy — Live-config API gateway" />
+  <meta property="og:description" content="Route, secure, and observe traffic from JSON and MCP — without reloading nginx for every rule change." />
+  <meta property="og:type" content="website" />
+  <title>WSLProxy — Live-config API gateway &amp; edge control plane</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --ink: #0b1c2c;
+      --ink-soft: #243447;
+      --steel: #3d5a80;
+      --mist: #eef2f6;
+      --paper: #f7f9fc;
+      --line: #c5d0dc;
+      --copper: #c45c26;
+      --copper-deep: #9a4519;
+      --signal: #1a7a6d;
+      --mono: "JetBrains Mono", ui-monospace, monospace;
+      --sans: "Outfit", system-ui, sans-serif;
+      --display: "Fraunces", Georgia, serif;
+      --radius: 6px;
+      --max: 1120px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
       }
+    }
 
-      * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: var(--sans);
+      font-size: 1.0625rem;
+      line-height: 1.55;
+      color: var(--ink);
+      background: var(--paper);
+    }
 
-      body {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-        color: var(--dark);
-        line-height: 1.6;
-        overflow-x: hidden;
-      }
+    a { color: var(--copper-deep); }
+    a:focus-visible { outline: 2px solid var(--copper); outline-offset: 3px; }
 
-      /* Navbar */
-      .navbar-custom {
-        background: rgba(15, 23, 42, 0.95);
-        backdrop-filter: blur(20px);
-        padding: 1rem 0;
-        position: fixed;
-        width: 100%;
-        top: 0;
-        z-index: 1000;
-        border-bottom: 1px solid rgba(255,255,255,0.1);
-        transition: all 0.3s ease;
-      }
+    .wrap {
+      width: min(100% - 2.5rem, var(--max));
+      margin-inline: auto;
+    }
 
-      .navbar-brand {
-        font-size: 1.5rem;
-        font-weight: 800;
-        color: var(--white) !important;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        text-decoration: none;
-      }
-
-      .navbar-brand span {
-        background: var(--gradient);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-      }
-
-      .nav-link-custom {
-        color: rgba(255,255,255,0.8) !important;
-        font-weight: 500;
-        padding: 0.5rem 1rem !important;
-        transition: all 0.3s ease;
-        text-decoration: none;
-      }
-
-      .nav-link-custom:hover { color: var(--white) !important; }
-
-      .btn-nav {
-        background: var(--gradient);
-        color: var(--white) !important;
-        padding: 0.6rem 1.5rem !important;
-        border-radius: 8px;
-        font-weight: 600;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        margin-left: 1rem;
-        border: none;
-      }
-
-      .btn-nav:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 40px rgba(99, 102, 241, 0.4);
-      }
-
-      /* Hero Section */
-      .hero {
-        min-height: 100vh;
-        background: var(--gradient-dark);
-        position: relative;
-        display: flex;
-        align-items: center;
-        overflow: hidden;
-        padding-top: 80px;
-      }
-
-      .hero::before {
-        content: '';
+    /* —— Nav —— */
+    .nav {
+      position: sticky;
+      top: 0;
+      z-index: 40;
+      background: color-mix(in srgb, var(--paper) 88%, transparent);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--line);
+    }
+    .nav-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.85rem 0;
+    }
+    .brand {
+      font-family: var(--display);
+      font-weight: 700;
+      font-size: 1.35rem;
+      color: var(--ink);
+      text-decoration: none;
+      letter-spacing: -0.02em;
+    }
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 1.25rem;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    .nav-links a {
+      color: var(--ink-soft);
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 0.95rem;
+    }
+    .nav-links a:hover { color: var(--ink); }
+    .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.45rem 0.95rem;
+      background: var(--ink);
+      color: var(--paper) !important;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.9rem;
+      border-radius: var(--radius);
+    }
+    .nav-cta:hover { background: var(--ink-soft); }
+    .nav-toggle {
+      display: none;
+      background: none;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 0.35rem 0.6rem;
+      font: inherit;
+      cursor: pointer;
+    }
+    @media (max-width: 760px) {
+      .nav-toggle { display: block; }
+      .nav-links {
+        display: none;
         position: absolute;
-        top: 0; left: 0; right: 0; bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/></pattern></defs><rect width="100" height="100" fill="url(%23grid)"/></svg>');
-        pointer-events: none;
+        left: 0; right: 0;
+        top: 100%;
+        flex-direction: column;
+        align-items: stretch;
+        background: var(--paper);
+        border-bottom: 1px solid var(--line);
+        padding: 1rem 1.25rem 1.25rem;
+        gap: 0.75rem;
       }
+      .nav-links.open { display: flex; }
+    }
 
-      .hero-glow {
-        position: absolute;
-        width: 600px; height: 600px;
-        background: radial-gradient(circle, rgba(99, 102, 241, 0.3) 0%, transparent 70%);
-        top: -200px; right: -100px;
-        pointer-events: none;
-      }
+    /* —— Hero —— */
+    .hero {
+      position: relative;
+      min-height: min(100vh, 820px);
+      display: grid;
+      align-items: end;
+      padding: 4.5rem 0 3.5rem;
+      overflow: hidden;
+      background:
+        radial-gradient(1200px 500px at 70% -10%, color-mix(in srgb, var(--steel) 18%, transparent), transparent 60%),
+        linear-gradient(165deg, var(--mist) 0%, var(--paper) 45%, #e4ebe7 100%);
+    }
+    .hero::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(var(--line) 1px, transparent 1px),
+        linear-gradient(90deg, var(--line) 1px, transparent 1px);
+      background-size: 48px 48px;
+      opacity: 0.35;
+      mask-image: linear-gradient(180deg, #000 20%, transparent 85%);
+      pointer-events: none;
+    }
+    .hero-grid {
+      position: relative;
+      display: grid;
+      gap: 2.5rem;
+    }
+    .hero-copy { max-width: 36rem; }
+    .hero h1 {
+      font-family: var(--display);
+      font-weight: 700;
+      font-size: clamp(2.6rem, 6vw, 4.1rem);
+      line-height: 1.05;
+      letter-spacing: -0.03em;
+      margin: 0 0 1rem;
+      color: var(--ink);
+    }
+    .hero-lede {
+      margin: 0 0 1.75rem;
+      font-size: 1.15rem;
+      color: var(--ink-soft);
+      max-width: 32rem;
+    }
+    .cta-row { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.85rem 1.25rem;
+      border-radius: var(--radius);
+      font-weight: 600;
+      font-size: 0.98rem;
+      text-decoration: none;
+      border: 1px solid transparent;
+      transition: transform 0.2s ease, background 0.2s ease;
+    }
+    .btn:hover { transform: translateY(-1px); }
+    .btn-primary {
+      background: var(--copper);
+      color: #fff;
+    }
+    .btn-primary:hover { background: var(--copper-deep); color: #fff; }
+    .btn-ghost {
+      background: transparent;
+      border-color: var(--line);
+      color: var(--ink);
+    }
+    .btn-ghost:hover { border-color: var(--ink-soft); }
 
-      .hero-glow-2 {
-        position: absolute;
-        width: 400px; height: 400px;
-        background: radial-gradient(circle, rgba(14, 165, 233, 0.2) 0%, transparent 70%);
-        bottom: -100px; left: -100px;
-        pointer-events: none;
-      }
+    /* Request path visual — signature */
+    .path-stage {
+      position: relative;
+      margin-top: 0.5rem;
+      padding: 1.5rem 0 0.25rem;
+    }
+    .path-label {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--steel);
+      margin-bottom: 0.75rem;
+    }
+    .path-svg {
+      width: 100%;
+      height: auto;
+      display: block;
+      overflow: visible;
+    }
+    .path-wire {
+      fill: none;
+      stroke: var(--line);
+      stroke-width: 3;
+    }
+    .path-wire-live {
+      fill: none;
+      stroke: var(--signal);
+      stroke-width: 3;
+      stroke-dasharray: 12 220;
+      animation: packet 3.2s linear infinite;
+    }
+    @keyframes packet {
+      to { stroke-dashoffset: -232; }
+    }
+    .path-node {
+      fill: var(--paper);
+      stroke: var(--ink);
+      stroke-width: 2;
+    }
+    .path-node-active { stroke: var(--copper); }
+    .path-text {
+      font-family: var(--mono);
+      font-size: 11px;
+      fill: var(--ink-soft);
+    }
 
-      .hero-content { position: relative; z-index: 2; }
+    /* —— Sections —— */
+    section { padding: 4.5rem 0; }
+    .section-kicker {
+      font-family: var(--mono);
+      font-size: 0.75rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--steel);
+      margin: 0 0 0.75rem;
+    }
+    .section-title {
+      font-family: var(--display);
+      font-size: clamp(1.75rem, 3.5vw, 2.4rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin: 0 0 0.75rem;
+      max-width: 22ch;
+    }
+    .section-lede {
+      margin: 0 0 2rem;
+      color: var(--ink-soft);
+      max-width: 40rem;
+    }
 
-      .hero-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        background: rgba(99, 102, 241, 0.2);
-        border: 1px solid rgba(99, 102, 241, 0.3);
-        padding: 0.5rem 1rem;
-        border-radius: 50px;
-        color: var(--primary);
-        font-size: 0.875rem;
-        font-weight: 500;
-        margin-bottom: 1.5rem;
-      }
+    .split {
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: 1fr;
+    }
+    @media (min-width: 860px) {
+      .split-2 { grid-template-columns: 1fr 1fr; align-items: start; }
+      .split-aside { grid-template-columns: 1.1fr 0.9fr; }
+    }
 
-      .hero h1 {
-        font-size: 3.5rem;
-        font-weight: 800;
-        color: var(--white);
-        line-height: 1.1;
-        margin-bottom: 1.5rem;
-      }
+    .strip {
+      border-top: 1px solid var(--line);
+      padding: 1.5rem 0;
+    }
+    .strip h3 {
+      font-family: var(--display);
+      font-size: 1.35rem;
+      margin: 0 0 0.4rem;
+      letter-spacing: -0.01em;
+    }
+    .strip p { margin: 0; color: var(--ink-soft); }
 
-      .hero h1 .gradient-text {
-        background: var(--gradient);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-      }
+    .band {
+      background: var(--ink);
+      color: var(--mist);
+    }
+    .band .section-kicker { color: color-mix(in srgb, var(--mist) 55%, transparent); }
+    .band .section-title { color: #fff; max-width: none; }
+    .band .section-lede { color: color-mix(in srgb, var(--mist) 75%, transparent); }
 
-      .hero-description {
-        font-size: 1.25rem;
-        color: rgba(255,255,255,0.7);
-        max-width: 600px;
-        margin-bottom: 2rem;
-      }
+    .ops-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 1rem;
+    }
+    .ops-list li {
+      border-left: 3px solid var(--copper);
+      padding: 0.35rem 0 0.35rem 1rem;
+    }
+    .ops-list strong {
+      display: block;
+      font-family: var(--display);
+      font-size: 1.15rem;
+      margin-bottom: 0.2rem;
+      color: #fff;
+    }
+    .ops-list span { color: color-mix(in srgb, var(--mist) 72%, transparent); font-size: 0.98rem; }
 
-      .hero-buttons { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .code-panel {
+      background: #07131f;
+      color: #d7e2ec;
+      border-radius: var(--radius);
+      padding: 1.15rem 1.25rem;
+      font-family: var(--mono);
+      font-size: 0.8rem;
+      line-height: 1.65;
+      overflow-x: auto;
+      border: 1px solid #1c3348;
+    }
+    .code-panel .cmt { color: #6d8499; }
+    .code-panel .cmd { color: #e8a87c; }
 
-      .btn-primary-custom {
-        background: var(--gradient);
-        color: var(--white);
-        padding: 1rem 2rem;
-        border-radius: 12px;
-        font-weight: 600;
-        font-size: 1rem;
-        border: none;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-      }
+    .flow-steps {
+      display: grid;
+      gap: 0;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+      background: #fff;
+    }
+    .flow-step {
+      display: grid;
+      grid-template-columns: 4.5rem 1fr;
+      gap: 1rem;
+      padding: 1.1rem 1.25rem;
+      border-bottom: 1px solid var(--line);
+    }
+    .flow-step:last-child { border-bottom: 0; }
+    .flow-step code {
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      color: var(--copper-deep);
+      align-self: start;
+      padding-top: 0.15rem;
+    }
+    .flow-step strong { display: block; margin-bottom: 0.2rem; }
+    .flow-step p { margin: 0; color: var(--ink-soft); font-size: 0.95rem; }
 
-      .btn-primary-custom:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 20px 40px rgba(99, 102, 241, 0.4);
-        color: var(--white);
-      }
+    .start-grid {
+      display: grid;
+      gap: 1.5rem;
+    }
+    @media (min-width: 720px) {
+      .start-grid { grid-template-columns: repeat(3, 1fr); }
+    }
+    .start-item h3 {
+      font-family: var(--display);
+      font-size: 1.2rem;
+      margin: 0 0 0.5rem;
+    }
+    .start-item p { margin: 0 0 0.75rem; color: var(--ink-soft); font-size: 0.95rem; }
+    .start-item a { font-weight: 600; text-decoration: none; }
+    .start-item a:hover { text-decoration: underline; }
 
-      .btn-secondary-custom {
-        background: transparent;
-        color: var(--white);
-        padding: 1rem 2rem;
-        border-radius: 12px;
-        font-weight: 600;
-        font-size: 1rem;
-        border: 2px solid rgba(255,255,255,0.2);
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-      }
+    .cta-final {
+      text-align: center;
+      padding: 5rem 0;
+      background:
+        linear-gradient(180deg, var(--paper), var(--mist));
+    }
+    .cta-final h2 {
+      font-family: var(--display);
+      font-size: clamp(1.8rem, 4vw, 2.6rem);
+      margin: 0 0 0.75rem;
+    }
+    .cta-final p {
+      margin: 0 auto 1.5rem;
+      max-width: 32rem;
+      color: var(--ink-soft);
+    }
 
-      .btn-secondary-custom:hover {
-        background: rgba(255,255,255,0.1);
-        border-color: rgba(255,255,255,0.4);
-        color: var(--white);
-      }
+    footer {
+      border-top: 1px solid var(--line);
+      padding: 2rem 0 2.5rem;
+      font-size: 0.9rem;
+      color: var(--ink-soft);
+    }
+    .footer-inner {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .footer-links { display: flex; flex-wrap: wrap; gap: 1rem; }
+    .footer-links a { color: var(--ink-soft); text-decoration: none; }
+    .footer-links a:hover { color: var(--ink); }
+  </style>
+</head>
+<body>
+  <header class="nav">
+    <div class="wrap nav-inner">
+      <a class="brand" href="/">WSLProxy</a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="nav-menu" id="nav-toggle">Menu</button>
+      <ul class="nav-links" id="nav-menu">
+        <li><a href="#pipeline">Pipeline</a></li>
+        <li><a href="#capabilities">Capabilities</a></li>
+        <li><a href="#operate">Operate</a></li>
+        <li><a href="#start">Start</a></li>
+        <li><a class="nav-cta" href="https://github.com/bwalia/wslproxy">GitHub</a></li>
+      </ul>
+    </div>
+  </header>
 
-      .hero-stats {
-        display: flex;
-        gap: 3rem;
-        margin-top: 4rem;
-        padding-top: 2rem;
-        border-top: 1px solid rgba(255,255,255,0.1);
-        flex-wrap: wrap;
-      }
-
-      .stat-item { text-align: center; }
-
-      .stat-number {
-        font-size: 2.5rem;
-        font-weight: 800;
-        background: var(--gradient);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-      }
-
-      .stat-label { color: rgba(255,255,255,0.6); font-size: 0.875rem; }
-
-      /* Terminal */
-      .terminal-window {
-        background: var(--dark);
-        border-radius: 16px;
-        overflow: hidden;
-        box-shadow: 0 40px 80px rgba(0,0,0,0.5);
-        border: 1px solid rgba(255,255,255,0.1);
-      }
-
-      .terminal-header {
-        background: var(--dark-light);
-        padding: 1rem 1.5rem;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-      }
-
-      .terminal-dot { width: 12px; height: 12px; border-radius: 50%; }
-      .terminal-dot.red { background: #ff5f57; }
-      .terminal-dot.yellow { background: #febc2e; }
-      .terminal-dot.green { background: #28c840; }
-
-      .terminal-body {
-        padding: 1.5rem;
-        font-family: 'Monaco', 'Menlo', monospace;
-        font-size: 0.8rem;
-        color: rgba(255,255,255,0.8);
-        min-height: 280px;
-      }
-
-      .terminal-line { margin-bottom: 0.5rem; display: flex; gap: 0.5rem; }
-      .terminal-prompt { color: var(--accent); }
-      .terminal-command { color: var(--secondary); }
-      .terminal-output { color: rgba(255,255,255,0.6); padding-left: 1rem; }
-
-      /* Features Section */
-      .features { padding: 6rem 0; background: var(--light); }
-
-      .section-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        background: rgba(99, 102, 241, 0.1);
-        padding: 0.5rem 1rem;
-        border-radius: 50px;
-        color: var(--primary);
-        font-size: 0.875rem;
-        font-weight: 500;
-        margin-bottom: 1rem;
-      }
-
-      .section-title {
-        font-size: 2.5rem;
-        font-weight: 800;
-        color: var(--dark);
-        margin-bottom: 1rem;
-      }
-
-      .section-description {
-        font-size: 1.125rem;
-        color: var(--gray);
-        max-width: 600px;
-        margin: 0 auto 3rem;
-      }
-
-      .feature-card {
-        background: var(--white);
-        border-radius: 20px;
-        padding: 2rem;
-        height: 100%;
-        border: 1px solid rgba(0,0,0,0.05);
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.03);
-      }
-
-      .feature-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 20px 60px rgba(0,0,0,0.1);
-      }
-
-      .feature-icon {
-        width: 60px;
-        height: 60px;
-        border-radius: 16px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        margin-bottom: 1.5rem;
-        font-size: 1.5rem;
-      }
-
-      .feature-icon.blue { background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(14, 165, 233, 0.2)); color: var(--primary); }
-      .feature-icon.green { background: linear-gradient(135deg, rgba(16, 185, 129, 0.2), rgba(5, 150, 105, 0.2)); color: var(--accent); }
-      .feature-icon.purple { background: linear-gradient(135deg, rgba(139, 92, 246, 0.2), rgba(168, 85, 247, 0.2)); color: #8b5cf6; }
-      .feature-icon.orange { background: linear-gradient(135deg, rgba(249, 115, 22, 0.2), rgba(234, 88, 12, 0.2)); color: #f97316; }
-      .feature-icon.cyan { background: linear-gradient(135deg, rgba(6, 182, 212, 0.2), rgba(8, 145, 178, 0.2)); color: #06b6d4; }
-      .feature-icon.red { background: linear-gradient(135deg, rgba(239, 68, 68, 0.2), rgba(220, 38, 38, 0.2)); color: #ef4444; }
-      .feature-icon.pink { background: linear-gradient(135deg, rgba(236, 72, 153, 0.2), rgba(219, 39, 119, 0.2)); color: #ec4899; }
-      .feature-icon.yellow { background: linear-gradient(135deg, rgba(245, 158, 11, 0.2), rgba(217, 119, 6, 0.2)); color: #f59e0b; }
-      .feature-icon.indigo { background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(79, 70, 229, 0.2)); color: #6366f1; }
-      .feature-icon.teal { background: linear-gradient(135deg, rgba(20, 184, 166, 0.2), rgba(13, 148, 136, 0.2)); color: #14b8a6; }
-
-      .feature-card h4 { font-size: 1.25rem; font-weight: 700; color: var(--dark); margin-bottom: 0.75rem; }
-      .feature-card p { color: var(--gray); font-size: 0.95rem; line-height: 1.6; margin: 0; }
-
-      /* Request Flow Diagram */
-      .flow-section { padding: 5rem 0; background: var(--gradient-dark); }
-
-      .flow-diagram {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-wrap: wrap;
-        gap: 0;
-        padding: 2rem 0;
-      }
-
-      .flow-node {
-        background: rgba(255,255,255,0.1);
-        border: 1px solid rgba(255,255,255,0.2);
-        border-radius: 12px;
-        padding: 1rem 1.5rem;
-        text-align: center;
-        backdrop-filter: blur(10px);
-        min-width: 100px;
-      }
-
-      .flow-node i { font-size: 1.5rem; margin-bottom: 0.5rem; display: block; }
-      .flow-node span { font-size: 0.75rem; color: rgba(255,255,255,0.9); font-weight: 500; }
-      .flow-node.primary { background: rgba(99, 102, 241, 0.3); border-color: var(--primary); }
-      .flow-node.primary i { color: var(--primary); }
-      .flow-node.success { background: rgba(16, 185, 129, 0.3); border-color: var(--accent); }
-      .flow-node.success i { color: var(--accent); }
-      .flow-node.warning { background: rgba(249, 115, 22, 0.3); border-color: #f97316; }
-      .flow-node.warning i { color: #f97316; }
-      .flow-node.info { background: rgba(14, 165, 233, 0.3); border-color: var(--secondary); }
-      .flow-node.info i { color: var(--secondary); }
-
-      .flow-arrow {
-        color: rgba(255,255,255,0.4);
-        font-size: 1.5rem;
-        padding: 0 0.5rem;
-      }
-
-      /* API Section */
-      .api-section { padding: 5rem 0; background: var(--light); }
-
-      .api-card {
-        background: var(--white);
-        border-radius: 12px;
-        padding: 1.5rem;
-        border: 1px solid rgba(0,0,0,0.05);
-        height: 100%;
-        transition: all 0.3s ease;
-      }
-
-      .api-card:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-      }
-
-      .api-method {
-        display: inline-block;
-        padding: 0.25rem 0.75rem;
-        border-radius: 6px;
-        font-size: 0.75rem;
-        font-weight: 700;
-        margin-bottom: 0.75rem;
-      }
-
-      .api-method.get { background: rgba(16, 185, 129, 0.2); color: var(--accent); }
-      .api-method.post { background: rgba(99, 102, 241, 0.2); color: var(--primary); }
-      .api-method.put { background: rgba(249, 115, 22, 0.2); color: #f97316; }
-      .api-method.delete { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
-
-      .api-endpoint { font-family: 'Monaco', monospace; font-size: 0.875rem; color: var(--dark); margin-bottom: 0.5rem; font-weight: 600; }
-      .api-desc { color: var(--gray); font-size: 0.85rem; margin: 0; }
-
-      /* CTA Section */
-      .cta-section {
-        padding: 6rem 0;
-        background: var(--gradient-dark);
-        text-align: center;
-      }
-
-      .cta-section h2 { font-size: 2.5rem; font-weight: 800; color: var(--white); margin-bottom: 1rem; }
-      .cta-section p { font-size: 1.125rem; color: rgba(255,255,255,0.7); margin-bottom: 2rem; max-width: 600px; margin-left: auto; margin-right: auto; }
-
-      /* Footer */
-      .footer {
-        background: var(--dark);
-        padding: 4rem 0 2rem;
-        color: rgba(255,255,255,0.7);
-      }
-
-      .footer h5 { color: var(--white); font-weight: 700; margin-bottom: 1.5rem; }
-      .footer ul { list-style: none; padding: 0; }
-      .footer ul li { margin-bottom: 0.75rem; }
-      .footer a { color: rgba(255,255,255,0.6); text-decoration: none; transition: color 0.3s ease; }
-      .footer a:hover { color: var(--white); }
-      .footer-bottom { border-top: 1px solid rgba(255,255,255,0.1); padding-top: 2rem; margin-top: 3rem; text-align: center; }
-      .footer-logo { font-size: 1.5rem; font-weight: 800; margin-bottom: 1rem; }
-      .footer-logo span { background: var(--gradient); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
-
-      .social-links { display: flex; gap: 1rem; margin-top: 1rem; }
-      .social-links a {
-        width: 40px; height: 40px;
-        border-radius: 50%;
-        background: rgba(255,255,255,0.1);
-        display: flex; align-items: center; justify-content: center;
-        color: var(--white);
-        transition: all 0.3s ease;
-      }
-      .social-links a:hover { background: var(--primary); transform: translateY(-3px); }
-
-      /* Responsive */
-      @media (max-width: 768px) {
-        .hero h1 { font-size: 2.5rem; }
-        .hero-stats { gap: 1.5rem; }
-        .stat-number { font-size: 1.75rem; }
-        .section-title { font-size: 2rem; }
-        .flow-diagram { flex-direction: column; gap: 0.5rem; }
-        .flow-arrow { transform: rotate(90deg); padding: 0.25rem 0; }
-      }
-    </style>
-  </head>
-  <body>
-    <!-- Navbar -->
-    <nav class="navbar-custom">
-      <div class="container d-flex justify-content-between align-items-center">
-        <a class="navbar-brand" href="#">
-          <i class="fas fa-cube"></i>
-          <span>WSL Proxy</span>
-        </a>
-        <div class="d-flex align-items-center">
-          <a class="nav-link-custom d-none d-md-inline" href="#features">Features</a>
-          <a class="nav-link-custom d-none d-md-inline" href="#ai-gateway">AI Gateway</a>
-          <a class="nav-link-custom d-none d-md-inline" href="#flow">Architecture</a>
-          <a class="nav-link-custom d-none d-md-inline" href="#api">API</a>
-          <a class="nav-link-custom d-none d-md-inline" href="https://github.com/bwalia/wslproxy" target="_blank">Docs</a>
-          <a class="btn-nav" href="https://github.com/bwalia/wslproxy" target="_blank">
-            <i class="fab fa-github"></i> GitHub
-          </a>
-        </div>
-      </div>
-    </nav>
-
-    <!-- Hero Section -->
-    <section class="hero">
-      <div class="hero-glow"></div>
-      <div class="hero-glow-2"></div>
-      <div class="container">
-        <div class="row align-items-center">
-          <div class="col-lg-6 hero-content">
-            <div class="hero-badge">
-              <i class="fas fa-bolt"></i>
-              <span>OpenResty + Lua Powered Edge Computing</span>
-            </div>
-            <h1>Build Your Own <span class="gradient-text">Enterprise AI Gateways, CDN</span> and much more.</h1>
-            <p class="hero-description">
-              WSL Proxy is a high-performance reverse proxy, load balancer, and edge computing platform. 
-              Deploy globally with multi-region failover, edge caching, WAF protection, and API gateway capabilities.
-            </p>
-            <div class="hero-buttons">
-              <a href="https://github.com/bwalia/wslproxy" class="btn-primary-custom" target="_blank">
-                <i class="fas fa-rocket"></i> Get Started
-              </a>
-              <a href="https://github.com/bwalia/wslproxy" class="btn-secondary-custom" target="_blank">
-                <i class="fab fa-github"></i> View on GitHub
-              </a>
-            </div>
-            <div class="hero-stats">
-              <div class="stat-item">
-                <div class="stat-number">&lt;10ms</div>
-                <div class="stat-label">Latency</div>
-              </div>
-              <div class="stat-item">
-                <div class="stat-number">99.99%</div>
-                <div class="stat-label">Uptime</div>
-              </div>
-              <div class="stat-item">
-                <div class="stat-number">100K+</div>
-                <div class="stat-label">RPS</div>
-              </div>
-              <div class="stat-item">
-                <div class="stat-number">50+</div>
-                <div class="stat-label">Edge Locations</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-lg-6 d-none d-lg-block">
-            <div class="terminal-window">
-              <div class="terminal-header">
-                <span class="terminal-dot red"></span>
-                <span class="terminal-dot yellow"></span>
-                <span class="terminal-dot green"></span>
-              </div>
-              <div class="terminal-body">
-                <div class="terminal-line">
-                  <span class="terminal-prompt">$</span>
-                  <span class="terminal-command">docker pull bwalia/wslproxy:latest</span>
-                </div>
-                <div class="terminal-output">Pulling from bwalia/wslproxy...</div>
-                <div class="terminal-output">Status: Downloaded newer image</div>
-                <div class="terminal-line">
-                  <span class="terminal-prompt">$</span>
-                  <span class="terminal-command">docker-compose up -d</span>
-                </div>
-                <div class="terminal-output">Creating wslproxy_redis_1 ... done</div>
-                <div class="terminal-output">Creating wslproxy_openresty_1 ... done</div>
-                <div class="terminal-line">
-                  <span class="terminal-prompt">$</span>
-                  <span class="terminal-command">curl https://your-domain.com/api/health</span>
-                </div>
-                <div class="terminal-output" style="color: #10b981;">{"status":"healthy","version":"2.0"}</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Features Section -->
-    <section class="features" id="features">
-      <div class="container">
-        <div class="text-center mb-5">
-          <span class="section-badge"><i class="fas fa-sparkles"></i> Features</span>
-          <h2 class="section-title">Everything You Need for Edge Computing</h2>
-          <p class="section-description">
-            From load balancing to WAF protection, WSL Proxy provides enterprise-grade features for building your own CDN.
+  <main>
+    <section class="hero" aria-label="Introduction">
+      <div class="wrap hero-grid">
+        <div class="hero-copy">
+          <h1>WSLProxy</h1>
+          <p class="hero-lede">
+            Live-config API gateway on OpenResty. Change rules, WAF, and traffic splits without reloading nginx — drive it from UI, REST, MCP, or CLI.
           </p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="https://github.com/bwalia/wslproxy#quick-start">Get started</a>
+            <a class="btn btn-ghost" href="/swagger/">Open API docs</a>
+          </div>
         </div>
-        <div class="row g-4">
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon blue"><i class="fas fa-balance-scale"></i></div>
-              <h4>Load Balancing</h4>
-              <p>Distribute traffic across multiple backends with round-robin, least connections, or IP hash algorithms.</p>
+
+        <div class="path-stage" aria-hidden="true">
+          <div class="path-label">Request path · live evaluation</div>
+          <svg class="path-svg" viewBox="0 0 960 88" role="img">
+            <title>Client to origin through SSL, WAF, rules, and balancer</title>
+            <path class="path-wire" d="M40 44 H920" />
+            <path class="path-wire-live" d="M40 44 H920" />
+            <circle class="path-node" cx="40" cy="44" r="8" />
+            <circle class="path-node path-node-active" cx="220" cy="44" r="8" />
+            <circle class="path-node path-node-active" cx="400" cy="44" r="8" />
+            <circle class="path-node path-node-active" cx="580" cy="44" r="8" />
+            <circle class="path-node path-node-active" cx="760" cy="44" r="8" />
+            <circle class="path-node" cx="920" cy="44" r="8" />
+            <text class="path-text" x="40" y="74" text-anchor="middle">Client</text>
+            <text class="path-text" x="220" y="74" text-anchor="middle">TLS</text>
+            <text class="path-text" x="400" y="74" text-anchor="middle">WAF</text>
+            <text class="path-text" x="580" y="74" text-anchor="middle">Rules</text>
+            <text class="path-text" x="760" y="74" text-anchor="middle">Balancer</text>
+            <text class="path-text" x="920" y="74" text-anchor="middle">Origin</text>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <section id="pipeline">
+      <div class="wrap">
+        <p class="section-kicker">How traffic moves</p>
+        <h2 class="section-title">Match once. Decide per request.</h2>
+        <p class="section-lede">
+          OpenResty loads server and rule JSON on the hot path. Only server-block nginx changes need a reload flag — rules and WAF stay live.
+        </p>
+        <div class="flow-steps">
+          <div class="flow-step">
+            <code>rewrite</code>
+            <div>
+              <strong>gateway_ack</strong>
+              <p>Load host config, score candidate rules (path, IP, country, JWT…), run rate limit and WAF, stash the winner.</p>
             </div>
           </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon green"><i class="fas fa-globe"></i></div>
-              <h4>Multi-Region Failover</h4>
-              <p>Automatic failover to healthy regions with configurable health checks and priority routing.</p>
+          <div class="flow-step">
+            <code>access</code>
+            <div>
+              <strong>gateway_resp</strong>
+              <p>Honor response code: proxy (305), redirect, HTML block, CAPTCHA (306), or 403 — then resolve backend and timeouts.</p>
             </div>
           </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon purple"><i class="fas fa-bolt"></i></div>
-              <h4>Edge Caching</h4>
-              <p>Cache responses at the edge with fine-grained TTL control and instant cache invalidation via API.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon orange"><i class="fas fa-shield-alt"></i></div>
-              <h4>WAF Protection</h4>
-              <p>Content-based WAF rules with SQL injection mitigation, XSS protection, and custom rule sets.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon cyan"><i class="fas fa-lock"></i></div>
-              <h4>SSL/TLS Termination</h4>
-              <p>Automatic certificate management with Let's Encrypt integration and cloud certificate pipelines.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon red"><i class="fas fa-key"></i></div>
-              <h4>Edge Authorization</h4>
-              <p>JWT validation, API key management, and OAuth2 integration at the edge.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon pink"><i class="fas fa-chart-line"></i></div>
-              <h4>Observability</h4>
-              <p>Prometheus metrics, structured logging, and distributed tracing for full visibility.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon yellow"><i class="fas fa-map-marker-alt"></i></div>
-              <h4>Geo Traffic Rules</h4>
-              <p>Route traffic by country or continent with IP2Location integration.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon indigo"><i class="fas fa-code-branch"></i></div>
-              <h4>GitOps Ready</h4>
-              <p>Declarative configuration with Helm charts and GitHub Actions CI/CD integration.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon blue"><i class="fas fa-tachometer-alt"></i></div>
-              <h4>Monitoring Integration</h4>
-              <p>Native integration with Prometheus, Grafana, Loki, Mimir, Alertmanager, ELK Stack, Dynatrace, and Datadog.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon teal"><i class="fas fa-sliders-h"></i></div>
-              <h4>Web UI Control Plane</h4>
-              <p>Fully-featured Web UI Administrator to manage entire cluster configuration from a single place securely.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon purple"><i class="fas fa-robot"></i></div>
-              <h4>AI Gateway (OpenAI-Compatible)</h4>
-              <p>Front Anthropic, OpenAI, or self-hosted models behind one OpenAI-compatible endpoint — with live SSE token streaming, per-route API keys, rate limits, and metrics. <a href="#ai-gateway">Learn more →</a></p>
+          <div class="flow-step">
+            <code>balancer</code>
+            <div>
+              <strong>Peer + timeouts</strong>
+              <p>Weighted, canary, sticky, or least-conn selection with per-server connect/send/read timeouts.</p>
             </div>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- AI Gateway Section -->
-    <section class="features" id="ai-gateway" style="background: var(--light);">
-      <div class="container">
-        <div class="text-center mb-5">
-          <span class="section-badge"><i class="fas fa-robot"></i> New &middot; AI Gateway</span>
-          <h2 class="section-title">OpenAI-Compatible Edge for LLMs</h2>
-          <p class="section-description">
-            Put one secure, observable gateway in front of every model provider. Your apps speak the
-            standard OpenAI API; WSL Proxy translates, routes, secures, and meters the traffic —
-            Anthropic, OpenAI, or self-hosted Ollama behind a single endpoint.
-          </p>
-        </div>
-
-        <div class="row g-4 align-items-stretch mb-4">
-          <div class="col-lg-6">
-            <div class="feature-card" style="height: 100%;">
-              <div class="feature-icon purple"><i class="fas fa-language"></i></div>
-              <h4>What it is</h4>
-              <p>
-                A protocol-translating LLM gateway built into the proxy. Clients call the familiar
-                <strong>OpenAI Chat Completions</strong> API; WSL Proxy rewrites each request into the
-                target provider's native API (e.g. <strong>Anthropic Messages</strong>) and converts the
-                reply back — including <strong>live token streaming (SSE)</strong> — so you never rewrite
-                application code to switch or mix providers.
-              </p>
+    <section id="capabilities" style="background: #fff; border-block: 1px solid var(--line);">
+      <div class="wrap">
+        <p class="section-kicker">Platform</p>
+        <h2 class="section-title">Built for real edge ops</h2>
+        <p class="section-lede">Not a brochure CDN — a control plane you run on your POPs, VMs, or k3s.</p>
+        <div class="split split-2">
+          <div>
+            <div class="strip">
+              <h3>Dynamic routing</h3>
+              <p>Priority-aware rules with geo, IP, JWT, and path matching. Attach many rules per virtual host.</p>
+            </div>
+            <div class="strip">
+              <h3>WAF policy packs</h3>
+              <p>Detection rules, anomaly scoring, monitor or block modes, and an events API — including the v2 engine.</p>
+            </div>
+            <div class="strip">
+              <h3>Traffic engineering</h3>
+              <p>Canary weights, promote/rollback, topology views, and passive/active upstream health.</p>
             </div>
           </div>
-          <div class="col-lg-6">
-            <div class="feature-card" style="height: 100%;">
-              <div class="feature-icon green"><i class="fas fa-terminal"></i></div>
-              <h4>One endpoint, any model</h4>
-              <p>Path-based rules route each call to the right backend, each with its own keys, rate limits, and WAF:</p>
-              <pre style="background: var(--dark); color: #e2e8f0; padding: 1rem 1.25rem; border-radius: 12px; font-size: 0.85rem; line-height: 1.7; overflow-x: auto; margin: 0;"><code>POST /api/claude  &rarr; api.anthropic.com   <span style="color:#10b981;"># OpenAI &harr; Anthropic</span>
-POST /api/openai  &rarr; api.openai.com
-POST /api/llm     &rarr; ollama            <span style="color:#10b981;"># self-hosted</span></code></pre>
+          <div>
+            <div class="strip">
+              <h3>Multi-POP + DNS</h3>
+              <p>Declare edge locations and provision Cloudflare A records with guardrails so unmanaged DNS stays untouched.</p>
             </div>
-          </div>
-        </div>
-
-        <div class="text-center mb-4">
-          <h3 style="font-size: 1.4rem; font-weight: 700; color: var(--dark);">Use Cases &amp; Benefits</h3>
-        </div>
-        <div class="row g-4">
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon blue"><i class="fas fa-cubes"></i></div>
-              <h4>Vendor-neutral apps</h4>
-              <p>Write once to the OpenAI API and swap or blend Claude, GPT, and local models by configuration — no SDK changes, no lock-in.</p>
+            <div class="strip">
+              <h3>SSL &amp; cache</h3>
+              <p>auto-ssl / Let’s Encrypt, force HTTPS, edge static cache, optional Varnish and Docker blob cache.</p>
             </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon red"><i class="fas fa-user-shield"></i></div>
-              <h4>Govern &amp; secure centrally</h4>
-              <p>Provider keys never touch client apps. Enforce JWT / API-key auth, WAF, and rate limits at the edge — per route, per team.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon orange"><i class="fas fa-route"></i></div>
-              <h4>Control cost &amp; latency</h4>
-              <p>Route by model, weight, or canary; fail over between providers; send cheap/private work to self-hosted models and hard tasks to frontier models.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon pink"><i class="fas fa-chart-line"></i></div>
-              <h4>Observability &amp; spend</h4>
-              <p>Every prompt and response flows through one place — Prometheus metrics, audit logs, and per-model traffic stats for usage and cost visibility.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon cyan"><i class="fas fa-bolt"></i></div>
-              <h4>Streaming-native</h4>
-              <p>Server-Sent Event token streams are translated chunk-by-chunk, so chat UIs stay real-time and responsive across providers.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon green"><i class="fas fa-plug"></i></div>
-              <h4>Drop-in migration</h4>
-              <p>Point your existing OpenAI base URL at the gateway. No payload rewrites — start mixing providers without touching client code.</p>
+            <div class="strip">
+              <h3>Two-layer ingress</h3>
+              <p>Outer POP plus optional k3s <code>wslproxy-ingress</code> Helm chart — tune timeouts on both layers.</p>
             </div>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- Request Flow Section -->
-    <section class="flow-section" id="flow">
-      <div class="container">
-        <div class="text-center mb-5">
-          <span class="section-badge" style="background: rgba(255,255,255,0.1); color: var(--white);">
-            <i class="fas fa-project-diagram"></i> Architecture
-          </span>
-          <h2 class="section-title" style="color: var(--white);">Request Flow</h2>
-          <p class="section-description" style="color: rgba(255,255,255,0.7);">
-            Every request flows through our optimized edge pipeline for maximum performance and security.
-          </p>
+    <section class="band" id="operate">
+      <div class="wrap split split-aside">
+        <div>
+          <p class="section-kicker">Control plane</p>
+          <h2 class="section-title">UI, API, agents, and pipelines</h2>
+          <p class="section-lede">Same surface whether a human clicks, a script runs, or Cursor calls MCP.</p>
+          <ul class="ops-list">
+            <li>
+              <strong>Admin UI</strong>
+              <span>React Admin for day-to-day CRUD; Next.js dashboard for logs and AI-assisted analysis.</span>
+            </li>
+            <li>
+              <strong>REST + Swagger</strong>
+              <span>Full CRUD for servers, rules, WAF, traffic, cache — JWT auth like the UI.</span>
+            </li>
+            <li>
+              <strong>MCP</strong>
+              <span>Resources and tools for Claude / Cursor: validate_config, CRUD, traffic, POPs/DNS.</span>
+            </li>
+            <li>
+              <strong>wslproxy-cli</strong>
+              <span>Pull → edit → push JSON; check nginx/health; ship via <code>ghcr.io/bwalia/wslproxy-cli</code>.</span>
+            </li>
+          </ul>
         </div>
-        <div class="flow-diagram">
-          <div class="flow-node info"><i class="fas fa-user"></i><span>Client</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node"><i class="fas fa-network-wired"></i><span>DNS</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node success"><i class="fas fa-lock"></i><span>SSL/TLS</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node warning"><i class="fas fa-shield-alt"></i><span>WAF</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node primary"><i class="fas fa-key"></i><span>Auth</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node"><i class="fas fa-database"></i><span>Cache</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node info"><i class="fas fa-balance-scale"></i><span>LB</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node success"><i class="fas fa-server"></i><span>Origin</span></div>
-        </div>
-      </div>
-    </section>
-
-    <!-- API Section -->
-    <section class="api-section" id="api">
-      <div class="container">
-        <div class="text-center mb-5">
-          <span class="section-badge"><i class="fas fa-code"></i> API-Driven</span>
-          <h2 class="section-title">RESTful Configuration API</h2>
-          <p class="section-description">
-            Manage your entire edge infrastructure through our comprehensive REST API.
-          </p>
-        </div>
-        <div class="row g-4">
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method get">GET</span>
-              <div class="api-endpoint">/api/servers</div>
-              <p class="api-desc">List all configured backend servers</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method post">POST</span>
-              <div class="api-endpoint">/api/servers</div>
-              <p class="api-desc">Create a new server configuration</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method get">GET</span>
-              <div class="api-endpoint">/api/rules</div>
-              <p class="api-desc">List all routing and WAF rules</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method post">POST</span>
-              <div class="api-endpoint">/api/cache/purge</div>
-              <p class="api-desc">Purge cached content by pattern</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method get">GET</span>
-              <div class="api-endpoint">/metrics</div>
-              <p class="api-desc">Prometheus-compatible metrics</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method get">GET</span>
-              <div class="api-endpoint">/api/health</div>
-              <p class="api-desc">Health check endpoint</p>
-            </div>
+        <div>
+          <div class="code-panel" aria-label="Example CI command">
+            <div><span class="cmt"># GitHub Actions / GitLab CI</span></div>
+            <div><span class="cmd">docker run --rm \</span></div>
+            <div>&nbsp;&nbsp;-e WSLPROXY_BASE_URL \</div>
+            <div>&nbsp;&nbsp;-e WSLPROXY_TOKEN \</div>
+            <div>&nbsp;&nbsp;ghcr.io/bwalia/wslproxy-cli:latest \</div>
+            <div>&nbsp;&nbsp;check nginx -o json</div>
+            <div style="margin-top:0.85rem"><span class="cmt"># Config as files</span></div>
+            <div>wslproxy-cli pull -d ./cfg --resources servers,rules,waf</div>
+            <div>wslproxy-cli push -d ./cfg --yes --verify</div>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- CTA Section -->
-    <section class="cta-section">
-      <div class="container">
-        <h2>Ready to Build Your Own AI Gateway &amp; CDN?</h2>
-        <p>Get started with WSL Proxy in minutes. Deploy on Docker, Kubernetes, or bare metal.</p>
-        <div class="d-flex justify-content-center gap-3 flex-wrap">
-          <a href="https://github.com/bwalia/wslproxy" class="btn-primary-custom" target="_blank">
-            <i class="fas fa-rocket"></i> Get Started
-          </a>
-          <a href="https://github.com/bwalia/wslproxy/issues" class="btn-secondary-custom" target="_blank">
-            <i class="fas fa-comments"></i> Join Community
-          </a>
+    <section id="start">
+      <div class="wrap">
+        <p class="section-kicker">Get going</p>
+        <h2 class="section-title">Three ways in</h2>
+        <div class="start-grid">
+          <article class="start-item">
+            <h3>Local Docker</h3>
+            <p><code>./dev.sh</code> brings up OpenResty, Redis, and the admin UI with hot-reload for Lua.</p>
+            <a href="https://github.com/bwalia/wslproxy#quick-start">Dev quick start →</a>
+          </article>
+          <article class="start-item">
+            <h3>Ansible / Helm</h3>
+            <p>Bare-metal POPs via Ansible; k3s ingress via the Helm chart under <code>ingress-controller/</code>.</p>
+            <a href="https://github.com/bwalia/wslproxy/tree/main/infra/ansible">Ansible role →</a>
+          </article>
+          <article class="start-item">
+            <h3>Docs &amp; demos</h3>
+            <p>WAF demo packs, MCP guides, CLI examples, and architecture diagrams in the repo.</p>
+            <a href="https://github.com/bwalia/wslproxy/tree/main/docs">Browse docs →</a>
+          </article>
         </div>
       </div>
     </section>
 
-    <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="row">
-          <div class="col-lg-4 mb-4 mb-lg-0">
-            <div class="footer-logo"><i class="fas fa-cube"></i> <span>WSL Proxy</span></div>
-            <p>Enterprise-grade reverse proxy, load balancer, and edge computing platform.</p>
-            <div class="social-links">
-              <a href="https://github.com/bwalia/wslproxy" target="_blank"><i class="fab fa-github"></i></a>
-              <a href="#"><i class="fab fa-slack"></i></a>
-              <a href="#"><i class="fab fa-twitter"></i></a>
-              <a href="#"><i class="fab fa-linkedin"></i></a>
-            </div>
-          </div>
-          <div class="col-6 col-lg-2">
-            <h5>Product</h5>
-            <ul>
-              <li><a href="#features">Features</a></li>
-              <li><a href="#ai-gateway">AI Gateway</a></li>
-              <li><a href="#flow">Architecture</a></li>
-              <li><a href="#api">API</a></li>
-              <li><a href="https://github.com/bwalia/wslproxy">Documentation</a></li>
-            </ul>
-          </div>
-          <div class="col-6 col-lg-2">
-            <h5>Resources</h5>
-            <ul>
-              <li><a href="https://github.com/bwalia/wslproxy">GitHub</a></li>
-              <li><a href="https://github.com/bwalia/wslproxy/issues">Issues</a></li>
-              <li><a href="https://github.com/bwalia/wslproxy/releases">Releases</a></li>
-              <li><a href="https://hub.docker.com/r/bwalia/wslproxy">Docker Hub</a></li>
-            </ul>
-          </div>
-          <div class="col-6 col-lg-2">
-            <h5>Company</h5>
-            <ul>
-              <li><a href="#">About</a></li>
-              <li><a href="#">Blog</a></li>
-              <li><a href="#">Careers</a></li>
-              <li><a href="#">Contact</a></li>
-            </ul>
-          </div>
-          <div class="col-6 col-lg-2">
-            <h5>Legal</h5>
-            <ul>
-              <li><a href="#">Privacy</a></li>
-              <li><a href="#">Terms</a></li>
-              <li><a href="https://github.com/bwalia/wslproxy/blob/main/LICENSE">License</a></li>
-            </ul>
-          </div>
-        </div>
-        <div class="footer-bottom">
-          <p>&copy; 2025 Workstation Solutions Limited. Open Source under MIT License.</p>
+    <section class="cta-final">
+      <div class="wrap">
+        <h2>Own the edge you run.</h2>
+        <p>Open source gateway, real POPs, agent-ready control plane — start from the repo and ship config like code.</p>
+        <div class="cta-row" style="justify-content:center">
+          <a class="btn btn-primary" href="https://github.com/bwalia/wslproxy">View on GitHub</a>
+          <a class="btn btn-ghost" href="/swagger/">Swagger</a>
         </div>
       </div>
-    </footer>
+    </section>
+  </main>
 
-    <!-- Bootstrap JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  </body>
+  <footer>
+    <div class="wrap footer-inner">
+      <div>© Workstation Solutions Limited · WSLProxy</div>
+      <div class="footer-links">
+        <a href="https://github.com/bwalia/wslproxy">GitHub</a>
+        <a href="/swagger/">API</a>
+        <a href="https://github.com/bwalia/wslproxy/blob/main/docs/wslproxy-cli.md">CLI</a>
+        <a href="https://github.com/bwalia/wslproxy/blob/main/docs/mcp.md">MCP</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var btn = document.getElementById("nav-toggle");
+      var menu = document.getElementById("nav-menu");
+      if (!btn || !menu) return;
+      btn.addEventListener("click", function () {
+        var open = menu.classList.toggle("open");
+        btn.setAttribute("aria-expanded", open ? "true" : "false");
+      });
+    })();
+  </script>
+</body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -1,822 +1,645 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="WSL Proxy - Enterprise-grade reverse proxy, load balancer, and edge computing platform. Build your own CDN with multi-region failover, edge caching, and WAF protection." />
-    <meta name="keywords" content="CDN, reverse proxy, load balancer, edge computing, WAF, SSL, cache, API gateway, OpenResty, Lua, nginx" />
-    <meta name="author" content="Workstation Solutions Limited" />
-    <meta property="og:title" content="WSL Proxy - Build Your Own CDN" />
-    <meta property="og:description" content="Enterprise-grade reverse proxy, load balancer, and edge computing platform with multi-region failover, edge caching, and WAF protection." />
-    <meta property="og:type" content="website" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="WSL Proxy - Build Your Own CDN" />
-    <meta name="twitter:description" content="Enterprise-grade reverse proxy and edge computing platform" />
-    <title>WSL Proxy - Build Your Own CDN | Enterprise Edge Platform</title>
-    
-    <!-- CDN Dependencies for GitHub Pages -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet" />
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" />
-    
-    <style>
-      :root {
-        --primary: #6366f1;
-        --primary-dark: #4f46e5;
-        --secondary: #0ea5e9;
-        --accent: #10b981;
-        --dark: #0f172a;
-        --dark-light: #1e293b;
-        --gray: #64748b;
-        --light: #f8fafc;
-        --white: #ffffff;
-        --gradient: linear-gradient(135deg, #6366f1 0%, #0ea5e9 50%, #10b981 100%);
-        --gradient-dark: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="WSLProxy — dynamic API gateway and reverse proxy on OpenResty. Live rules, WAF, multi-POP edge, MCP for AI agents, and a CLI for GitOps." />
+  <meta name="author" content="Workstation Solutions Limited" />
+  <meta property="og:title" content="WSLProxy — Live-config API gateway" />
+  <meta property="og:description" content="Route, secure, and observe traffic from JSON and MCP — without reloading nginx for every rule change." />
+  <meta property="og:type" content="website" />
+  <title>WSLProxy — Live-config API gateway &amp; edge control plane</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --ink: #0b1c2c;
+      --ink-soft: #243447;
+      --steel: #3d5a80;
+      --mist: #eef2f6;
+      --paper: #f7f9fc;
+      --line: #c5d0dc;
+      --copper: #c45c26;
+      --copper-deep: #9a4519;
+      --signal: #1a7a6d;
+      --mono: "JetBrains Mono", ui-monospace, monospace;
+      --sans: "Outfit", system-ui, sans-serif;
+      --display: "Fraunces", Georgia, serif;
+      --radius: 6px;
+      --max: 1120px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
       }
+    }
 
-      * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: var(--sans);
+      font-size: 1.0625rem;
+      line-height: 1.55;
+      color: var(--ink);
+      background: var(--paper);
+    }
 
-      body {
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
-        color: var(--dark);
-        line-height: 1.6;
-        overflow-x: hidden;
-      }
+    a { color: var(--copper-deep); }
+    a:focus-visible { outline: 2px solid var(--copper); outline-offset: 3px; }
 
-      /* Navbar */
-      .navbar-custom {
-        background: rgba(15, 23, 42, 0.95);
-        backdrop-filter: blur(20px);
-        padding: 1rem 0;
-        position: fixed;
-        width: 100%;
-        top: 0;
-        z-index: 1000;
-        border-bottom: 1px solid rgba(255,255,255,0.1);
-        transition: all 0.3s ease;
-      }
+    .wrap {
+      width: min(100% - 2.5rem, var(--max));
+      margin-inline: auto;
+    }
 
-      .navbar-brand {
-        font-size: 1.5rem;
-        font-weight: 800;
-        color: var(--white) !important;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        text-decoration: none;
-      }
-
-      .navbar-brand span {
-        background: var(--gradient);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-      }
-
-      .nav-link-custom {
-        color: rgba(255,255,255,0.8) !important;
-        font-weight: 500;
-        padding: 0.5rem 1rem !important;
-        transition: all 0.3s ease;
-        text-decoration: none;
-      }
-
-      .nav-link-custom:hover { color: var(--white) !important; }
-
-      .btn-nav {
-        background: var(--gradient);
-        color: var(--white) !important;
-        padding: 0.6rem 1.5rem !important;
-        border-radius: 8px;
-        font-weight: 600;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        margin-left: 1rem;
-        border: none;
-      }
-
-      .btn-nav:hover {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 40px rgba(99, 102, 241, 0.4);
-      }
-
-      /* Hero Section */
-      .hero {
-        min-height: 100vh;
-        background: var(--gradient-dark);
-        position: relative;
-        display: flex;
-        align-items: center;
-        overflow: hidden;
-        padding-top: 80px;
-      }
-
-      .hero::before {
-        content: '';
+    /* —— Nav —— */
+    .nav {
+      position: sticky;
+      top: 0;
+      z-index: 40;
+      background: color-mix(in srgb, var(--paper) 88%, transparent);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--line);
+    }
+    .nav-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 0.85rem 0;
+    }
+    .brand {
+      font-family: var(--display);
+      font-weight: 700;
+      font-size: 1.35rem;
+      color: var(--ink);
+      text-decoration: none;
+      letter-spacing: -0.02em;
+    }
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 1.25rem;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    .nav-links a {
+      color: var(--ink-soft);
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 0.95rem;
+    }
+    .nav-links a:hover { color: var(--ink); }
+    .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.45rem 0.95rem;
+      background: var(--ink);
+      color: var(--paper) !important;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 0.9rem;
+      border-radius: var(--radius);
+    }
+    .nav-cta:hover { background: var(--ink-soft); }
+    .nav-toggle {
+      display: none;
+      background: none;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      padding: 0.35rem 0.6rem;
+      font: inherit;
+      cursor: pointer;
+    }
+    @media (max-width: 760px) {
+      .nav-toggle { display: block; }
+      .nav-links {
+        display: none;
         position: absolute;
-        top: 0; left: 0; right: 0; bottom: 0;
-        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><defs><pattern id="grid" width="10" height="10" patternUnits="userSpaceOnUse"><path d="M 10 0 L 0 0 0 10" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/></pattern></defs><rect width="100" height="100" fill="url(%23grid)"/></svg>');
-        pointer-events: none;
+        left: 0; right: 0;
+        top: 100%;
+        flex-direction: column;
+        align-items: stretch;
+        background: var(--paper);
+        border-bottom: 1px solid var(--line);
+        padding: 1rem 1.25rem 1.25rem;
+        gap: 0.75rem;
       }
+      .nav-links.open { display: flex; }
+    }
 
-      .hero-glow {
-        position: absolute;
-        width: 600px; height: 600px;
-        background: radial-gradient(circle, rgba(99, 102, 241, 0.3) 0%, transparent 70%);
-        top: -200px; right: -100px;
-        pointer-events: none;
-      }
+    /* —— Hero —— */
+    .hero {
+      position: relative;
+      min-height: min(100vh, 820px);
+      display: grid;
+      align-items: end;
+      padding: 4.5rem 0 3.5rem;
+      overflow: hidden;
+      background:
+        radial-gradient(1200px 500px at 70% -10%, color-mix(in srgb, var(--steel) 18%, transparent), transparent 60%),
+        linear-gradient(165deg, var(--mist) 0%, var(--paper) 45%, #e4ebe7 100%);
+    }
+    .hero::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(var(--line) 1px, transparent 1px),
+        linear-gradient(90deg, var(--line) 1px, transparent 1px);
+      background-size: 48px 48px;
+      opacity: 0.35;
+      mask-image: linear-gradient(180deg, #000 20%, transparent 85%);
+      pointer-events: none;
+    }
+    .hero-grid {
+      position: relative;
+      display: grid;
+      gap: 2.5rem;
+    }
+    .hero-copy { max-width: 36rem; }
+    .hero h1 {
+      font-family: var(--display);
+      font-weight: 700;
+      font-size: clamp(2.6rem, 6vw, 4.1rem);
+      line-height: 1.05;
+      letter-spacing: -0.03em;
+      margin: 0 0 1rem;
+      color: var(--ink);
+    }
+    .hero-lede {
+      margin: 0 0 1.75rem;
+      font-size: 1.15rem;
+      color: var(--ink-soft);
+      max-width: 32rem;
+    }
+    .cta-row { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.85rem 1.25rem;
+      border-radius: var(--radius);
+      font-weight: 600;
+      font-size: 0.98rem;
+      text-decoration: none;
+      border: 1px solid transparent;
+      transition: transform 0.2s ease, background 0.2s ease;
+    }
+    .btn:hover { transform: translateY(-1px); }
+    .btn-primary {
+      background: var(--copper);
+      color: #fff;
+    }
+    .btn-primary:hover { background: var(--copper-deep); color: #fff; }
+    .btn-ghost {
+      background: transparent;
+      border-color: var(--line);
+      color: var(--ink);
+    }
+    .btn-ghost:hover { border-color: var(--ink-soft); }
 
-      .hero-glow-2 {
-        position: absolute;
-        width: 400px; height: 400px;
-        background: radial-gradient(circle, rgba(14, 165, 233, 0.2) 0%, transparent 70%);
-        bottom: -100px; left: -100px;
-        pointer-events: none;
-      }
+    /* Request path visual — signature */
+    .path-stage {
+      position: relative;
+      margin-top: 0.5rem;
+      padding: 1.5rem 0 0.25rem;
+    }
+    .path-label {
+      font-family: var(--mono);
+      font-size: 0.72rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--steel);
+      margin-bottom: 0.75rem;
+    }
+    .path-svg {
+      width: 100%;
+      height: auto;
+      display: block;
+      overflow: visible;
+    }
+    .path-wire {
+      fill: none;
+      stroke: var(--line);
+      stroke-width: 3;
+    }
+    .path-wire-live {
+      fill: none;
+      stroke: var(--signal);
+      stroke-width: 3;
+      stroke-dasharray: 12 220;
+      animation: packet 3.2s linear infinite;
+    }
+    @keyframes packet {
+      to { stroke-dashoffset: -232; }
+    }
+    .path-node {
+      fill: var(--paper);
+      stroke: var(--ink);
+      stroke-width: 2;
+    }
+    .path-node-active { stroke: var(--copper); }
+    .path-text {
+      font-family: var(--mono);
+      font-size: 11px;
+      fill: var(--ink-soft);
+    }
 
-      .hero-content { position: relative; z-index: 2; }
+    /* —— Sections —— */
+    section { padding: 4.5rem 0; }
+    .section-kicker {
+      font-family: var(--mono);
+      font-size: 0.75rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--steel);
+      margin: 0 0 0.75rem;
+    }
+    .section-title {
+      font-family: var(--display);
+      font-size: clamp(1.75rem, 3.5vw, 2.4rem);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+      margin: 0 0 0.75rem;
+      max-width: 22ch;
+    }
+    .section-lede {
+      margin: 0 0 2rem;
+      color: var(--ink-soft);
+      max-width: 40rem;
+    }
 
-      .hero-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        background: rgba(99, 102, 241, 0.2);
-        border: 1px solid rgba(99, 102, 241, 0.3);
-        padding: 0.5rem 1rem;
-        border-radius: 50px;
-        color: var(--primary);
-        font-size: 0.875rem;
-        font-weight: 500;
-        margin-bottom: 1.5rem;
-      }
+    .split {
+      display: grid;
+      gap: 2rem;
+      grid-template-columns: 1fr;
+    }
+    @media (min-width: 860px) {
+      .split-2 { grid-template-columns: 1fr 1fr; align-items: start; }
+      .split-aside { grid-template-columns: 1.1fr 0.9fr; }
+    }
 
-      .hero h1 {
-        font-size: 3.5rem;
-        font-weight: 800;
-        color: var(--white);
-        line-height: 1.1;
-        margin-bottom: 1.5rem;
-      }
+    .strip {
+      border-top: 1px solid var(--line);
+      padding: 1.5rem 0;
+    }
+    .strip h3 {
+      font-family: var(--display);
+      font-size: 1.35rem;
+      margin: 0 0 0.4rem;
+      letter-spacing: -0.01em;
+    }
+    .strip p { margin: 0; color: var(--ink-soft); }
 
-      .hero h1 .gradient-text {
-        background: var(--gradient);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-      }
+    .band {
+      background: var(--ink);
+      color: var(--mist);
+    }
+    .band .section-kicker { color: color-mix(in srgb, var(--mist) 55%, transparent); }
+    .band .section-title { color: #fff; max-width: none; }
+    .band .section-lede { color: color-mix(in srgb, var(--mist) 75%, transparent); }
 
-      .hero-description {
-        font-size: 1.25rem;
-        color: rgba(255,255,255,0.7);
-        max-width: 600px;
-        margin-bottom: 2rem;
-      }
+    .ops-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 1rem;
+    }
+    .ops-list li {
+      border-left: 3px solid var(--copper);
+      padding: 0.35rem 0 0.35rem 1rem;
+    }
+    .ops-list strong {
+      display: block;
+      font-family: var(--display);
+      font-size: 1.15rem;
+      margin-bottom: 0.2rem;
+      color: #fff;
+    }
+    .ops-list span { color: color-mix(in srgb, var(--mist) 72%, transparent); font-size: 0.98rem; }
 
-      .hero-buttons { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .code-panel {
+      background: #07131f;
+      color: #d7e2ec;
+      border-radius: var(--radius);
+      padding: 1.15rem 1.25rem;
+      font-family: var(--mono);
+      font-size: 0.8rem;
+      line-height: 1.65;
+      overflow-x: auto;
+      border: 1px solid #1c3348;
+    }
+    .code-panel .cmt { color: #6d8499; }
+    .code-panel .cmd { color: #e8a87c; }
 
-      .btn-primary-custom {
-        background: var(--gradient);
-        color: var(--white);
-        padding: 1rem 2rem;
-        border-radius: 12px;
-        font-weight: 600;
-        font-size: 1rem;
-        border: none;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-      }
+    .flow-steps {
+      display: grid;
+      gap: 0;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      overflow: hidden;
+      background: #fff;
+    }
+    .flow-step {
+      display: grid;
+      grid-template-columns: 4.5rem 1fr;
+      gap: 1rem;
+      padding: 1.1rem 1.25rem;
+      border-bottom: 1px solid var(--line);
+    }
+    .flow-step:last-child { border-bottom: 0; }
+    .flow-step code {
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      color: var(--copper-deep);
+      align-self: start;
+      padding-top: 0.15rem;
+    }
+    .flow-step strong { display: block; margin-bottom: 0.2rem; }
+    .flow-step p { margin: 0; color: var(--ink-soft); font-size: 0.95rem; }
 
-      .btn-primary-custom:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 20px 40px rgba(99, 102, 241, 0.4);
-        color: var(--white);
-      }
+    .start-grid {
+      display: grid;
+      gap: 1.5rem;
+    }
+    @media (min-width: 720px) {
+      .start-grid { grid-template-columns: repeat(3, 1fr); }
+    }
+    .start-item h3 {
+      font-family: var(--display);
+      font-size: 1.2rem;
+      margin: 0 0 0.5rem;
+    }
+    .start-item p { margin: 0 0 0.75rem; color: var(--ink-soft); font-size: 0.95rem; }
+    .start-item a { font-weight: 600; text-decoration: none; }
+    .start-item a:hover { text-decoration: underline; }
 
-      .btn-secondary-custom {
-        background: transparent;
-        color: var(--white);
-        padding: 1rem 2rem;
-        border-radius: 12px;
-        font-weight: 600;
-        font-size: 1rem;
-        border: 2px solid rgba(255,255,255,0.2);
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-      }
+    .cta-final {
+      text-align: center;
+      padding: 5rem 0;
+      background:
+        linear-gradient(180deg, var(--paper), var(--mist));
+    }
+    .cta-final h2 {
+      font-family: var(--display);
+      font-size: clamp(1.8rem, 4vw, 2.6rem);
+      margin: 0 0 0.75rem;
+    }
+    .cta-final p {
+      margin: 0 auto 1.5rem;
+      max-width: 32rem;
+      color: var(--ink-soft);
+    }
 
-      .btn-secondary-custom:hover {
-        background: rgba(255,255,255,0.1);
-        border-color: rgba(255,255,255,0.4);
-        color: var(--white);
-      }
+    footer {
+      border-top: 1px solid var(--line);
+      padding: 2rem 0 2.5rem;
+      font-size: 0.9rem;
+      color: var(--ink-soft);
+    }
+    .footer-inner {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .footer-links { display: flex; flex-wrap: wrap; gap: 1rem; }
+    .footer-links a { color: var(--ink-soft); text-decoration: none; }
+    .footer-links a:hover { color: var(--ink); }
+  </style>
+</head>
+<body>
+  <header class="nav">
+    <div class="wrap nav-inner">
+      <a class="brand" href="/">WSLProxy</a>
+      <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="nav-menu" id="nav-toggle">Menu</button>
+      <ul class="nav-links" id="nav-menu">
+        <li><a href="#pipeline">Pipeline</a></li>
+        <li><a href="#capabilities">Capabilities</a></li>
+        <li><a href="#operate">Operate</a></li>
+        <li><a href="#start">Start</a></li>
+        <li><a class="nav-cta" href="https://github.com/bwalia/wslproxy">GitHub</a></li>
+      </ul>
+    </div>
+  </header>
 
-      .hero-stats {
-        display: flex;
-        gap: 3rem;
-        margin-top: 4rem;
-        padding-top: 2rem;
-        border-top: 1px solid rgba(255,255,255,0.1);
-        flex-wrap: wrap;
-      }
-
-      .stat-item { text-align: center; }
-
-      .stat-number {
-        font-size: 2.5rem;
-        font-weight: 800;
-        background: var(--gradient);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-      }
-
-      .stat-label { color: rgba(255,255,255,0.6); font-size: 0.875rem; }
-
-      /* Terminal */
-      .terminal-window {
-        background: var(--dark);
-        border-radius: 16px;
-        overflow: hidden;
-        box-shadow: 0 40px 80px rgba(0,0,0,0.5);
-        border: 1px solid rgba(255,255,255,0.1);
-      }
-
-      .terminal-header {
-        background: var(--dark-light);
-        padding: 1rem 1.5rem;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-      }
-
-      .terminal-dot { width: 12px; height: 12px; border-radius: 50%; }
-      .terminal-dot.red { background: #ff5f57; }
-      .terminal-dot.yellow { background: #febc2e; }
-      .terminal-dot.green { background: #28c840; }
-
-      .terminal-body {
-        padding: 1.5rem;
-        font-family: 'Monaco', 'Menlo', monospace;
-        font-size: 0.8rem;
-        color: rgba(255,255,255,0.8);
-        min-height: 280px;
-      }
-
-      .terminal-line { margin-bottom: 0.5rem; display: flex; gap: 0.5rem; }
-      .terminal-prompt { color: var(--accent); }
-      .terminal-command { color: var(--secondary); }
-      .terminal-output { color: rgba(255,255,255,0.6); padding-left: 1rem; }
-
-      /* Features Section */
-      .features { padding: 6rem 0; background: var(--light); }
-
-      .section-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        background: rgba(99, 102, 241, 0.1);
-        padding: 0.5rem 1rem;
-        border-radius: 50px;
-        color: var(--primary);
-        font-size: 0.875rem;
-        font-weight: 500;
-        margin-bottom: 1rem;
-      }
-
-      .section-title {
-        font-size: 2.5rem;
-        font-weight: 800;
-        color: var(--dark);
-        margin-bottom: 1rem;
-      }
-
-      .section-description {
-        font-size: 1.125rem;
-        color: var(--gray);
-        max-width: 600px;
-        margin: 0 auto 3rem;
-      }
-
-      .feature-card {
-        background: var(--white);
-        border-radius: 20px;
-        padding: 2rem;
-        height: 100%;
-        border: 1px solid rgba(0,0,0,0.05);
-        transition: all 0.3s ease;
-        box-shadow: 0 4px 20px rgba(0,0,0,0.03);
-      }
-
-      .feature-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 20px 60px rgba(0,0,0,0.1);
-      }
-
-      .feature-icon {
-        width: 60px;
-        height: 60px;
-        border-radius: 16px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        margin-bottom: 1.5rem;
-        font-size: 1.5rem;
-      }
-
-      .feature-icon.blue { background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(14, 165, 233, 0.2)); color: var(--primary); }
-      .feature-icon.green { background: linear-gradient(135deg, rgba(16, 185, 129, 0.2), rgba(5, 150, 105, 0.2)); color: var(--accent); }
-      .feature-icon.purple { background: linear-gradient(135deg, rgba(139, 92, 246, 0.2), rgba(168, 85, 247, 0.2)); color: #8b5cf6; }
-      .feature-icon.orange { background: linear-gradient(135deg, rgba(249, 115, 22, 0.2), rgba(234, 88, 12, 0.2)); color: #f97316; }
-      .feature-icon.cyan { background: linear-gradient(135deg, rgba(6, 182, 212, 0.2), rgba(8, 145, 178, 0.2)); color: #06b6d4; }
-      .feature-icon.red { background: linear-gradient(135deg, rgba(239, 68, 68, 0.2), rgba(220, 38, 38, 0.2)); color: #ef4444; }
-      .feature-icon.pink { background: linear-gradient(135deg, rgba(236, 72, 153, 0.2), rgba(219, 39, 119, 0.2)); color: #ec4899; }
-      .feature-icon.yellow { background: linear-gradient(135deg, rgba(245, 158, 11, 0.2), rgba(217, 119, 6, 0.2)); color: #f59e0b; }
-      .feature-icon.indigo { background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(79, 70, 229, 0.2)); color: #6366f1; }
-      .feature-icon.teal { background: linear-gradient(135deg, rgba(20, 184, 166, 0.2), rgba(13, 148, 136, 0.2)); color: #14b8a6; }
-
-      .feature-card h4 { font-size: 1.25rem; font-weight: 700; color: var(--dark); margin-bottom: 0.75rem; }
-      .feature-card p { color: var(--gray); font-size: 0.95rem; line-height: 1.6; margin: 0; }
-
-      /* Request Flow Diagram */
-      .flow-section { padding: 5rem 0; background: var(--gradient-dark); }
-
-      .flow-diagram {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-wrap: wrap;
-        gap: 0;
-        padding: 2rem 0;
-      }
-
-      .flow-node {
-        background: rgba(255,255,255,0.1);
-        border: 1px solid rgba(255,255,255,0.2);
-        border-radius: 12px;
-        padding: 1rem 1.5rem;
-        text-align: center;
-        backdrop-filter: blur(10px);
-        min-width: 100px;
-      }
-
-      .flow-node i { font-size: 1.5rem; margin-bottom: 0.5rem; display: block; }
-      .flow-node span { font-size: 0.75rem; color: rgba(255,255,255,0.9); font-weight: 500; }
-      .flow-node.primary { background: rgba(99, 102, 241, 0.3); border-color: var(--primary); }
-      .flow-node.primary i { color: var(--primary); }
-      .flow-node.success { background: rgba(16, 185, 129, 0.3); border-color: var(--accent); }
-      .flow-node.success i { color: var(--accent); }
-      .flow-node.warning { background: rgba(249, 115, 22, 0.3); border-color: #f97316; }
-      .flow-node.warning i { color: #f97316; }
-      .flow-node.info { background: rgba(14, 165, 233, 0.3); border-color: var(--secondary); }
-      .flow-node.info i { color: var(--secondary); }
-
-      .flow-arrow {
-        color: rgba(255,255,255,0.4);
-        font-size: 1.5rem;
-        padding: 0 0.5rem;
-      }
-
-      /* API Section */
-      .api-section { padding: 5rem 0; background: var(--light); }
-
-      .api-card {
-        background: var(--white);
-        border-radius: 12px;
-        padding: 1.5rem;
-        border: 1px solid rgba(0,0,0,0.05);
-        height: 100%;
-        transition: all 0.3s ease;
-      }
-
-      .api-card:hover {
-        transform: translateY(-3px);
-        box-shadow: 0 10px 30px rgba(0,0,0,0.1);
-      }
-
-      .api-method {
-        display: inline-block;
-        padding: 0.25rem 0.75rem;
-        border-radius: 6px;
-        font-size: 0.75rem;
-        font-weight: 700;
-        margin-bottom: 0.75rem;
-      }
-
-      .api-method.get { background: rgba(16, 185, 129, 0.2); color: var(--accent); }
-      .api-method.post { background: rgba(99, 102, 241, 0.2); color: var(--primary); }
-      .api-method.put { background: rgba(249, 115, 22, 0.2); color: #f97316; }
-      .api-method.delete { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
-
-      .api-endpoint { font-family: 'Monaco', monospace; font-size: 0.875rem; color: var(--dark); margin-bottom: 0.5rem; font-weight: 600; }
-      .api-desc { color: var(--gray); font-size: 0.85rem; margin: 0; }
-
-      /* CTA Section */
-      .cta-section {
-        padding: 6rem 0;
-        background: var(--gradient-dark);
-        text-align: center;
-      }
-
-      .cta-section h2 { font-size: 2.5rem; font-weight: 800; color: var(--white); margin-bottom: 1rem; }
-      .cta-section p { font-size: 1.125rem; color: rgba(255,255,255,0.7); margin-bottom: 2rem; max-width: 600px; margin-left: auto; margin-right: auto; }
-
-      /* Footer */
-      .footer {
-        background: var(--dark);
-        padding: 4rem 0 2rem;
-        color: rgba(255,255,255,0.7);
-      }
-
-      .footer h5 { color: var(--white); font-weight: 700; margin-bottom: 1.5rem; }
-      .footer ul { list-style: none; padding: 0; }
-      .footer ul li { margin-bottom: 0.75rem; }
-      .footer a { color: rgba(255,255,255,0.6); text-decoration: none; transition: color 0.3s ease; }
-      .footer a:hover { color: var(--white); }
-      .footer-bottom { border-top: 1px solid rgba(255,255,255,0.1); padding-top: 2rem; margin-top: 3rem; text-align: center; }
-      .footer-logo { font-size: 1.5rem; font-weight: 800; margin-bottom: 1rem; }
-      .footer-logo span { background: var(--gradient); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
-
-      .social-links { display: flex; gap: 1rem; margin-top: 1rem; }
-      .social-links a {
-        width: 40px; height: 40px;
-        border-radius: 50%;
-        background: rgba(255,255,255,0.1);
-        display: flex; align-items: center; justify-content: center;
-        color: var(--white);
-        transition: all 0.3s ease;
-      }
-      .social-links a:hover { background: var(--primary); transform: translateY(-3px); }
-
-      /* Responsive */
-      @media (max-width: 768px) {
-        .hero h1 { font-size: 2.5rem; }
-        .hero-stats { gap: 1.5rem; }
-        .stat-number { font-size: 1.75rem; }
-        .section-title { font-size: 2rem; }
-        .flow-diagram { flex-direction: column; gap: 0.5rem; }
-        .flow-arrow { transform: rotate(90deg); padding: 0.25rem 0; }
-      }
-    </style>
-  </head>
-  <body>
-    <!-- Navbar -->
-    <nav class="navbar-custom">
-      <div class="container d-flex justify-content-between align-items-center">
-        <a class="navbar-brand" href="#">
-          <i class="fas fa-cube"></i>
-          <span>WSL Proxy</span>
-        </a>
-        <div class="d-flex align-items-center">
-          <a class="nav-link-custom d-none d-md-inline" href="#features">Features</a>
-          <a class="nav-link-custom d-none d-md-inline" href="#flow">Architecture</a>
-          <a class="nav-link-custom d-none d-md-inline" href="#api">API</a>
-          <a class="nav-link-custom d-none d-md-inline" href="https://github.com/bwalia/wslproxy" target="_blank">Docs</a>
-          <a class="btn-nav" href="https://github.com/bwalia/wslproxy" target="_blank">
-            <i class="fab fa-github"></i> GitHub
-          </a>
-        </div>
-      </div>
-    </nav>
-
-    <!-- Hero Section -->
-    <section class="hero">
-      <div class="hero-glow"></div>
-      <div class="hero-glow-2"></div>
-      <div class="container">
-        <div class="row align-items-center">
-          <div class="col-lg-6 hero-content">
-            <div class="hero-badge">
-              <i class="fas fa-bolt"></i>
-              <span>OpenResty + Lua Powered Edge Computing</span>
-            </div>
-            <h1>Build Your Own <span class="gradient-text">Enterprise CDN</span></h1>
-            <p class="hero-description">
-              WSL Proxy is a high-performance reverse proxy, load balancer, and edge computing platform. 
-              Deploy globally with multi-region failover, edge caching, WAF protection, and API gateway capabilities.
-            </p>
-            <div class="hero-buttons">
-              <a href="https://github.com/bwalia/wslproxy" class="btn-primary-custom" target="_blank">
-                <i class="fas fa-rocket"></i> Get Started
-              </a>
-              <a href="https://github.com/bwalia/wslproxy" class="btn-secondary-custom" target="_blank">
-                <i class="fab fa-github"></i> View on GitHub
-              </a>
-            </div>
-            <div class="hero-stats">
-              <div class="stat-item">
-                <div class="stat-number">&lt;10ms</div>
-                <div class="stat-label">Latency</div>
-              </div>
-              <div class="stat-item">
-                <div class="stat-number">99.99%</div>
-                <div class="stat-label">Uptime</div>
-              </div>
-              <div class="stat-item">
-                <div class="stat-number">100K+</div>
-                <div class="stat-label">RPS</div>
-              </div>
-              <div class="stat-item">
-                <div class="stat-number">50+</div>
-                <div class="stat-label">Edge Locations</div>
-              </div>
-            </div>
-          </div>
-          <div class="col-lg-6 d-none d-lg-block">
-            <div class="terminal-window">
-              <div class="terminal-header">
-                <span class="terminal-dot red"></span>
-                <span class="terminal-dot yellow"></span>
-                <span class="terminal-dot green"></span>
-              </div>
-              <div class="terminal-body">
-                <div class="terminal-line">
-                  <span class="terminal-prompt">$</span>
-                  <span class="terminal-command">docker pull bwalia/wslproxy:latest</span>
-                </div>
-                <div class="terminal-output">Pulling from bwalia/wslproxy...</div>
-                <div class="terminal-output">Status: Downloaded newer image</div>
-                <div class="terminal-line">
-                  <span class="terminal-prompt">$</span>
-                  <span class="terminal-command">docker-compose up -d</span>
-                </div>
-                <div class="terminal-output">Creating wslproxy_redis_1 ... done</div>
-                <div class="terminal-output">Creating wslproxy_openresty_1 ... done</div>
-                <div class="terminal-line">
-                  <span class="terminal-prompt">$</span>
-                  <span class="terminal-command">curl https://your-domain.com/api/health</span>
-                </div>
-                <div class="terminal-output" style="color: #10b981;">{"status":"healthy","version":"2.0"}</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Features Section -->
-    <section class="features" id="features">
-      <div class="container">
-        <div class="text-center mb-5">
-          <span class="section-badge"><i class="fas fa-sparkles"></i> Features</span>
-          <h2 class="section-title">Everything You Need for Edge Computing</h2>
-          <p class="section-description">
-            From load balancing to WAF protection, WSL Proxy provides enterprise-grade features for building your own CDN.
+  <main>
+    <section class="hero" aria-label="Introduction">
+      <div class="wrap hero-grid">
+        <div class="hero-copy">
+          <h1>WSLProxy</h1>
+          <p class="hero-lede">
+            Live-config API gateway on OpenResty. Change rules, WAF, and traffic splits without reloading nginx — drive it from UI, REST, MCP, or CLI.
           </p>
+          <div class="cta-row">
+            <a class="btn btn-primary" href="https://github.com/bwalia/wslproxy#quick-start">Get started</a>
+            <a class="btn btn-ghost" href="/swagger/">Open API docs</a>
+          </div>
         </div>
-        <div class="row g-4">
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon blue"><i class="fas fa-balance-scale"></i></div>
-              <h4>Load Balancing</h4>
-              <p>Distribute traffic across multiple backends with round-robin, least connections, or IP hash algorithms.</p>
+
+        <div class="path-stage" aria-hidden="true">
+          <div class="path-label">Request path · live evaluation</div>
+          <svg class="path-svg" viewBox="0 0 960 88" role="img">
+            <title>Client to origin through SSL, WAF, rules, and balancer</title>
+            <path class="path-wire" d="M40 44 H920" />
+            <path class="path-wire-live" d="M40 44 H920" />
+            <circle class="path-node" cx="40" cy="44" r="8" />
+            <circle class="path-node path-node-active" cx="220" cy="44" r="8" />
+            <circle class="path-node path-node-active" cx="400" cy="44" r="8" />
+            <circle class="path-node path-node-active" cx="580" cy="44" r="8" />
+            <circle class="path-node path-node-active" cx="760" cy="44" r="8" />
+            <circle class="path-node" cx="920" cy="44" r="8" />
+            <text class="path-text" x="40" y="74" text-anchor="middle">Client</text>
+            <text class="path-text" x="220" y="74" text-anchor="middle">TLS</text>
+            <text class="path-text" x="400" y="74" text-anchor="middle">WAF</text>
+            <text class="path-text" x="580" y="74" text-anchor="middle">Rules</text>
+            <text class="path-text" x="760" y="74" text-anchor="middle">Balancer</text>
+            <text class="path-text" x="920" y="74" text-anchor="middle">Origin</text>
+          </svg>
+        </div>
+      </div>
+    </section>
+
+    <section id="pipeline">
+      <div class="wrap">
+        <p class="section-kicker">How traffic moves</p>
+        <h2 class="section-title">Match once. Decide per request.</h2>
+        <p class="section-lede">
+          OpenResty loads server and rule JSON on the hot path. Only server-block nginx changes need a reload flag — rules and WAF stay live.
+        </p>
+        <div class="flow-steps">
+          <div class="flow-step">
+            <code>rewrite</code>
+            <div>
+              <strong>gateway_ack</strong>
+              <p>Load host config, score candidate rules (path, IP, country, JWT…), run rate limit and WAF, stash the winner.</p>
             </div>
           </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon green"><i class="fas fa-globe"></i></div>
-              <h4>Multi-Region Failover</h4>
-              <p>Automatic failover to healthy regions with configurable health checks and priority routing.</p>
+          <div class="flow-step">
+            <code>access</code>
+            <div>
+              <strong>gateway_resp</strong>
+              <p>Honor response code: proxy (305), redirect, HTML block, CAPTCHA (306), or 403 — then resolve backend and timeouts.</p>
             </div>
           </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon purple"><i class="fas fa-bolt"></i></div>
-              <h4>Edge Caching</h4>
-              <p>Cache responses at the edge with fine-grained TTL control and instant cache invalidation via API.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon orange"><i class="fas fa-shield-alt"></i></div>
-              <h4>WAF Protection</h4>
-              <p>Content-based WAF rules with SQL injection mitigation, XSS protection, and custom rule sets.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon cyan"><i class="fas fa-lock"></i></div>
-              <h4>SSL/TLS Termination</h4>
-              <p>Automatic certificate management with Let's Encrypt integration and cloud certificate pipelines.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon red"><i class="fas fa-key"></i></div>
-              <h4>Edge Authorization</h4>
-              <p>JWT validation, API key management, and OAuth2 integration at the edge.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon pink"><i class="fas fa-chart-line"></i></div>
-              <h4>Observability</h4>
-              <p>Prometheus metrics, structured logging, and distributed tracing for full visibility.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon yellow"><i class="fas fa-map-marker-alt"></i></div>
-              <h4>Geo Traffic Rules</h4>
-              <p>Route traffic by country or continent with IP2Location integration.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon indigo"><i class="fas fa-code-branch"></i></div>
-              <h4>GitOps Ready</h4>
-              <p>Declarative configuration with Helm charts and GitHub Actions CI/CD integration.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon blue"><i class="fas fa-tachometer-alt"></i></div>
-              <h4>Monitoring Integration</h4>
-              <p>Native integration with Prometheus, Grafana, Loki, Mimir, Alertmanager, ELK Stack, Dynatrace, and Datadog.</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="feature-card">
-              <div class="feature-icon teal"><i class="fas fa-sliders-h"></i></div>
-              <h4>Web UI Control Plane</h4>
-              <p>Fully-featured Web UI Administrator to manage entire cluster configuration from a single place securely.</p>
+          <div class="flow-step">
+            <code>balancer</code>
+            <div>
+              <strong>Peer + timeouts</strong>
+              <p>Weighted, canary, sticky, or least-conn selection with per-server connect/send/read timeouts.</p>
             </div>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- Request Flow Section -->
-    <section class="flow-section" id="flow">
-      <div class="container">
-        <div class="text-center mb-5">
-          <span class="section-badge" style="background: rgba(255,255,255,0.1); color: var(--white);">
-            <i class="fas fa-project-diagram"></i> Architecture
-          </span>
-          <h2 class="section-title" style="color: var(--white);">Request Flow</h2>
-          <p class="section-description" style="color: rgba(255,255,255,0.7);">
-            Every request flows through our optimized edge pipeline for maximum performance and security.
-          </p>
-        </div>
-        <div class="flow-diagram">
-          <div class="flow-node info"><i class="fas fa-user"></i><span>Client</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node"><i class="fas fa-network-wired"></i><span>DNS</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node success"><i class="fas fa-lock"></i><span>SSL/TLS</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node warning"><i class="fas fa-shield-alt"></i><span>WAF</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node primary"><i class="fas fa-key"></i><span>Auth</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node"><i class="fas fa-database"></i><span>Cache</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node info"><i class="fas fa-balance-scale"></i><span>LB</span></div>
-          <span class="flow-arrow"><i class="fas fa-arrow-right"></i></span>
-          <div class="flow-node success"><i class="fas fa-server"></i><span>Origin</span></div>
-        </div>
-      </div>
-    </section>
-
-    <!-- API Section -->
-    <section class="api-section" id="api">
-      <div class="container">
-        <div class="text-center mb-5">
-          <span class="section-badge"><i class="fas fa-code"></i> API-Driven</span>
-          <h2 class="section-title">RESTful Configuration API</h2>
-          <p class="section-description">
-            Manage your entire edge infrastructure through our comprehensive REST API.
-          </p>
-        </div>
-        <div class="row g-4">
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method get">GET</span>
-              <div class="api-endpoint">/api/servers</div>
-              <p class="api-desc">List all configured backend servers</p>
+    <section id="capabilities" style="background: #fff; border-block: 1px solid var(--line);">
+      <div class="wrap">
+        <p class="section-kicker">Platform</p>
+        <h2 class="section-title">Built for real edge ops</h2>
+        <p class="section-lede">Not a brochure CDN — a control plane you run on your POPs, VMs, or k3s.</p>
+        <div class="split split-2">
+          <div>
+            <div class="strip">
+              <h3>Dynamic routing</h3>
+              <p>Priority-aware rules with geo, IP, JWT, and path matching. Attach many rules per virtual host.</p>
+            </div>
+            <div class="strip">
+              <h3>WAF policy packs</h3>
+              <p>Detection rules, anomaly scoring, monitor or block modes, and an events API — including the v2 engine.</p>
+            </div>
+            <div class="strip">
+              <h3>Traffic engineering</h3>
+              <p>Canary weights, promote/rollback, topology views, and passive/active upstream health.</p>
             </div>
           </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method post">POST</span>
-              <div class="api-endpoint">/api/servers</div>
-              <p class="api-desc">Create a new server configuration</p>
+          <div>
+            <div class="strip">
+              <h3>Multi-POP + DNS</h3>
+              <p>Declare edge locations and provision Cloudflare A records with guardrails so unmanaged DNS stays untouched.</p>
             </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method get">GET</span>
-              <div class="api-endpoint">/api/rules</div>
-              <p class="api-desc">List all routing and WAF rules</p>
+            <div class="strip">
+              <h3>SSL &amp; cache</h3>
+              <p>auto-ssl / Let’s Encrypt, force HTTPS, edge static cache, optional Varnish and Docker blob cache.</p>
             </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method post">POST</span>
-              <div class="api-endpoint">/api/cache/purge</div>
-              <p class="api-desc">Purge cached content by pattern</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method get">GET</span>
-              <div class="api-endpoint">/metrics</div>
-              <p class="api-desc">Prometheus-compatible metrics</p>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4">
-            <div class="api-card">
-              <span class="api-method get">GET</span>
-              <div class="api-endpoint">/api/health</div>
-              <p class="api-desc">Health check endpoint</p>
+            <div class="strip">
+              <h3>Two-layer ingress</h3>
+              <p>Outer POP plus optional k3s <code>wslproxy-ingress</code> Helm chart — tune timeouts on both layers.</p>
             </div>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- CTA Section -->
-    <section class="cta-section">
-      <div class="container">
-        <h2>Ready to Build Your Own CDN?</h2>
-        <p>Get started with WSL Proxy in minutes. Deploy on Docker, Kubernetes, or bare metal.</p>
-        <div class="d-flex justify-content-center gap-3 flex-wrap">
-          <a href="https://github.com/bwalia/wslproxy" class="btn-primary-custom" target="_blank">
-            <i class="fas fa-rocket"></i> Get Started
-          </a>
-          <a href="https://github.com/bwalia/wslproxy/issues" class="btn-secondary-custom" target="_blank">
-            <i class="fas fa-comments"></i> Join Community
-          </a>
+    <section class="band" id="operate">
+      <div class="wrap split split-aside">
+        <div>
+          <p class="section-kicker">Control plane</p>
+          <h2 class="section-title">UI, API, agents, and pipelines</h2>
+          <p class="section-lede">Same surface whether a human clicks, a script runs, or Cursor calls MCP.</p>
+          <ul class="ops-list">
+            <li>
+              <strong>Admin UI</strong>
+              <span>React Admin for day-to-day CRUD; Next.js dashboard for logs and AI-assisted analysis.</span>
+            </li>
+            <li>
+              <strong>REST + Swagger</strong>
+              <span>Full CRUD for servers, rules, WAF, traffic, cache — JWT auth like the UI.</span>
+            </li>
+            <li>
+              <strong>MCP</strong>
+              <span>Resources and tools for Claude / Cursor: validate_config, CRUD, traffic, POPs/DNS.</span>
+            </li>
+            <li>
+              <strong>wslproxy-cli</strong>
+              <span>Pull → edit → push JSON; check nginx/health; ship via <code>ghcr.io/bwalia/wslproxy-cli</code>.</span>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <div class="code-panel" aria-label="Example CI command">
+            <div><span class="cmt"># GitHub Actions / GitLab CI</span></div>
+            <div><span class="cmd">docker run --rm \</span></div>
+            <div>&nbsp;&nbsp;-e WSLPROXY_BASE_URL \</div>
+            <div>&nbsp;&nbsp;-e WSLPROXY_TOKEN \</div>
+            <div>&nbsp;&nbsp;ghcr.io/bwalia/wslproxy-cli:latest \</div>
+            <div>&nbsp;&nbsp;check nginx -o json</div>
+            <div style="margin-top:0.85rem"><span class="cmt"># Config as files</span></div>
+            <div>wslproxy-cli pull -d ./cfg --resources servers,rules,waf</div>
+            <div>wslproxy-cli push -d ./cfg --yes --verify</div>
+          </div>
         </div>
       </div>
     </section>
 
-    <!-- Footer -->
-    <footer class="footer">
-      <div class="container">
-        <div class="row">
-          <div class="col-lg-4 mb-4 mb-lg-0">
-            <div class="footer-logo"><i class="fas fa-cube"></i> <span>WSL Proxy</span></div>
-            <p>Enterprise-grade reverse proxy, load balancer, and edge computing platform.</p>
-            <div class="social-links">
-              <a href="https://github.com/bwalia/wslproxy" target="_blank"><i class="fab fa-github"></i></a>
-              <a href="#"><i class="fab fa-slack"></i></a>
-              <a href="#"><i class="fab fa-twitter"></i></a>
-              <a href="#"><i class="fab fa-linkedin"></i></a>
-            </div>
-          </div>
-          <div class="col-6 col-lg-2">
-            <h5>Product</h5>
-            <ul>
-              <li><a href="#features">Features</a></li>
-              <li><a href="#flow">Architecture</a></li>
-              <li><a href="#api">API</a></li>
-              <li><a href="https://github.com/bwalia/wslproxy">Documentation</a></li>
-            </ul>
-          </div>
-          <div class="col-6 col-lg-2">
-            <h5>Resources</h5>
-            <ul>
-              <li><a href="https://github.com/bwalia/wslproxy">GitHub</a></li>
-              <li><a href="https://github.com/bwalia/wslproxy/issues">Issues</a></li>
-              <li><a href="https://github.com/bwalia/wslproxy/releases">Releases</a></li>
-              <li><a href="https://hub.docker.com/r/bwalia/wslproxy">Docker Hub</a></li>
-            </ul>
-          </div>
-          <div class="col-6 col-lg-2">
-            <h5>Company</h5>
-            <ul>
-              <li><a href="#">About</a></li>
-              <li><a href="#">Blog</a></li>
-              <li><a href="#">Careers</a></li>
-              <li><a href="#">Contact</a></li>
-            </ul>
-          </div>
-          <div class="col-6 col-lg-2">
-            <h5>Legal</h5>
-            <ul>
-              <li><a href="#">Privacy</a></li>
-              <li><a href="#">Terms</a></li>
-              <li><a href="https://github.com/bwalia/wslproxy/blob/main/LICENSE">License</a></li>
-            </ul>
-          </div>
-        </div>
-        <div class="footer-bottom">
-          <p>&copy; 2025 Workstation Solutions Limited. Open Source under MIT License.</p>
+    <section id="start">
+      <div class="wrap">
+        <p class="section-kicker">Get going</p>
+        <h2 class="section-title">Three ways in</h2>
+        <div class="start-grid">
+          <article class="start-item">
+            <h3>Local Docker</h3>
+            <p><code>./dev.sh</code> brings up OpenResty, Redis, and the admin UI with hot-reload for Lua.</p>
+            <a href="https://github.com/bwalia/wslproxy#quick-start">Dev quick start →</a>
+          </article>
+          <article class="start-item">
+            <h3>Ansible / Helm</h3>
+            <p>Bare-metal POPs via Ansible; k3s ingress via the Helm chart under <code>ingress-controller/</code>.</p>
+            <a href="https://github.com/bwalia/wslproxy/tree/main/infra/ansible">Ansible role →</a>
+          </article>
+          <article class="start-item">
+            <h3>Docs &amp; demos</h3>
+            <p>WAF demo packs, MCP guides, CLI examples, and architecture diagrams in the repo.</p>
+            <a href="https://github.com/bwalia/wslproxy/tree/main/docs">Browse docs →</a>
+          </article>
         </div>
       </div>
-    </footer>
+    </section>
 
-    <!-- Bootstrap JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  </body>
+    <section class="cta-final">
+      <div class="wrap">
+        <h2>Own the edge you run.</h2>
+        <p>Open source gateway, real POPs, agent-ready control plane — start from the repo and ship config like code.</p>
+        <div class="cta-row" style="justify-content:center">
+          <a class="btn btn-primary" href="https://github.com/bwalia/wslproxy">View on GitHub</a>
+          <a class="btn btn-ghost" href="/swagger/">Swagger</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="wrap footer-inner">
+      <div>© Workstation Solutions Limited · WSLProxy</div>
+      <div class="footer-links">
+        <a href="https://github.com/bwalia/wslproxy">GitHub</a>
+        <a href="/swagger/">API</a>
+        <a href="https://github.com/bwalia/wslproxy/blob/main/docs/wslproxy-cli.md">CLI</a>
+        <a href="https://github.com/bwalia/wslproxy/blob/main/docs/mcp.md">MCP</a>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var btn = document.getElementById("nav-toggle");
+      var menu = document.getElementById("nav-menu");
+      if (!btn || !menu) return;
+      btn.addEventListener("click", function () {
+        var open = menu.classList.toggle("open");
+        btn.setAttribute("aria-expanded", open ? "true" : "false");
+      });
+    })();
+  </script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- Rewrite root README around live rules, WAF, MCP, CLI, multi-POP, and deploy paths — with Mermaid diagrams that render on GitHub
- Redesign `html/index.html` (synced to `docs/index.html`) with clearer product story and updated UX/UI
- Point `docs/diagrams/README.md` at Mermaid in the root README (Draw.io files remain)

## Test plan
- [ ] README Mermaid renders on the GitHub PR Files changed / rendered view
- [ ] Open `html/index.html` locally — hero, pipeline, capabilities, operate, mobile nav
- [ ] Confirm `diff -q html/index.html docs/index.html` is empty
- [ ] Links: GitHub, Swagger `/swagger/`, CLI/MCP docs


Made with [Cursor](https://cursor.com)