### PR TITLE
fix(next): Textarea hint contrast

### DIFF
--- a/openresty-admin-next/src/components/ui/Textarea.tsx
+++ b/openresty-admin-next/src/components/ui/Textarea.tsx
@@ -54,7 +54,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           </p>
         )}
         {hint && !error && (
-          <p id={hintId} className="text-sm text-slate-500 dark:text-slate-400">
+          <p id={hintId} className="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
             {hint}
           </p>
         )}


### PR DESCRIPTION
## Summary
- Align Textarea helper text contrast with the Input/Select readability polish

## Test plan
- [ ] Form fields with Textarea hints readable in light/dark


Made with [Cursor](https://cursor.com)