### PR TITLE
Align dashboard style with landing + dark mode

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,21 @@
   <meta property="og:description" content="Route, secure, and observe traffic from JSON and MCP — without reloading nginx for every rule change." />
   <meta property="og:type" content="website" />
   <title>WSLProxy — Live-config API gateway &amp; edge control plane</title>
+  <meta name="color-scheme" content="light dark" />
+  <script>
+    (function () {
+      try {
+        var key = "wslproxy.theme";
+        var t = localStorage.getItem(key);
+        if (t !== "light" && t !== "dark") {
+          t = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+        document.documentElement.setAttribute("data-theme", t);
+        document.documentElement.classList.toggle("dark", t === "dark");
+        document.documentElement.style.colorScheme = t;
+      } catch (e) {}
+    })();
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet" />
@@ -23,11 +38,37 @@
       --copper: #c45c26;
       --copper-deep: #9a4519;
       --signal: #1a7a6d;
+      --surface: #ffffff;
+      --band: #0b1c2c;
+      --band-ink: #eef2f6;
+      --band-muted: rgba(238, 242, 246, 0.72);
+      --code-bg: #07131f;
+      --code-ink: #d7e2ec;
       --mono: "JetBrains Mono", ui-monospace, monospace;
       --sans: "Outfit", system-ui, sans-serif;
       --display: "Fraunces", Georgia, serif;
       --radius: 6px;
       --max: 1120px;
+      color-scheme: light;
+    }
+
+    html.dark {
+      --ink: #eef2f6;
+      --ink-soft: #b7c4d4;
+      --steel: #8fa3b8;
+      --mist: #122233;
+      --paper: #0b1c2c;
+      --line: #2a3d52;
+      --copper: #e07a3d;
+      --copper-deep: #f0a06a;
+      --signal: #3dbaa8;
+      --surface: #122233;
+      --band: #152838;
+      --band-ink: #f7f9fc;
+      --band-muted: rgba(247, 249, 252, 0.7);
+      --code-bg: #061018;
+      --code-ink: #d7e2ec;
+      color-scheme: dark;
     }
 
     *, *::before, *::after { box-sizing: border-box; }
@@ -108,7 +149,30 @@
       font-size: 0.9rem;
       border-radius: var(--radius);
     }
+    html.dark .nav-cta {
+      background: var(--copper);
+      color: #fff !important;
+    }
     .nav-cta:hover { background: var(--ink-soft); }
+    html.dark .nav-cta:hover { background: var(--copper-deep); }
+    .theme-toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.25rem;
+      height: 2.25rem;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--ink-soft);
+      cursor: pointer;
+      padding: 0;
+    }
+    .theme-toggle:hover { color: var(--ink); border-color: var(--steel); }
+    .theme-toggle svg { width: 1.1rem; height: 1.1rem; }
+    .theme-toggle .icon-sun { display: none; }
+    html.dark .theme-toggle .icon-sun { display: block; }
+    html.dark .theme-toggle .icon-moon { display: none; }
     .nav-toggle {
       display: none;
       background: none;
@@ -117,6 +181,7 @@
       padding: 0.35rem 0.6rem;
       font: inherit;
       cursor: pointer;
+      color: var(--ink);
     }
     @media (max-width: 760px) {
       .nav-toggle { display: block; }
@@ -145,7 +210,7 @@
       overflow: hidden;
       background:
         radial-gradient(1200px 500px at 70% -10%, color-mix(in srgb, var(--steel) 18%, transparent), transparent 60%),
-        linear-gradient(165deg, var(--mist) 0%, var(--paper) 45%, #e4ebe7 100%);
+        linear-gradient(165deg, var(--mist) 0%, var(--paper) 45%, color-mix(in srgb, var(--signal) 12%, var(--paper)) 100%);
     }
     .hero::before {
       content: "";
@@ -300,12 +365,12 @@
     .strip p { margin: 0; color: var(--ink-soft); }
 
     .band {
-      background: var(--ink);
-      color: var(--mist);
+      background: var(--band);
+      color: var(--band-ink);
     }
-    .band .section-kicker { color: color-mix(in srgb, var(--mist) 55%, transparent); }
-    .band .section-title { color: #fff; max-width: none; }
-    .band .section-lede { color: color-mix(in srgb, var(--mist) 75%, transparent); }
+    .band .section-kicker { color: color-mix(in srgb, var(--band-ink) 55%, transparent); }
+    .band .section-title { color: var(--band-ink); max-width: none; }
+    .band .section-lede { color: var(--band-muted); }
 
     .ops-list {
       list-style: none;
@@ -323,20 +388,20 @@
       font-family: var(--display);
       font-size: 1.15rem;
       margin-bottom: 0.2rem;
-      color: #fff;
+      color: var(--band-ink);
     }
-    .ops-list span { color: color-mix(in srgb, var(--mist) 72%, transparent); font-size: 0.98rem; }
+    .ops-list span { color: var(--band-muted); font-size: 0.98rem; }
 
     .code-panel {
-      background: #07131f;
-      color: #d7e2ec;
+      background: var(--code-bg);
+      color: var(--code-ink);
       border-radius: var(--radius);
       padding: 1.15rem 1.25rem;
       font-family: var(--mono);
       font-size: 0.8rem;
       line-height: 1.65;
       overflow-x: auto;
-      border: 1px solid #1c3348;
+      border: 1px solid var(--line);
     }
     .code-panel .cmt { color: #6d8499; }
     .code-panel .cmd { color: #e8a87c; }
@@ -347,7 +412,11 @@
       border: 1px solid var(--line);
       border-radius: var(--radius);
       overflow: hidden;
-      background: #fff;
+      background: var(--surface);
+    }
+    .surface-panel {
+      background: var(--surface);
+      border-block: 1px solid var(--line);
     }
     .flow-step {
       display: grid;
@@ -428,6 +497,17 @@
         <li><a href="#capabilities">Capabilities</a></li>
         <li><a href="#operate">Operate</a></li>
         <li><a href="#start">Start</a></li>
+        <li>
+          <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
+            <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M21 14.5A8.5 8.5 0 0 1 9.5 3 7 7 0 1 0 21 14.5z" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <circle cx="12" cy="12" r="4"/>
+              <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" stroke-linecap="round"/>
+            </svg>
+          </button>
+        </li>
         <li><a class="nav-cta" href="https://github.com/bwalia/wslproxy">GitHub</a></li>
       </ul>
     </div>
@@ -503,7 +583,7 @@
       </div>
     </section>
 
-    <section id="capabilities" style="background: #fff; border-block: 1px solid var(--line);">
+    <section id="capabilities" class="surface-panel">
       <div class="wrap">
         <p class="section-kicker">Platform</p>
         <h2 class="section-title">Built for real edge ops</h2>
@@ -634,11 +714,33 @@
     (function () {
       var btn = document.getElementById("nav-toggle");
       var menu = document.getElementById("nav-menu");
-      if (!btn || !menu) return;
-      btn.addEventListener("click", function () {
-        var open = menu.classList.toggle("open");
-        btn.setAttribute("aria-expanded", open ? "true" : "false");
-      });
+      if (btn && menu) {
+        btn.addEventListener("click", function () {
+          var open = menu.classList.toggle("open");
+          btn.setAttribute("aria-expanded", open ? "true" : "false");
+        });
+      }
+
+      var key = "wslproxy.theme";
+      var themeBtn = document.getElementById("theme-toggle");
+      function applyTheme(t) {
+        document.documentElement.setAttribute("data-theme", t);
+        document.documentElement.classList.toggle("dark", t === "dark");
+        document.documentElement.style.colorScheme = t;
+        try { localStorage.setItem(key, t); } catch (e) {}
+        if (themeBtn) {
+          themeBtn.setAttribute(
+            "aria-label",
+            t === "dark" ? "Switch to light mode" : "Switch to dark mode"
+          );
+        }
+      }
+      if (themeBtn) {
+        themeBtn.addEventListener("click", function () {
+          var next = document.documentElement.classList.contains("dark") ? "light" : "dark";
+          applyTheme(next);
+        });
+      }
     })();
   </script>
 </body>

--- a/html/index.html
+++ b/html/index.html
@@ -9,6 +9,21 @@
   <meta property="og:description" content="Route, secure, and observe traffic from JSON and MCP — without reloading nginx for every rule change." />
   <meta property="og:type" content="website" />
   <title>WSLProxy — Live-config API gateway &amp; edge control plane</title>
+  <meta name="color-scheme" content="light dark" />
+  <script>
+    (function () {
+      try {
+        var key = "wslproxy.theme";
+        var t = localStorage.getItem(key);
+        if (t !== "light" && t !== "dark") {
+          t = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+        document.documentElement.setAttribute("data-theme", t);
+        document.documentElement.classList.toggle("dark", t === "dark");
+        document.documentElement.style.colorScheme = t;
+      } catch (e) {}
+    })();
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=JetBrains+Mono:wght@400;500&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet" />
@@ -23,11 +38,37 @@
       --copper: #c45c26;
       --copper-deep: #9a4519;
       --signal: #1a7a6d;
+      --surface: #ffffff;
+      --band: #0b1c2c;
+      --band-ink: #eef2f6;
+      --band-muted: rgba(238, 242, 246, 0.72);
+      --code-bg: #07131f;
+      --code-ink: #d7e2ec;
       --mono: "JetBrains Mono", ui-monospace, monospace;
       --sans: "Outfit", system-ui, sans-serif;
       --display: "Fraunces", Georgia, serif;
       --radius: 6px;
       --max: 1120px;
+      color-scheme: light;
+    }
+
+    html.dark {
+      --ink: #eef2f6;
+      --ink-soft: #b7c4d4;
+      --steel: #8fa3b8;
+      --mist: #122233;
+      --paper: #0b1c2c;
+      --line: #2a3d52;
+      --copper: #e07a3d;
+      --copper-deep: #f0a06a;
+      --signal: #3dbaa8;
+      --surface: #122233;
+      --band: #152838;
+      --band-ink: #f7f9fc;
+      --band-muted: rgba(247, 249, 252, 0.7);
+      --code-bg: #061018;
+      --code-ink: #d7e2ec;
+      color-scheme: dark;
     }
 
     *, *::before, *::after { box-sizing: border-box; }
@@ -108,7 +149,30 @@
       font-size: 0.9rem;
       border-radius: var(--radius);
     }
+    html.dark .nav-cta {
+      background: var(--copper);
+      color: #fff !important;
+    }
     .nav-cta:hover { background: var(--ink-soft); }
+    html.dark .nav-cta:hover { background: var(--copper-deep); }
+    .theme-toggle {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.25rem;
+      height: 2.25rem;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      color: var(--ink-soft);
+      cursor: pointer;
+      padding: 0;
+    }
+    .theme-toggle:hover { color: var(--ink); border-color: var(--steel); }
+    .theme-toggle svg { width: 1.1rem; height: 1.1rem; }
+    .theme-toggle .icon-sun { display: none; }
+    html.dark .theme-toggle .icon-sun { display: block; }
+    html.dark .theme-toggle .icon-moon { display: none; }
     .nav-toggle {
       display: none;
       background: none;
@@ -117,6 +181,7 @@
       padding: 0.35rem 0.6rem;
       font: inherit;
       cursor: pointer;
+      color: var(--ink);
     }
     @media (max-width: 760px) {
       .nav-toggle { display: block; }
@@ -145,7 +210,7 @@
       overflow: hidden;
       background:
         radial-gradient(1200px 500px at 70% -10%, color-mix(in srgb, var(--steel) 18%, transparent), transparent 60%),
-        linear-gradient(165deg, var(--mist) 0%, var(--paper) 45%, #e4ebe7 100%);
+        linear-gradient(165deg, var(--mist) 0%, var(--paper) 45%, color-mix(in srgb, var(--signal) 12%, var(--paper)) 100%);
     }
     .hero::before {
       content: "";
@@ -300,12 +365,12 @@
     .strip p { margin: 0; color: var(--ink-soft); }
 
     .band {
-      background: var(--ink);
-      color: var(--mist);
+      background: var(--band);
+      color: var(--band-ink);
     }
-    .band .section-kicker { color: color-mix(in srgb, var(--mist) 55%, transparent); }
-    .band .section-title { color: #fff; max-width: none; }
-    .band .section-lede { color: color-mix(in srgb, var(--mist) 75%, transparent); }
+    .band .section-kicker { color: color-mix(in srgb, var(--band-ink) 55%, transparent); }
+    .band .section-title { color: var(--band-ink); max-width: none; }
+    .band .section-lede { color: var(--band-muted); }
 
     .ops-list {
       list-style: none;
@@ -323,20 +388,20 @@
       font-family: var(--display);
       font-size: 1.15rem;
       margin-bottom: 0.2rem;
-      color: #fff;
+      color: var(--band-ink);
     }
-    .ops-list span { color: color-mix(in srgb, var(--mist) 72%, transparent); font-size: 0.98rem; }
+    .ops-list span { color: var(--band-muted); font-size: 0.98rem; }
 
     .code-panel {
-      background: #07131f;
-      color: #d7e2ec;
+      background: var(--code-bg);
+      color: var(--code-ink);
       border-radius: var(--radius);
       padding: 1.15rem 1.25rem;
       font-family: var(--mono);
       font-size: 0.8rem;
       line-height: 1.65;
       overflow-x: auto;
-      border: 1px solid #1c3348;
+      border: 1px solid var(--line);
     }
     .code-panel .cmt { color: #6d8499; }
     .code-panel .cmd { color: #e8a87c; }
@@ -347,7 +412,11 @@
       border: 1px solid var(--line);
       border-radius: var(--radius);
       overflow: hidden;
-      background: #fff;
+      background: var(--surface);
+    }
+    .surface-panel {
+      background: var(--surface);
+      border-block: 1px solid var(--line);
     }
     .flow-step {
       display: grid;
@@ -428,6 +497,17 @@
         <li><a href="#capabilities">Capabilities</a></li>
         <li><a href="#operate">Operate</a></li>
         <li><a href="#start">Start</a></li>
+        <li>
+          <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode" title="Toggle theme">
+            <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <path d="M21 14.5A8.5 8.5 0 0 1 9.5 3 7 7 0 1 0 21 14.5z" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <circle cx="12" cy="12" r="4"/>
+              <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" stroke-linecap="round"/>
+            </svg>
+          </button>
+        </li>
         <li><a class="nav-cta" href="https://github.com/bwalia/wslproxy">GitHub</a></li>
       </ul>
     </div>
@@ -503,7 +583,7 @@
       </div>
     </section>
 
-    <section id="capabilities" style="background: #fff; border-block: 1px solid var(--line);">
+    <section id="capabilities" class="surface-panel">
       <div class="wrap">
         <p class="section-kicker">Platform</p>
         <h2 class="section-title">Built for real edge ops</h2>
@@ -634,11 +714,33 @@
     (function () {
       var btn = document.getElementById("nav-toggle");
       var menu = document.getElementById("nav-menu");
-      if (!btn || !menu) return;
-      btn.addEventListener("click", function () {
-        var open = menu.classList.toggle("open");
-        btn.setAttribute("aria-expanded", open ? "true" : "false");
-      });
+      if (btn && menu) {
+        btn.addEventListener("click", function () {
+          var open = menu.classList.toggle("open");
+          btn.setAttribute("aria-expanded", open ? "true" : "false");
+        });
+      }
+
+      var key = "wslproxy.theme";
+      var themeBtn = document.getElementById("theme-toggle");
+      function applyTheme(t) {
+        document.documentElement.setAttribute("data-theme", t);
+        document.documentElement.classList.toggle("dark", t === "dark");
+        document.documentElement.style.colorScheme = t;
+        try { localStorage.setItem(key, t); } catch (e) {}
+        if (themeBtn) {
+          themeBtn.setAttribute(
+            "aria-label",
+            t === "dark" ? "Switch to light mode" : "Switch to dark mode"
+          );
+        }
+      }
+      if (themeBtn) {
+        themeBtn.addEventListener("click", function () {
+          var next = document.documentElement.classList.contains("dark") ? "light" : "dark";
+          applyTheme(next);
+        });
+      }
     })();
   </script>
 </body>

--- a/openresty-admin-next/src/app/globals.css
+++ b/openresty-admin-next/src/app/globals.css
@@ -2,29 +2,30 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Brand tokens aligned with the public landing page (html/index.html). */
 @theme {
-  --color-primary-50: #eef2ff;
-  --color-primary-100: #e0e7ff;
-  --color-primary-200: #c7d2fe;
-  --color-primary-300: #a5b4fc;
-  --color-primary-400: #818cf8;
-  --color-primary-500: #6366f1;
-  --color-primary-600: #4f46e5;
-  --color-primary-700: #4338ca;
-  --color-primary-800: #3730a3;
-  --color-primary-900: #312e81;
-  --color-primary-950: #1e1b4e;
+  --color-primary-50: #fdf4ef;
+  --color-primary-100: #fbe6d9;
+  --color-primary-200: #f5c9b0;
+  --color-primary-300: #eba67d;
+  --color-primary-400: #dc7d4a;
+  --color-primary-500: #c45c26;
+  --color-primary-600: #9a4519;
+  --color-primary-700: #7a3715;
+  --color-primary-800: #652f15;
+  --color-primary-900: #542914;
+  --color-primary-950: #2d1409;
 
-  --color-accent-50: #ecfdf5;
-  --color-accent-100: #d1fae5;
-  --color-accent-200: #a7f3d0;
-  --color-accent-300: #6ee7b7;
-  --color-accent-400: #34d399;
-  --color-accent-500: #10b981;
-  --color-accent-600: #059669;
-  --color-accent-700: #047857;
-  --color-accent-800: #065f46;
-  --color-accent-900: #064e3b;
+  --color-accent-50: #ecf8f6;
+  --color-accent-100: #d0efe9;
+  --color-accent-200: #a2ddd3;
+  --color-accent-300: #6bc4b5;
+  --color-accent-400: #3dbaa8;
+  --color-accent-500: #1a7a6d;
+  --color-accent-600: #156257;
+  --color-accent-700: #124e46;
+  --color-accent-800: #103f39;
+  --color-accent-900: #0e352f;
 
   --color-danger-50: #fef2f2;
   --color-danger-500: #ef4444;
@@ -35,46 +36,27 @@
   --color-warn-500: #f59e0b;
   --color-warn-600: #d97706;
 
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-sans: var(--font-outfit), "Outfit", ui-sans-serif, system-ui, sans-serif;
+  --font-display: var(--font-fraunces), "Fraunces", Georgia, serif;
+  --font-mono: var(--font-jetbrains), "JetBrains Mono", ui-monospace, monospace;
 
-  /* ── Typography scale tune-up ─────────────────────────────────────────
-     Lift the smallest text from 12px → 13px so eyebrow labels (sidebar
-     section headings, footer build-info labels, form field hints,
-     small badge text) stop straining the eye.  Body text stays at
-     14px (text-sm) which is the industry-standard admin density —
-     bumping that would feel "consumer app" instead of "operator
-     console".  text-sm and above are unchanged.
-     Line heights tuned together so the new size still snaps to the
-     8px vertical rhythm. */
-  --text-xs: 0.8125rem;        /* 13px (was 0.75rem / 12px) */
-  --text-xs--line-height: 1.125rem; /* 18px */
+  --text-xs: 0.8125rem;
+  --text-xs--line-height: 1.125rem;
 }
-
-/* ── Base resets ─────────────────────────────────────────────────────────── */
 
 html {
   @apply scroll-smooth antialiased;
 }
 
 body {
-  @apply bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100;
-
-  /* Inter's OpenType features that make it read like a polished
-     design system instead of the default Google Fonts look:
-       cv02 — clearer `1` (less ambiguous next to `l`/`I`)
-       cv03 — improved `4` (open shape, no closed counter)
-       cv04 — clearer `6` and `9`
-       cv11 — single-story `a` and `g` (design-system feel)
-       ss03 — cleaner numerals (matters for dashboards full of stats)
-       cv01 — alternate `l` (less ambiguous next to `1` and `I`)
-     Plus `tabular-nums` so numbers in tables, stats, badges, and
-     log timestamps align column-wise rather than wandering.  This is
-     usually the single biggest "professional" tell on an admin UI. */
-  font-feature-settings: "cv02", "cv03", "cv04", "cv11", "ss03", "cv01";
+  @apply bg-[#f7f9fc] text-[#0b1c2c] dark:bg-[#0b1c2c] dark:text-[#eef2f6];
+  font-family: var(--font-sans);
   font-variant-numeric: tabular-nums;
 }
 
-/* ── Scrollbar ───────────────────────────────────────────────────────────── */
+.font-display {
+  font-family: var(--font-display);
+}
 
 ::-webkit-scrollbar {
   @apply w-1.5;
@@ -86,8 +68,6 @@ body {
   @apply rounded-full bg-slate-300 dark:bg-slate-700;
 }
 
-/* ── Focus ring ──────────────────────────────────────────────────────────── */
-
 *:focus-visible {
-  @apply ring-2 ring-primary-500/50 ring-offset-2 ring-offset-white outline-none dark:ring-offset-slate-900;
+  @apply ring-2 ring-primary-500/50 ring-offset-2 ring-offset-[#f7f9fc] outline-none dark:ring-offset-[#0b1c2c];
 }

--- a/openresty-admin-next/src/app/layout.tsx
+++ b/openresty-admin-next/src/app/layout.tsx
@@ -1,18 +1,30 @@
 import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
-import { Inter } from "next/font/google";
+import { Fraunces, JetBrains_Mono, Outfit } from "next/font/google";
 import Providers from "./providers";
 import "./globals.css";
 
-const inter = Inter({
+const outfit = Outfit({
   subsets: ["latin"],
   display: "swap",
-  variable: "--font-inter",
+  variable: "--font-outfit",
 });
 
-const siteName = "WSL Proxy Admin";
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-fraunces",
+});
+
+const jetbrains = JetBrains_Mono({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-jetbrains",
+});
+
+const siteName = "WSLProxy Admin";
 const siteDescription =
-  "Administration dashboard for WSL Proxy — manage servers, rules, upstreams, WAF policies, SSL certificates, and more.";
+  "Administration dashboard for WSLProxy — manage servers, rules, upstreams, WAF policies, SSL certificates, and more.";
 
 export const metadata: Metadata = {
   title: {
@@ -51,8 +63,8 @@ export const viewport: Viewport = {
   maximumScale: 5,
   colorScheme: "light dark",
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#f8fafc" },
-    { media: "(prefers-color-scheme: dark)", color: "#0f172a" },
+    { media: "(prefers-color-scheme: light)", color: "#f7f9fc" },
+    { media: "(prefers-color-scheme: dark)", color: "#0b1c2c" },
   ],
 };
 
@@ -62,8 +74,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning className={inter.variable}>
-      <body className={inter.className}>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${outfit.variable} ${fraunces.variable} ${jetbrains.variable}`}
+    >
+      <body className="font-sans">
+        {/* Prevent theme FOUC — key must match STORAGE_KEYS.theme */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var k="wslproxy.theme";var t=localStorage.getItem(k);if(t!=="light"&&t!=="dark"){t=window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light"}document.documentElement.classList.toggle("dark",t==="dark");document.documentElement.style.colorScheme=t}catch(e){}})();`,
+          }}
+        />
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-lg focus:bg-primary-600 focus:px-4 focus:py-2 focus:text-sm focus:font-medium focus:text-white focus:shadow-lg focus:outline-none"
@@ -74,11 +96,11 @@ export default function RootLayout({
           <Suspense
             fallback={
               <div
-                className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950"
+                className="flex min-h-screen items-center justify-center bg-[#f7f9fc] dark:bg-[#0b1c2c]"
                 role="status"
                 aria-label="Loading"
               >
-                <div className="h-10 w-10 animate-spin rounded-full border-4 border-slate-200 border-t-primary-600 dark:border-slate-700 dark:border-t-primary-500" />
+                <div className="h-10 w-10 animate-spin rounded-full border-4 border-slate-200 border-t-primary-600 dark:border-slate-700 dark:border-t-primary-400" />
                 <span className="sr-only">Loading&hellip;</span>
               </div>
             }

--- a/openresty-admin-next/src/app/login/page.tsx
+++ b/openresty-admin-next/src/app/login/page.tsx
@@ -60,7 +60,7 @@ function SubmitButton() {
       type="submit"
       disabled={pending}
       aria-disabled={pending}
-      className="group relative flex w-full items-center justify-center gap-2 rounded-lg bg-linear-to-br from-primary-600 to-violet-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg shadow-primary-500/30 transition-all hover:from-primary-500 hover:to-violet-500 hover:shadow-primary-500/40 focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:from-slate-400 disabled:to-slate-400 disabled:opacity-70 disabled:shadow-none dark:focus-visible:ring-offset-slate-900"
+      className="group relative flex w-full items-center justify-center gap-2 rounded-lg bg-primary-600 px-4 py-2.5 text-sm font-semibold text-white shadow-lg shadow-primary-600/25 transition-all hover:bg-primary-500 hover:shadow-primary-500/35 focus-visible:ring-2 focus-visible:ring-primary-500/50 focus-visible:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:bg-slate-400 disabled:opacity-70 disabled:shadow-none dark:focus-visible:ring-offset-slate-900"
     >
       {pending ? (
         <>
@@ -156,8 +156,8 @@ export default function LoginPage() {
         aria-hidden="true"
         className="pointer-events-none fixed inset-0 z-0 overflow-hidden"
       >
-        <div className="absolute -top-32 -right-32 h-120 w-120 rounded-full bg-primary-500/15 blur-3xl dark:bg-primary-500/10" />
-        <div className="absolute -bottom-32 -left-32 h-105 w-105 rounded-full bg-emerald-500/10 blur-3xl dark:bg-emerald-500/10" />
+        <div className="absolute -top-32 -right-32 h-120 w-120 rounded-full bg-primary-500/15 blur-3xl dark:bg-primary-400/10" />
+        <div className="absolute -bottom-32 -left-32 h-105 w-105 rounded-full bg-accent-500/10 blur-3xl dark:bg-accent-400/10" />
       </div>
 
       {/* ── Theme toggle (top-right) ────────────────────────────────── */}
@@ -179,7 +179,7 @@ export default function LoginPage() {
               <div className="mb-6 flex justify-center">
                 <Logo width={200} height={44} variant="full" theme={theme} />
               </div>
-              <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+              <h1 className="font-display text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
                 Welcome back
               </h1>
               <p className="mt-1.5 text-sm text-slate-500 dark:text-slate-400">

--- a/openresty-admin-next/src/components/Logo.tsx
+++ b/openresty-admin-next/src/components/Logo.tsx
@@ -1,29 +1,6 @@
 import React from "react";
 
-/* ──────────────────────────────────────────────────────────────────────────
-   WSL Proxy Logo — TypeScript port of openresty-admin/src/component/Logo.jsx.
-
-   Two variants:
-     - "full"  (default)  shield + WSL Proxy wordmark + ADMIN pill (200×44)
-     - "icon"             shield only, square aspect for collapsed sidebar
-
-   Theme controls only the wordmark colour ("WSL" half).  The shield gradient
-   and accent ("Proxy" + ADMIN pill) are theme-invariant because the brand
-   purple/indigo holds contrast against both light and dark surfaces.
-
-   Gradient ID is intentionally STATIC (not `useId()`):
-     - The brand gradient is the same across every Logo instance, so a
-       per-instance unique ID has no visual purpose.
-     - `url(#id)` resolves to the first element with that ID in document
-       order; since each `<linearGradient>` definition we emit is
-       byte-identical, every Logo paints the same fill regardless of
-       which definition the browser happens to reach first.
-     - `useId()` can produce different counter values for the same
-       Logo across SSR vs. CSR when the component straddles a Suspense
-       streaming boundary (Sidebar + WelcomeBanner are an exact example),
-       producing a hydration mismatch on the `id` / `fill="url(#…)"`
-       attributes.  Static ID dodges that entirely.
-   ────────────────────────────────────────────────────────────────────────── */
+/* WSLProxy logo — copper brand aligned with the public landing page. */
 
 const GRADIENT_ID = "wslproxy-logo-gradient";
 
@@ -32,7 +9,6 @@ export interface LogoProps {
   height?: number;
   variant?: "full" | "icon";
   theme?: "light" | "dark";
-  /** Optional accessible name; defaults to "WSL Proxy". */
   title?: string;
   className?: string;
 }
@@ -42,12 +18,11 @@ const Logo: React.FC<LogoProps> = ({
   height = 40,
   variant = "full",
   theme = "dark",
-  title = "WSL Proxy",
+  title = "WSLProxy",
   className,
 }) => {
-  const wordmarkColor = theme === "dark" ? "#ffffff" : "#0f172a";
-  const accentColor = "#6366f1"; // Indigo-500 — matches Tailwind primary
-
+  const wordmarkColor = theme === "dark" ? "#eef2f6" : "#0b1c2c";
+  const accentColor = "#c45c26";
   const gradientId = GRADIENT_ID;
 
   if (variant === "icon") {
@@ -64,8 +39,8 @@ const Logo: React.FC<LogoProps> = ({
         <title>{title}</title>
         <defs>
           <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#6366f1" />
-            <stop offset="100%" stopColor="#8b5cf6" />
+            <stop offset="0%" stopColor="#c45c26" />
+            <stop offset="100%" stopColor="#1a7a6d" />
           </linearGradient>
         </defs>
         <path
@@ -100,11 +75,10 @@ const Logo: React.FC<LogoProps> = ({
       <title>{title}</title>
       <defs>
         <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#6366f1" />
-          <stop offset="100%" stopColor="#8b5cf6" />
+          <stop offset="0%" stopColor="#c45c26" />
+          <stop offset="100%" stopColor="#1a7a6d" />
         </linearGradient>
       </defs>
-      {/* Shield + network nodes (matches the icon variant scaled to 40px) */}
       <g transform="translate(2, 2)">
         <path
           d="M20 2L4 8v10c0 9 6.5 17 16 20 9.5-3 16-11 16-20V8L20 2z"
@@ -122,11 +96,10 @@ const Logo: React.FC<LogoProps> = ({
           opacity="0.7"
         />
       </g>
-      {/* Wordmark — "WSL" in theme colour, "Proxy" in brand accent */}
       <text
         x="48"
         y="28"
-        fontFamily="Inter, system-ui, -apple-system, sans-serif"
+        fontFamily="Fraunces, Georgia, serif"
         fontSize="20"
         fontWeight="700"
         fill={wordmarkColor}
@@ -137,15 +110,14 @@ const Logo: React.FC<LogoProps> = ({
       <text
         x="92"
         y="28"
-        fontFamily="Inter, system-ui, -apple-system, sans-serif"
+        fontFamily="Fraunces, Georgia, serif"
         fontSize="20"
-        fontWeight="400"
+        fontWeight="500"
         fill={accentColor}
         letterSpacing="-0.5"
       >
         Proxy
       </text>
-      {/* Admin pill — soft fill to keep visual weight on the wordmark */}
       <rect
         x="148"
         y="12"
@@ -153,12 +125,12 @@ const Logo: React.FC<LogoProps> = ({
         height="20"
         rx="4"
         fill={`url(#${gradientId})`}
-        opacity="0.15"
+        opacity="0.18"
       />
       <text
         x="172"
         y="26"
-        fontFamily="Inter, system-ui, -apple-system, sans-serif"
+        fontFamily="Outfit, system-ui, sans-serif"
         fontSize="10"
         fontWeight="600"
         fill={accentColor}

--- a/openresty-admin-next/src/components/ui/PageHeader.tsx
+++ b/openresty-admin-next/src/components/ui/PageHeader.tsx
@@ -76,7 +76,7 @@ const PageHeader: React.FC<PageHeaderProps> = ({
           </div>
         )}
         <div className="min-w-0 flex-1">
-          <h1 className="truncate text-xl font-bold text-slate-900 dark:text-slate-100 sm:text-2xl">
+          <h1 className="font-display truncate text-xl font-bold tracking-tight text-slate-900 dark:text-slate-100 sm:text-2xl">
             {title}
           </h1>
           {subtitle && (

--- a/openresty-admin-next/src/contexts/ThemeContext.tsx
+++ b/openresty-admin-next/src/contexts/ThemeContext.tsx
@@ -44,6 +44,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // Sync class whenever theme changes
   useEffect(() => {
     document.documentElement.classList.toggle("dark", theme === "dark");
+    document.documentElement.style.colorScheme = theme;
     set(STORAGE_KEYS.theme, theme);
   }, [theme]);
 


### PR DESCRIPTION
## Summary
- Next.js dashboard: Outfit + Fraunces + JetBrains Mono, copper/signal palette (replacing indigo/Inter)
- Logo, login, PageHeader titles updated to match landing brand
- Landing page: dark mode tokens + nav theme toggle
- Shared `localStorage` key `wslproxy.theme` so landing and dashboard stay in sync
- FOUC-safe theme bootstrap on both surfaces

## Test plan
- [ ] Open `html/index.html` — toggle light/dark; preference persists on reload
- [ ] Next.js login + AppBar theme toggle; fonts/copper accents visible
- [ ] After Pages deploy, https://wslproxy.org/ theme toggle works
- [ ] Dashboard dark mode on existing pages (sidebar, tables) still readable


Made with [Cursor](https://cursor.com)