### PR TITLE
Polish Next.js admin for easier reading

### DIFF
--- a/openresty-admin-next/src/app/(dashboard)/layout.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/layout.tsx
@@ -29,7 +29,7 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
   }, []);
 
   return (
-    <div className="flex min-h-screen bg-slate-50 dark:bg-slate-950">
+    <div className="flex min-h-screen bg-[#f7f9fc] dark:bg-[#0b1c2c]">
       <RouteFocusReset />
       <Sidebar collapsed={sidebarCollapsed} onToggle={toggleSidebar} />
 

--- a/openresty-admin-next/src/app/globals.css
+++ b/openresty-admin-next/src/app/globals.css
@@ -40,8 +40,11 @@
   --font-display: var(--font-fraunces), "Fraunces", Georgia, serif;
   --font-mono: var(--font-jetbrains), "JetBrains Mono", ui-monospace, monospace;
 
+  /* Slightly larger floor so labels and table chrome stay readable */
   --text-xs: 0.8125rem;
-  --text-xs--line-height: 1.125rem;
+  --text-xs--line-height: 1.25rem;
+  --text-sm: 0.9375rem; /* 15px */
+  --text-sm--line-height: 1.4rem;
 }
 
 html {
@@ -51,11 +54,21 @@ html {
 body {
   @apply bg-[#f7f9fc] text-[#0b1c2c] dark:bg-[#0b1c2c] dark:text-[#eef2f6];
   font-family: var(--font-sans);
+  font-size: 0.9375rem;
+  line-height: 1.55;
   font-variant-numeric: tabular-nums;
 }
 
 .font-display {
   font-family: var(--font-display);
+}
+
+/* Readable muted text — prefer these over raw slate-400 in new code */
+.text-muted {
+  @apply text-slate-600 dark:text-slate-300;
+}
+.text-subtle {
+  @apply text-slate-500 dark:text-slate-400;
 }
 
 ::-webkit-scrollbar {

--- a/openresty-admin-next/src/app/login/page.tsx
+++ b/openresty-admin-next/src/app/login/page.tsx
@@ -204,7 +204,7 @@ export default function LoginPage() {
               <div>
                 <label
                   htmlFor="email"
-                  className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-400"
+                  className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300"
                 >
                   Email address
                 </label>
@@ -224,7 +224,7 @@ export default function LoginPage() {
               <div>
                 <label
                   htmlFor="password"
-                  className="mb-1.5 block text-xs font-semibold uppercase tracking-wider text-slate-600 dark:text-slate-400"
+                  className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300"
                 >
                   Password
                 </label>

--- a/openresty-admin-next/src/components/dashboard/DashboardTabs.tsx
+++ b/openresty-admin-next/src/components/dashboard/DashboardTabs.tsx
@@ -67,7 +67,7 @@ const DashboardTabs: React.FC<DashboardTabsProps> = ({
                 "flex items-center gap-2 px-4 py-3 text-sm font-medium whitespace-nowrap transition-colors border-b-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/30 focus-visible:ring-offset-2",
                 isActive
                   ? "border-primary-500 text-primary-600 dark:text-primary-400"
-                  : "border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300 hover:border-slate-300 dark:hover:border-slate-600"
+                  : "border-transparent text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-slate-100 hover:border-slate-300 dark:hover:border-slate-600"
               )}
               onClick={() => handleTabClick(index)}
             >

--- a/openresty-admin-next/src/components/dashboard/LogsSection.tsx
+++ b/openresty-admin-next/src/components/dashboard/LogsSection.tsx
@@ -104,7 +104,7 @@ const LogCard = React.memo(function LogCard({
         </div>
         <Link
           href={expandHref}
-          className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-medium text-slate-500 transition-colors hover:border-slate-300 hover:text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-600 dark:hover:text-slate-200"
+          className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2.5 py-1 text-xs font-medium text-slate-700 transition-colors hover:border-slate-300 hover:text-slate-900 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:border-slate-600 dark:hover:text-slate-100"
           aria-label={`Expand ${title} in full-screen viewer`}
           title="Expand + search (server-side grep)"
         >
@@ -118,7 +118,7 @@ const LogCard = React.memo(function LogCard({
             <Skeleton variant="rectangular" className="h-48 w-full" />
           </div>
         ) : hasContent ? (
-          <pre className="max-h-96 overflow-auto bg-slate-950 p-4 font-mono text-[11px] leading-relaxed text-slate-300">
+          <pre className="max-h-96 overflow-auto bg-slate-950 p-4 font-mono text-xs leading-relaxed text-slate-200">
             {content}
           </pre>
         ) : (

--- a/openresty-admin-next/src/components/dashboard/RecentBookmarks.tsx
+++ b/openresty-admin-next/src/components/dashboard/RecentBookmarks.tsx
@@ -124,7 +124,7 @@ const BookmarkRow = React.memo(function BookmarkRow({
           </p>
         </div>
         {bookmark.host && (
-          <p className="truncate font-mono text-xs text-slate-400 dark:text-slate-500">
+          <p className="truncate font-mono text-xs text-slate-600 dark:text-slate-300">
             {bookmark.host}
           </p>
         )}
@@ -132,7 +132,7 @@ const BookmarkRow = React.memo(function BookmarkRow({
       {bookmark.category && (
         <span
           className={cn(
-            "shrink-0 rounded-full px-2 py-0.5 text-[11px] font-semibold",
+            "shrink-0 rounded-full px-2 py-0.5 text-xs font-semibold",
             accent.pill,
           )}
         >

--- a/openresty-admin-next/src/components/dashboard/TopDomainsChart.tsx
+++ b/openresty-admin-next/src/components/dashboard/TopDomainsChart.tsx
@@ -66,7 +66,7 @@ const TopDomainsChart: React.FC<TopDomainsChartProps> = ({
           </h3>
         </div>
         {total > 0 && (
-          <span className="text-xs text-slate-500 dark:text-slate-400">
+          <span className="text-sm text-slate-600 dark:text-slate-300">
             {formatNumber(total)} total
           </span>
         )}
@@ -135,7 +135,7 @@ const DomainRow = React.memo(function DomainRow({
           >
             {domain}
           </span>
-          <span className="shrink-0 text-[11px] font-mono tabular-nums text-slate-500 dark:text-slate-400">
+          <span className="shrink-0 font-mono text-xs tabular-nums text-slate-600 dark:text-slate-300">
             {formatNumber(requests)}
           </span>
         </div>

--- a/openresty-admin-next/src/components/dashboard/TrafficStatsCards.tsx
+++ b/openresty-admin-next/src/components/dashboard/TrafficStatsCards.tsx
@@ -185,12 +185,12 @@ function TrendBadge({ pct }: { pct: number }) {
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-semibold tabular-nums",
+        "inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-xs font-semibold tabular-nums",
         tone,
       )}
       title={`${label} vs previous period`}
     >
-      <Icon className="h-2.5 w-2.5" aria-hidden="true" />
+      <Icon className="h-3 w-3" aria-hidden="true" />
       {label}
     </span>
   );
@@ -251,7 +251,7 @@ const SingleStatCard = React.memo(function SingleStatCard({
               {value}
             </p>
           )}
-          <p className="truncate text-xs font-medium text-slate-500 dark:text-slate-400">
+          <p className="truncate text-sm font-medium text-slate-600 dark:text-slate-300">
             {def.label}
           </p>
         </div>

--- a/openresty-admin-next/src/components/dashboard/WelcomeBanner.tsx
+++ b/openresty-admin-next/src/components/dashboard/WelcomeBanner.tsx
@@ -65,15 +65,15 @@ const WelcomeBanner = memo(function WelcomeBanner({ info }: WelcomeBannerProps) 
             <div className="mb-4">
               <Logo variant="full" width={210} height={44} theme="dark" />
             </div>
-            <span className="mb-3 inline-block rounded-full bg-white/20 px-3 py-1 text-xs font-medium backdrop-blur-sm">
-              Admin Portal
+            <span className="mb-3 inline-block rounded-md bg-white/20 px-3 py-1 text-sm font-medium backdrop-blur-sm">
+              Admin portal
             </span>
-            <h1 className="mb-2 text-3xl font-bold">Welcome to the WSL Proxy</h1>
-            <p className="mb-6 max-w-xl text-primary-100/90">
-              Strengthen your website&apos;s defenses with this comprehensive CDN
-              security platform. Effortlessly provision new servers and assign
-              tailored security rules to build a robust, multi-layered protection
-              strategy.
+            <h1 className="font-display mb-2 text-3xl font-bold tracking-tight sm:text-4xl">
+              Welcome to WSLProxy
+            </h1>
+            <p className="mb-6 max-w-xl text-base leading-relaxed text-primary-50/95">
+              Manage virtual hosts, live routing rules, WAF, and traffic from one
+              place — changes take effect without reloading nginx for every rule.
             </p>
             <div className="flex flex-wrap gap-3">
               <button
@@ -102,8 +102,8 @@ const WelcomeBanner = memo(function WelcomeBanner({ info }: WelcomeBannerProps) 
       <div>
         <Card className="h-full">
           <Card.Header>
-            <h2 className="text-xs font-bold uppercase tracking-wider text-slate-400">
-              Instance Info
+            <h2 className="font-display text-base font-semibold text-slate-800 dark:text-slate-100">
+              Instance info
             </h2>
           </Card.Header>
           <Card.Body>
@@ -161,7 +161,7 @@ const WelcomeBanner = memo(function WelcomeBanner({ info }: WelcomeBannerProps) 
                 />
               </div>
             ) : (
-              <p className="text-sm text-slate-400">Instance info unavailable</p>
+              <p className="text-sm text-slate-600 dark:text-slate-300">Instance info unavailable</p>
             )}
             <button
               // `/health` is the Lua JSON probe endpoint.  Nginx uses
@@ -194,8 +194,8 @@ const InfoRow = memo(function InfoRow({
     <div className="flex items-start gap-3">
       <div className="mt-0.5">{icon}</div>
       <div className="min-w-0 flex-1">
-        <p className="text-xs font-medium text-slate-400 dark:text-slate-500">{label}</p>
-        <div className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+        <p className="text-sm font-medium text-slate-600 dark:text-slate-300">{label}</p>
+        <div className="text-sm font-semibold text-slate-900 dark:text-slate-50">
           {value}
         </div>
       </div>

--- a/openresty-admin-next/src/components/layout/AppBar.tsx
+++ b/openresty-admin-next/src/components/layout/AppBar.tsx
@@ -37,7 +37,7 @@ export default function AppBar({ sidebarCollapsed }: AppBarProps) {
     // bump, equal z-index → DOM order wins → the page header covers
     // dropdowns that open from this AppBar (env switcher, user menu)
     // the moment you're on a page that has its own sticky header.
-    <header className="sticky top-0 z-30 flex h-16 items-center justify-between border-b border-slate-200 bg-white px-6 dark:border-slate-800 dark:bg-slate-900">
+    <header className="sticky top-0 z-30 flex h-16 items-center justify-between border-b border-slate-200 bg-white/95 px-6 backdrop-blur-sm dark:border-slate-700 dark:bg-[#122233]/95">
       {/* Left side - breadcrumb placeholder */}
       <div className="text-sm text-slate-500 dark:text-slate-400" />
 

--- a/openresty-admin-next/src/components/layout/ProfileSwitcher.tsx
+++ b/openresty-admin-next/src/components/layout/ProfileSwitcher.tsx
@@ -159,7 +159,7 @@ export default function ProfileSwitcher() {
         )}
       >
         <Layers className="h-4 w-4 text-slate-400" aria-hidden="true" />
-        <span className="font-mono text-xs uppercase tracking-wide">{profile}</span>
+        <span className="font-mono text-sm font-semibold uppercase tracking-wide">{profile}</span>
         <ChevronDown
           className={cn(
             "h-3.5 w-3.5 text-slate-400 transition-transform",

--- a/openresty-admin-next/src/components/layout/Sidebar.tsx
+++ b/openresty-admin-next/src/components/layout/Sidebar.tsx
@@ -143,7 +143,7 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
   return (
     <aside
       className={cn(
-        "fixed left-0 top-0 z-30 flex h-screen flex-col border-r border-slate-200 bg-white transition-all duration-300 dark:border-slate-800 dark:bg-slate-900",
+        "fixed left-0 top-0 z-30 flex h-screen flex-col border-r border-slate-200 bg-white transition-all duration-300 dark:border-slate-700 dark:bg-[#122233]",
         collapsed ? "w-[72px]" : "w-64",
       )}
     >
@@ -195,7 +195,7 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
             {!collapsed && (
               <p
                 className={cn(
-                  "mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-slate-400",
+                  "mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400",
                   sIdx > 0 ? "mt-6" : "mt-0",
                 )}
               >
@@ -215,17 +215,19 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
                       href={item.href}
                       title={collapsed ? item.label : undefined}
                       className={cn(
-                        "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors",
+                        "flex items-center gap-3 rounded-lg px-3 py-2.5 text-[0.9375rem] font-medium transition-colors",
                         active
-                          ? "border-l-2 border-primary-500 bg-primary-50 text-primary-700 dark:bg-primary-900/20 dark:text-primary-300"
-                          : "text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800",
+                          ? "border-l-2 border-primary-500 bg-primary-50 text-primary-800 dark:bg-primary-900/30 dark:text-primary-200"
+                          : "text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800/80",
                         collapsed && "justify-center px-0",
                       )}
                     >
                       <Icon
                         className={cn(
                           "h-5 w-5 shrink-0",
-                          active && "text-primary-600 dark:text-primary-400",
+                          active
+                            ? "text-primary-600 dark:text-primary-300"
+                            : "text-slate-500 dark:text-slate-400",
                         )}
                       />
                       {!collapsed && <span>{item.label}</span>}
@@ -241,7 +243,7 @@ export default function Sidebar({ collapsed, onToggle }: SidebarProps) {
       {/* Version footer */}
       {!collapsed && (
         <div className="border-t border-slate-200 px-4 py-3 dark:border-slate-800">
-          <p className="text-xs text-slate-400">
+          <p className="text-xs text-slate-500 dark:text-slate-400">
             v{env.appVersion} &middot; Build {env.buildNumber}
           </p>
         </div>

--- a/openresty-admin-next/src/components/ui/Badge.tsx
+++ b/openresty-admin-next/src/components/ui/Badge.tsx
@@ -10,20 +10,20 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 
 const variantStyles: Record<NonNullable<BadgeProps["variant"]>, string> = {
   default:
-    "bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300",
+    "bg-slate-100 text-slate-800 dark:bg-slate-700 dark:text-slate-100",
   primary:
-    "bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400",
+    "bg-primary-100 text-primary-800 dark:bg-primary-900/40 dark:text-primary-200",
   success:
-    "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400",
+    "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200",
   warning:
-    "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400",
-  danger: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
-  info: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+    "bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200",
+  danger: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200",
+  info: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200",
 };
 
 const sizeStyles: Record<NonNullable<BadgeProps["size"]>, string> = {
-  sm: "px-2 py-0.5 text-xs",
-  md: "px-2.5 py-0.5 text-sm",
+  sm: "px-2 py-0.5 text-xs leading-snug",
+  md: "px-2.5 py-1 text-sm leading-snug",
 };
 
 const Badge = React.memo(

--- a/openresty-admin-next/src/components/ui/Button.tsx
+++ b/openresty-admin-next/src/components/ui/Button.tsx
@@ -20,7 +20,7 @@ const variantStyles: Record<NonNullable<ButtonProps["variant"]>, string> = {
   danger:
     "bg-danger-600 text-white hover:bg-danger-700 active:bg-danger-800 focus-visible:ring-danger-500/30",
   ghost:
-    "bg-transparent text-slate-700 hover:bg-slate-100 active:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800 dark:active:bg-slate-700 focus-visible:ring-slate-500/30",
+    "bg-transparent text-slate-800 hover:bg-slate-100 active:bg-slate-200 dark:text-slate-100 dark:hover:bg-slate-800 dark:active:bg-slate-700 focus-visible:ring-slate-500/30",
 };
 
 const sizeStyles: Record<NonNullable<ButtonProps["size"]>, string> = {

--- a/openresty-admin-next/src/components/ui/Card.tsx
+++ b/openresty-admin-next/src/components/ui/Card.tsx
@@ -11,7 +11,7 @@ const CardRoot = React.forwardRef<HTMLDivElement, CardProps>(
     <div
       ref={ref}
       className={cn(
-        "bg-white dark:bg-slate-900 rounded-xl border border-slate-200 dark:border-slate-800 shadow-sm",
+        "rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700 dark:bg-[#122233]",
         className
       )}
       {...rest}
@@ -27,7 +27,7 @@ const Header = React.forwardRef<HTMLDivElement, CardSectionProps>(
     <div
       ref={ref}
       className={cn(
-        "flex justify-between items-center px-6 py-4 border-b border-slate-200 dark:border-slate-800",
+        "flex items-center justify-between border-b border-slate-200 px-6 py-4 dark:border-slate-700",
         className
       )}
       {...rest}
@@ -52,7 +52,7 @@ const Footer = React.forwardRef<HTMLDivElement, CardSectionProps>(
     <div
       ref={ref}
       className={cn(
-        "px-6 py-4 border-t border-slate-200 dark:border-slate-800",
+        "border-t border-slate-200 px-6 py-4 dark:border-slate-700",
         className
       )}
       {...rest}

--- a/openresty-admin-next/src/components/ui/DataTable.tsx
+++ b/openresty-admin-next/src/components/ui/DataTable.tsx
@@ -209,7 +209,7 @@ const TableRowInner = <T,>({
         <td
           key={col.field}
           className={cn(
-            "px-4 py-3 text-sm text-slate-700 dark:text-slate-300",
+            "px-4 py-3.5 text-sm text-slate-900 dark:text-slate-100",
             col.className
           )}
           style={col.width ? { width: col.width } : undefined}
@@ -401,7 +401,7 @@ function DataTableInner<T>({
                 <th
                   key={col.field}
                   className={cn(
-                    "px-4 py-3 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400",
+                    "px-4 py-3.5 text-sm font-semibold tracking-normal text-slate-700 dark:text-slate-200",
                     col.sortable && onSort && "cursor-pointer select-none",
                     col.className
                   )}

--- a/openresty-admin-next/src/components/ui/EmptyState.tsx
+++ b/openresty-admin-next/src/components/ui/EmptyState.tsx
@@ -28,15 +28,15 @@ const EmptyState: React.FC<EmptyStateProps> = ({
   >
     <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-slate-100 dark:bg-slate-800">
       <Icon
-        className="h-8 w-8 text-slate-400 dark:text-slate-500"
+        className="h-8 w-8 text-slate-600 dark:text-slate-300"
         aria-hidden="true"
       />
     </div>
-    <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+    <h3 className="font-display text-lg font-semibold text-slate-900 dark:text-slate-50">
       {title}
     </h3>
     {description && (
-      <p className="mt-1 max-w-sm text-sm text-slate-500 dark:text-slate-400">
+      <p className="mt-1.5 max-w-sm text-sm leading-relaxed text-slate-600 dark:text-slate-300">
         {description}
       </p>
     )}

--- a/openresty-admin-next/src/components/ui/Input.tsx
+++ b/openresty-admin-next/src/components/ui/Input.tsx
@@ -30,9 +30,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           ref={ref}
           id={inputId}
           className={cn(
-            "block w-full rounded-lg border px-3 py-2 text-sm",
-            "bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100",
-            "placeholder:text-slate-400 dark:placeholder:text-slate-500",
+            "block w-full rounded-lg border px-3 py-2.5 text-sm leading-normal",
+            "bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100",
+            "placeholder:text-slate-500 dark:placeholder:text-slate-400",
             "transition-colors",
             "focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500",
             error
@@ -53,7 +53,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           </p>
         )}
         {hint && !error && (
-          <p id={hintId} className="text-sm text-slate-500 dark:text-slate-400">
+          <p id={hintId} className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
             {hint}
           </p>
         )}

--- a/openresty-admin-next/src/components/ui/PageHeader.tsx
+++ b/openresty-admin-next/src/components/ui/PageHeader.tsx
@@ -76,11 +76,11 @@ const PageHeader: React.FC<PageHeaderProps> = ({
           </div>
         )}
         <div className="min-w-0 flex-1">
-          <h1 className="font-display truncate text-xl font-bold tracking-tight text-slate-900 dark:text-slate-100 sm:text-2xl">
+          <h1 className="font-display truncate text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-50 sm:text-[1.75rem]">
             {title}
           </h1>
           {subtitle && (
-            <p className="mt-0.5 truncate text-sm text-slate-500 dark:text-slate-400">
+            <p className="mt-1 line-clamp-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
               {subtitle}
             </p>
           )}

--- a/openresty-admin-next/src/components/ui/Select.tsx
+++ b/openresty-admin-next/src/components/ui/Select.tsx
@@ -42,8 +42,8 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
             ref={ref}
             id={selectId}
             className={cn(
-              "block w-full appearance-none rounded-lg border px-3 py-2 pr-10 text-sm",
-              "bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100",
+              "block w-full appearance-none rounded-lg border px-3 py-2.5 pr-10 text-sm leading-normal",
+              "bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100",
               "transition-colors",
               "focus:outline-none focus:ring-2 focus:ring-primary-500/20 focus:border-primary-500",
               error
@@ -80,7 +80,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
           </p>
         )}
         {hint && !error && (
-          <p id={hintId} className="text-sm text-slate-500 dark:text-slate-400">
+          <p id={hintId} className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
             {hint}
           </p>
         )}


### PR DESCRIPTION
## Summary
- Shared UI: DataTable headers (sentence case, stronger contrast), badges, inputs, cards, page headers, empty states
- Shell: sidebar/nav and AppBar contrast; profile chip larger
- Home: clearer welcome copy, readable instance labels, trend badges ≥12px
- Login labels match form fields (no tiny all-caps)
- Legacy `openresty-admin` unchanged

## Test plan
- [ ] Dashboard home — welcome + stats + instance info readable in light/dark
- [ ] Servers/rules lists — table headers and cells easy to scan
- [ ] Login form labels look like normal form labels
- [ ] Sidebar nav inactive text clear on dark theme


Made with [Cursor](https://cursor.com)