### PR TITLE
Polish Next.js screens for easier reading

### DIFF
--- a/openresty-admin-next/src/app/(dashboard)/logs/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/logs/page.tsx
@@ -82,10 +82,10 @@ const QuickStat = React.memo(function QuickStat({
 }) {
   return (
     <div className={cn("flex items-center gap-3 rounded-xl border-l-4 bg-white px-4 py-3 dark:bg-slate-800", color)}>
-      <Icon className="h-5 w-5 text-slate-400" />
+      <Icon className="h-5 w-5 text-slate-500 dark:text-slate-400" />
       <div>
         <p className="text-lg font-bold text-slate-900 dark:text-slate-100">{value}</p>
-        <p className="text-xs text-slate-500 dark:text-slate-400">{label}</p>
+        <p className="text-sm text-slate-600 dark:text-slate-300">{label}</p>
       </div>
     </div>
   );
@@ -353,7 +353,7 @@ export default function LogsPage() {
           <QuickStat icon={Activity} label="Requests (24h)" value={quickStats.totalRequests.toLocaleString()} color="border-l-blue-500" />
           <QuickStat icon={AlertCircle} label="Errors (24h)" value={quickStats.errorCount.toLocaleString()} color="border-l-red-500" />
           <QuickStat icon={Clock} label="Avg Latency" value={quickStats.avgLatency > 0 ? `${quickStats.avgLatency.toFixed(1)}ms` : "—"} color="border-l-amber-500" />
-          <QuickStat icon={TrendingUp} label="P95 Latency" value={quickStats.p95Latency > 0 ? `${quickStats.p95Latency.toFixed(1)}ms` : "—"} color="border-l-purple-500" />
+          <QuickStat icon={TrendingUp} label="P95 Latency" value={quickStats.p95Latency > 0 ? `${quickStats.p95Latency.toFixed(1)}ms` : "—"} color="border-l-primary-500" />
         </div>
       )}
 

--- a/openresty-admin-next/src/app/(dashboard)/rules/[id]/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/rules/[id]/page.tsx
@@ -221,17 +221,17 @@ function Subsection({
               {icon}
             </span>
           )}
-          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+          <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
             {title}
           </h3>
           {optional && (
-            <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-slate-600 dark:bg-slate-700 dark:text-slate-300">
+            <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-700 dark:text-slate-300">
               Optional
             </span>
           )}
         </div>
         {intro && (
-          <p className="mt-1.5 text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+          <p className="mt-1.5 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
             {intro}
           </p>
         )}
@@ -707,7 +707,7 @@ export default function RuleDetailPage() {
         <Card.Header>
           <div>
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Basic Rule Information</h2>
-            <p className="text-sm text-slate-500">Configure the rule name, profile, and metadata</p>
+            <p className="text-sm text-slate-600 dark:text-slate-300">Configure the rule name, profile, and metadata</p>
           </div>
         </Card.Header>
         <Card.Body>
@@ -779,7 +779,7 @@ export default function RuleDetailPage() {
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               Match rules
             </h2>
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-slate-600 dark:text-slate-300">
               When should this rule fire?  Configure one or more conditions
               below — the rule only runs when <em>every</em> condition you
               set matches the incoming request.
@@ -849,7 +849,7 @@ export default function RuleDetailPage() {
                   selects a country.  Same logic in "Restrict by client
                   IP" below. */}
               {form.country === "EU" && (
-                <div className="col-span-full rounded-lg bg-blue-50 p-3 text-xs text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
+                <div className="col-span-full rounded-lg bg-blue-50 p-3 text-sm leading-relaxed text-blue-800 dark:bg-blue-900/20 dark:text-blue-200">
                   “EU” expands to: AT, BE, BG, HR, CY, CZ, DK, EE, FI, FR,
                   DE, GR, HU, IE, IT, LV, LT, LU, MT, NL, PL, PT, RO, SK,
                   SI, ES, SE.
@@ -989,7 +989,7 @@ export default function RuleDetailPage() {
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               Response
             </h2>
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-slate-600 dark:text-slate-300">
               What should wslproxy do with the request when this rule matches?
             </p>
           </div>
@@ -1116,7 +1116,7 @@ export default function RuleDetailPage() {
           <Card.Header>
             <div>
               <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Traffic Splitting</h2>
-              <p className="text-sm text-slate-500">Configure multi-backend routing for canary releases, A/B testing, or weighted load balancing</p>
+              <p className="text-sm text-slate-600 dark:text-slate-300">Configure multi-backend routing for canary releases, A/B testing, or weighted load balancing</p>
             </div>
           </Card.Header>
           <Card.Body>

--- a/openresty-admin-next/src/app/(dashboard)/rules/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/rules/page.tsx
@@ -72,7 +72,7 @@ export default function RulesListPage() {
         field: "match.rules.path",
         label: "Path",
         render: (r) => (
-          <span className="font-mono text-xs">
+          <span className="font-mono text-sm text-slate-700 dark:text-slate-300">
             {r.match?.rules?.path ?? "-"}
           </span>
         ),

--- a/openresty-admin-next/src/app/(dashboard)/servers/page.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/servers/page.tsx
@@ -111,7 +111,9 @@ export default function ServersListPage() {
           const ids = Array.isArray(r.pop_ids) ? r.pop_ids : [];
           if (ids.length === 0) {
             return (
-              <span className="text-xs text-slate-400">profile default</span>
+              <span className="text-sm text-slate-600 dark:text-slate-400">
+                profile default
+              </span>
             );
           }
           const visible = ids.slice(0, 3);

--- a/openresty-admin-next/src/app/(dashboard)/settings/SettingsPanels.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/settings/SettingsPanels.tsx
@@ -53,7 +53,7 @@ export default async function SettingsPanels() {
           <dl className="divide-y divide-slate-100 dark:divide-slate-800">
             {entries.map(([label, value]) => (
               <div key={label} className="flex justify-between py-3">
-                <dt className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                <dt className="text-sm font-medium text-slate-600 dark:text-slate-300">
                   {label}
                 </dt>
                 <dd className="text-sm text-slate-900 dark:text-slate-100">
@@ -76,7 +76,7 @@ export default async function SettingsPanels() {
             <dl className="divide-y divide-slate-100 dark:divide-slate-800">
               {envVars.map(([key, val]) => (
                 <div key={key} className="flex justify-between py-3">
-                  <dt className="font-mono text-xs text-slate-500 dark:text-slate-400">
+                  <dt className="font-mono text-sm text-slate-600 dark:text-slate-300">
                     {key}
                   </dt>
                   <dd className="text-sm text-slate-900 dark:text-slate-100">

--- a/openresty-admin-next/src/app/(dashboard)/system-status/HealthPanels.tsx
+++ b/openresty-admin-next/src/app/(dashboard)/system-status/HealthPanels.tsx
@@ -107,9 +107,9 @@ function StatusBadge({ tone, label }: { tone: StatusTone; label: string }) {
   const s = STATUS_STYLES[tone];
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold ${s.bg} ${s.text}`}
+      className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-semibold ${s.bg} ${s.text}`}
     >
-      <s.Icon className="h-3 w-3" aria-hidden="true" />
+      <s.Icon className="h-3.5 w-3.5" aria-hidden="true" />
       {label}
     </span>
   );
@@ -125,11 +125,11 @@ function DefRow({
   mono?: boolean;
 }) {
   return (
-    <div className="flex items-start justify-between gap-4 border-b border-slate-100 py-1.5 text-sm last:border-b-0 dark:border-slate-800">
-      <span className="text-slate-500 dark:text-slate-400">{label}</span>
+    <div className="flex items-start justify-between gap-4 border-b border-slate-100 py-2 text-sm last:border-b-0 dark:border-slate-800">
+      <span className="text-slate-600 dark:text-slate-300">{label}</span>
       <span
-        className={`text-right font-medium text-slate-800 dark:text-slate-200 ${
-          mono ? "font-mono text-[12px]" : ""
+        className={`text-right font-medium text-slate-900 dark:text-slate-100 ${
+          mono ? "font-mono text-sm" : ""
         }`}
       >
         {children}
@@ -177,8 +177,8 @@ function PanelCard({
     <Card>
       <CardHeader>
         <div className="flex min-w-0 items-center gap-2">
-          <Icon className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
-          <h2 className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+          <Icon className="h-4 w-4 shrink-0 text-slate-500 dark:text-slate-400" aria-hidden="true" />
+          <h2 className="truncate text-base font-semibold text-slate-900 dark:text-slate-100">
             {title}
           </h2>
         </div>
@@ -217,7 +217,7 @@ function OverallBanner({ bundle }: { bundle: HealthBundle }) {
         <s.Icon className="h-5 w-5" aria-hidden="true" />
       </div>
       <div className="min-w-0 flex-1">
-        <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        <p className="text-sm font-medium text-slate-600 dark:text-slate-300">
           System Status
         </p>
         <p className={`text-lg font-bold ${s.text}`}>{label}</p>
@@ -265,7 +265,7 @@ function ServicesPanel({ health }: { health: HealthData }) {
         <DefRow label="OpenResty">
           <span className="inline-flex items-center gap-2">
             <StatusBadge tone={openrestyTone} label={s?.openresty?.status ?? "unknown"} />
-            <span className="font-mono text-[12px]">
+            <span className="font-mono text-sm">
               <Empty value={s?.openresty?.version} />
             </span>
           </span>
@@ -334,12 +334,12 @@ function ApiHealthPanel({ bundle }: { bundle: HealthBundle }) {
           />
         </DefRow>
         <DefRow label="Storage Type">
-          <span className="font-mono text-[12px] uppercase">
+          <span className="font-mono text-sm">
             <Empty value={bundle.health.settings?.storage_type ?? bundle.health.system?.storage_type} />
           </span>
         </DefRow>
         <DefRow label="Env Profile">
-          <span className="font-mono text-[12px] uppercase">
+          <span className="font-mono text-sm">
             <Empty value={bundle.health.settings?.env_profile ?? bundle.health.system?.env_profile} />
           </span>
         </DefRow>
@@ -458,7 +458,7 @@ function BuildVersionPanel({ health }: { health: HealthData }) {
           <Empty value={sys?.deployment_time ?? clientEnv.deploymentTime} />
         </DefRow>
         <DefRow label="Platform">
-          <span className="font-mono text-[12px] uppercase">
+          <span className="font-mono text-sm">
             <Empty value={clientEnv.targetPlatform} />
           </span>
         </DefRow>
@@ -513,7 +513,7 @@ function SettingsValidationPanel({ health }: { health: HealthData }) {
       </dl>
       {s?.missing_keys && s.missing_keys.length > 0 && (
         <div className="mt-3">
-          <p className="mb-1.5 text-xs font-medium text-slate-500 dark:text-slate-400">
+          <p className="mb-1.5 text-sm font-medium text-slate-600 dark:text-slate-300">
             Missing Keys
           </p>
           <div className="flex flex-wrap gap-1.5">
@@ -560,7 +560,7 @@ function FrontendEnvPanel({ health }: { health: HealthData }) {
       </dl>
       {fe?.missing && fe.missing.length > 0 && (
         <div className="mt-3">
-          <p className="mb-1.5 text-xs font-medium text-slate-500 dark:text-slate-400">
+          <p className="mb-1.5 text-sm font-medium text-slate-600 dark:text-slate-300">
             Missing Variables
           </p>
           <div className="flex flex-wrap gap-1.5">
@@ -573,7 +573,7 @@ function FrontendEnvPanel({ health }: { health: HealthData }) {
         </div>
       )}
       {fe?.note && (
-        <p className="mt-3 text-xs italic text-slate-400 dark:text-slate-500">
+        <p className="mt-3 text-sm italic leading-relaxed text-slate-600 dark:text-slate-400">
           {fe.note}
         </p>
       )}
@@ -621,13 +621,13 @@ function DataDirectoriesPanel({ health }: { health: HealthData }) {
     <PanelCard title="Data Directories" icon={FolderTree}>
       {entries.length > 0 ? (
         <div className="overflow-x-auto">
-          <table className="w-full text-xs">
+          <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-slate-200 text-[11px] uppercase tracking-wide text-slate-500 dark:border-slate-700">
-                <th className="py-1.5 text-left font-semibold">Path</th>
-                <th className="py-1.5 text-center font-semibold">Exists</th>
-                <th className="py-1.5 text-center font-semibold">Read</th>
-                <th className="py-1.5 text-center font-semibold">Write</th>
+              <tr className="border-b border-slate-200 text-slate-600 dark:border-slate-700 dark:text-slate-300">
+                <th className="py-2 text-left font-semibold">Path</th>
+                <th className="py-2 text-center font-semibold">Exists</th>
+                <th className="py-2 text-center font-semibold">Read</th>
+                <th className="py-2 text-center font-semibold">Write</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -708,7 +708,7 @@ function NetworkPanel({ bundle }: { bundle: HealthBundle }) {
     <PanelCard title="Network" icon={Network}>
       <div className="space-y-3">
         <div>
-          <p className="mb-1.5 text-xs font-medium text-slate-500 dark:text-slate-400">
+          <p className="mb-1.5 text-sm font-medium text-slate-600 dark:text-slate-300">
             IP Addresses
           </p>
           {ips.length > 0 ? (
@@ -716,15 +716,15 @@ function NetworkPanel({ bundle }: { bundle: HealthBundle }) {
               {ips.map((ip) => (
                 <span
                   key={ip}
-                  className="inline-flex items-center gap-1 rounded-md bg-primary-50 px-2 py-0.5 font-mono text-[11px] font-semibold text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
+                  className="inline-flex items-center gap-1 rounded-md bg-primary-50 px-2.5 py-1 font-mono text-sm font-semibold text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
                 >
-                  <Wifi className="h-3 w-3" aria-hidden="true" />
+                  <Wifi className="h-3.5 w-3.5" aria-hidden="true" />
                   {ip}
                 </span>
               ))}
             </div>
           ) : (
-            <p className="text-xs italic text-slate-400 dark:text-slate-500">
+            <p className="text-sm italic text-slate-600 dark:text-slate-400">
               No interfaces reported
             </p>
           )}

--- a/openresty-admin-next/src/components/logs/AIAnalysisPanel.tsx
+++ b/openresty-admin-next/src/components/logs/AIAnalysisPanel.tsx
@@ -125,7 +125,7 @@ const AnalysisResult = React.memo(function AnalysisResult({
           {/* Root causes */}
           {result.root_causes && result.root_causes.length > 0 && (
             <div>
-              <h4 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+              <h4 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-slate-700 dark:text-slate-200">
                 <Bug className="h-3.5 w-3.5" /> Root Causes
               </h4>
               <ul className="space-y-1.5">
@@ -142,7 +142,7 @@ const AnalysisResult = React.memo(function AnalysisResult({
           {/* Recommendations */}
           {result.recommendations && result.recommendations.length > 0 && (
             <div>
-              <h4 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+              <h4 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-slate-700 dark:text-slate-200">
                 <Lightbulb className="h-3.5 w-3.5" /> Recommendations
               </h4>
               <ul className="space-y-1.5">
@@ -263,14 +263,14 @@ const AIAnalysisPanel: React.FC<AIAnalysisPanelProps> = ({
         <Card.Header>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br from-violet-500 to-purple-600">
+              <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-600">
                 <Brain className="h-5 w-5 text-white" />
               </div>
               <div>
                 <h3 className="text-base font-bold text-slate-900 dark:text-slate-100">
                   AI Troubleshooting Assistant
                 </h3>
-                <p className="text-xs text-slate-500 dark:text-slate-400">
+                <p className="text-sm text-slate-600 dark:text-slate-300">
                   Powered by local LLM (Ollama) &middot; {selectedLogs.length} logs selected
                 </p>
               </div>
@@ -285,10 +285,10 @@ const AIAnalysisPanel: React.FC<AIAnalysisPanelProps> = ({
                 type="button"
                 onClick={() => setChatMode(!chatMode)}
                 className={cn(
-                  "rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
+                  "rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
                   chatMode
-                    ? "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300"
-                    : "text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800",
+                    ? "bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
+                    : "text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800",
                 )}
               >
                 <MessageSquare className="mr-1 inline h-3.5 w-3.5" />
@@ -313,12 +313,12 @@ const AIAnalysisPanel: React.FC<AIAnalysisPanelProps> = ({
                   disabled={analyzing || selectedLogs.length === 0}
                   onClick={() => runAnalysis(qp.prompt)}
                   className={cn(
-                    "flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2.5 text-left text-xs font-medium transition-all",
-                    "hover:border-purple-300 hover:bg-purple-50 hover:shadow-sm dark:border-slate-700 dark:hover:border-purple-700 dark:hover:bg-purple-900/20",
+                    "flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2.5 text-left text-sm font-medium transition-all",
+                    "hover:border-primary-300 hover:bg-primary-50 hover:shadow-sm dark:border-slate-700 dark:hover:border-primary-700 dark:hover:bg-primary-900/20",
                     "disabled:opacity-50 disabled:cursor-not-allowed",
                   )}
                 >
-                  <Icon className="h-4 w-4 shrink-0 text-purple-500" />
+                  <Icon className="h-4 w-4 shrink-0 text-primary-600 dark:text-primary-400" />
                   <span className="text-slate-700 dark:text-slate-300">{qp.label}</span>
                 </button>
               );
@@ -334,7 +334,6 @@ const AIAnalysisPanel: React.FC<AIAnalysisPanelProps> = ({
                 loading={analyzing}
                 disabled={selectedLogs.length === 0}
                 onClick={() => runAnalysis()}
-                className="bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700"
               >
                 {analyzing ? "Analyzing..." : `Analyze ${selectedLogs.length} Log Entries`}
               </Button>
@@ -351,7 +350,7 @@ const AIAnalysisPanel: React.FC<AIAnalysisPanelProps> = ({
             <div className="space-y-3">
               <div className="max-h-80 space-y-3 overflow-y-auto rounded-lg border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-800/50">
                 {chatMessages.length === 0 ? (
-                  <p className="py-8 text-center text-sm text-slate-400">
+                  <p className="py-8 text-center text-sm text-slate-600 dark:text-slate-400">
                     Ask questions about the selected logs. The AI will analyze them in context.
                   </p>
                 ) : (
@@ -393,14 +392,13 @@ const AIAnalysisPanel: React.FC<AIAnalysisPanelProps> = ({
                   onChange={(e) => setChatInput(e.target.value)}
                   onKeyDown={(e) => e.key === "Enter" && handleChat()}
                   placeholder="Ask about the logs... e.g., 'Why are 502s spiking?'"
-                  className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-purple-400 focus:outline-none focus:ring-2 focus:ring-purple-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+                  className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-500 focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400"
                 />
                 <Button
                   variant="primary"
                   icon={<Send className="h-4 w-4" />}
                   onClick={handleChat}
                   disabled={!chatInput.trim() || analyzing}
-                  className="bg-gradient-to-r from-violet-600 to-purple-600"
                 >
                   Send
                 </Button>

--- a/openresty-admin-next/src/components/logs/LogViewer.tsx
+++ b/openresty-admin-next/src/components/logs/LogViewer.tsx
@@ -170,7 +170,7 @@ const FilterBar = React.memo(function FilterBar({
             placeholder={logType === "access" ? "Search URI, IP, user agent..." : "Search error messages..."}
             value={filters.search || ""}
             onChange={(e) => onChange({ ...filters, search: e.target.value })}
-            className="w-full rounded-lg border border-slate-200 bg-white py-2 pl-10 pr-4 text-sm text-slate-900 placeholder:text-slate-400 focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500"
+            className="w-full rounded-lg border border-slate-200 bg-white py-2 pl-10 pr-4 text-sm text-slate-900 placeholder:text-slate-500 focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-500"
           />
         </div>
         <Button
@@ -205,10 +205,10 @@ const FilterBar = React.memo(function FilterBar({
                 type="button"
                 onClick={() => onChange({ ...filters, time_range: filters.time_range === t.value ? undefined : t.value })}
                 className={cn(
-                  "rounded-md px-2 py-1 text-xs font-medium transition-colors",
+                  "rounded-md px-2.5 py-1 text-sm font-medium transition-colors",
                   filters.time_range === t.value
                     ? "bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300"
-                    : "text-slate-500 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700",
+                    : "text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-700",
                 )}
               >
                 {t.label}
@@ -228,10 +228,10 @@ const FilterBar = React.memo(function FilterBar({
                     type="button"
                     onClick={() => onChange({ ...filters, method: filters.method === m ? undefined : m })}
                     className={cn(
-                      "rounded-md px-2 py-1 text-xs font-medium transition-colors",
+                      "rounded-md px-2.5 py-1 text-sm font-medium transition-colors",
                       filters.method === m
                         ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
-                        : "text-slate-500 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700",
+                        : "text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-700",
                     )}
                   >
                     {m}
@@ -249,10 +249,10 @@ const FilterBar = React.memo(function FilterBar({
                     type="button"
                     onClick={() => onChange({ ...filters, status_code: filters.status_code === s ? undefined : s })}
                     className={cn(
-                      "rounded-md px-2 py-1 text-xs font-medium transition-colors",
+                      "rounded-md px-2.5 py-1 text-sm font-medium transition-colors",
                       filters.status_code === s
                         ? "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
-                        : "text-slate-500 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700",
+                        : "text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-700",
                     )}
                   >
                     {s}
@@ -269,10 +269,10 @@ const FilterBar = React.memo(function FilterBar({
                   type="button"
                   onClick={() => onChange({ ...filters, level: filters.level === l ? undefined : l })}
                   className={cn(
-                    "rounded-md px-2 py-1 text-xs font-medium capitalize transition-colors",
+                    "rounded-md px-2.5 py-1 text-sm font-medium capitalize transition-colors",
                     filters.level === l
                       ? "bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300"
-                      : "text-slate-500 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-700",
+                      : "text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-700",
                   )}
                 >
                   {l}
@@ -319,16 +319,16 @@ const AccessLogRow = React.memo(function AccessLogRow({
           )}
         </button>
       </td>
-      <td className="py-2 px-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+      <td className="py-2 px-2 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
         {formatTimestamp(logTime(log))}
       </td>
       <td className="py-2 px-2">
-        <span className={cn("inline-block rounded px-1.5 py-0.5 text-xs font-bold", STATUS_CLASSES[cat])}>
+        <span className={cn("inline-block rounded px-1.5 py-0.5 text-sm font-bold", STATUS_CLASSES[cat])}>
           {log.status}
         </span>
       </td>
       <td className="py-2 px-2">
-        <span className="rounded bg-slate-100 px-1.5 py-0.5 text-xs font-mono font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-300">
+        <span className="rounded bg-slate-100 px-1.5 py-0.5 text-sm font-mono font-medium text-slate-800 dark:bg-slate-800 dark:text-slate-200">
           {log.method}
         </span>
       </td>
@@ -336,24 +336,24 @@ const AccessLogRow = React.memo(function AccessLogRow({
         <button
           type="button"
           onClick={onInspect}
-          className="truncate text-left text-xs font-mono text-slate-800 hover:text-primary-600 dark:text-slate-200 dark:hover:text-primary-400"
+          className="truncate text-left text-sm font-mono text-slate-900 hover:text-primary-600 dark:text-slate-100 dark:hover:text-primary-400"
           title={log.uri}
         >
           {log.uri}
         </button>
       </td>
-      <td className="py-2 px-2 text-xs font-mono text-slate-500 dark:text-slate-400">
+      <td className="py-2 px-2 text-sm font-mono text-slate-600 dark:text-slate-300">
         {log.remote_addr}
       </td>
       <td className={cn(
-        "py-2 px-2 text-xs font-medium text-right whitespace-nowrap",
+        "py-2 px-2 text-sm font-medium text-right whitespace-nowrap",
         log.request_time > 1 ? "text-red-600 dark:text-red-400" :
         log.request_time > 0.5 ? "text-amber-600 dark:text-amber-400" :
         "text-green-600 dark:text-green-400"
       )}>
         {formatLatency(log.request_time * 1000)}
       </td>
-      <td className="py-2 px-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+      <td className="py-2 px-2 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
         {logUpstream(log)}
       </td>
       <td className="py-2 px-2">
@@ -367,7 +367,7 @@ const AccessLogRow = React.memo(function AccessLogRow({
             <Badge size="sm" variant="danger">WAF</Badge>
           )}
           {log.country_code && (
-            <span className="text-xs text-slate-400">{log.country_code}</span>
+            <span className="text-sm text-slate-600 dark:text-slate-400">{log.country_code}</span>
           )}
         </div>
       </td>
@@ -408,23 +408,23 @@ const ErrorLogRow = React.memo(function ErrorLogRow({
             )}
           </button>
         </td>
-        <td className="py-2 px-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+        <td className="py-2 px-2 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
           {formatTimestamp(logTime(log))}
         </td>
         <td className="py-2 px-2">
-          <span className={cn("inline-block rounded px-1.5 py-0.5 text-xs font-bold uppercase", LEVEL_CLASSES[log.level] || LEVEL_CLASSES.info)}>
+          <span className={cn("inline-block rounded px-1.5 py-0.5 text-sm font-bold uppercase", LEVEL_CLASSES[log.level] || LEVEL_CLASSES.info)}>
             {log.level}
           </span>
         </td>
         <td className="py-2 px-3 max-w-[600px]" colSpan={2}>
-          <p className="truncate text-xs text-slate-800 dark:text-slate-200 font-mono">
+          <p className="truncate text-sm text-slate-900 dark:text-slate-100 font-mono">
             {log.message}
           </p>
         </td>
-        <td className="py-2 px-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+        <td className="py-2 px-2 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
           {log.client || "—"}
         </td>
-        <td className="py-2 px-2 text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">
+        <td className="py-2 px-2 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">
           {log.server || "—"}
         </td>
         <td className="py-2 px-2">
@@ -434,7 +434,7 @@ const ErrorLogRow = React.memo(function ErrorLogRow({
       {expanded && (
         <tr className="bg-slate-50 dark:bg-slate-800/30">
           <td colSpan={8} className="px-4 py-3">
-            <pre className="whitespace-pre-wrap text-xs font-mono text-slate-700 dark:text-slate-300 leading-relaxed">
+            <pre className="whitespace-pre-wrap text-sm font-mono text-slate-800 dark:text-slate-200 leading-relaxed">
               {log.message}
               {log.request && `\nRequest: ${log.request}`}
               {log.upstream && `\nUpstream: ${log.upstream}`}
@@ -597,32 +597,32 @@ const LogViewer: React.FC<LogViewerProps> = ({
                 </th>
                 {logType === "access" ? (
                   <>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400 cursor-pointer select-none" onClick={() => handleSort("timestamp")}>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300 cursor-pointer select-none" onClick={() => handleSort("timestamp")}>
                       <span className="inline-flex items-center gap-1">Time <ArrowUpDown className="h-3 w-3" /></span>
                     </th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400 cursor-pointer select-none" onClick={() => handleSort("status")}>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300 cursor-pointer select-none" onClick={() => handleSort("status")}>
                       <span className="inline-flex items-center gap-1">Status <ArrowUpDown className="h-3 w-3" /></span>
                     </th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400">Method</th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400">URI</th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400">Client IP</th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400 text-right cursor-pointer select-none" onClick={() => handleSort("request_time")}>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300">Method</th>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300">URI</th>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300">Client IP</th>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300 text-right cursor-pointer select-none" onClick={() => handleSort("request_time")}>
                       <span className="inline-flex items-center gap-1">Latency <ArrowUpDown className="h-3 w-3" /></span>
                     </th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400">Upstream</th>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300">Upstream</th>
                     {/* "Tags" was misleading — the cell renders cache /
                         WAF / country badges, not arbitrary tags. */}
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400">Flags</th>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300">Flags</th>
                   </>
                 ) : (
                   <>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400 cursor-pointer select-none" onClick={() => handleSort("timestamp")}>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300 cursor-pointer select-none" onClick={() => handleSort("timestamp")}>
                       <span className="inline-flex items-center gap-1">Time <ArrowUpDown className="h-3 w-3" /></span>
                     </th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400">Level</th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400" colSpan={2}>Message</th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400">Client</th>
-                    <th className="py-2.5 px-2 text-xs font-semibold text-slate-500 dark:text-slate-400">Server</th>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300">Level</th>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300" colSpan={2}>Message</th>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300">Client</th>
+                    <th className="py-2.5 px-2 text-sm font-semibold text-slate-600 dark:text-slate-300">Server</th>
                     <th className="py-2.5 px-2 w-8" />
                   </>
                 )}
@@ -642,7 +642,7 @@ const LogViewer: React.FC<LogViewerProps> = ({
                   <tr>
                     <td colSpan={9} className="py-12 text-center">
                       <AlertCircle className="mx-auto mb-2 h-8 w-8 text-slate-300 dark:text-slate-600" />
-                      <p className="text-sm text-slate-500 dark:text-slate-400">No access logs found matching filters</p>
+                      <p className="text-sm text-slate-600 dark:text-slate-300">No access logs found matching filters</p>
                     </td>
                   </tr>
                 ) : (
@@ -661,7 +661,7 @@ const LogViewer: React.FC<LogViewerProps> = ({
                   <tr>
                     <td colSpan={8} className="py-12 text-center">
                       <AlertCircle className="mx-auto mb-2 h-8 w-8 text-slate-300 dark:text-slate-600" />
-                      <p className="text-sm text-slate-500 dark:text-slate-400">No error logs found matching filters</p>
+                      <p className="text-sm text-slate-600 dark:text-slate-300">No error logs found matching filters</p>
                     </td>
                   </tr>
                 ) : (

--- a/openresty-admin-next/src/components/servers/NginxServerTab.tsx
+++ b/openresty-admin-next/src/components/servers/NginxServerTab.tsx
@@ -647,7 +647,7 @@ const NginxServerTab: React.FC<NginxServerTabProps> = ({
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               Docker Registry Blob Caching
             </h2>
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-slate-600 dark:text-slate-300">
               Cache Docker/OCI image blobs and manifests on disk for
               faster pulls.  Only enable when this server fronts a
               container registry backend (e.g. NebulaCR).
@@ -761,7 +761,7 @@ const NginxServerTab: React.FC<NginxServerTabProps> = ({
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               Proxy Timeouts
             </h2>
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-slate-600 dark:text-slate-300">
               Upstream (proxy_pass) timeouts in seconds.  Leave a field
               blank to use nginx's default of 60s.  Setting these fixes
               the classic 504-at-60s problem for long-running backends
@@ -1010,7 +1010,7 @@ const NginxServerTab: React.FC<NginxServerTabProps> = ({
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               Configuration Preview
             </h2>
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-slate-600 dark:text-slate-300">
               The composed nginx server block that will be written to
               disk.  Toggle <em>Active</em> below to actually load it
               into <code>/opt/nginx/conf.d/</code> — leaving it off
@@ -1040,7 +1040,7 @@ const NginxServerTab: React.FC<NginxServerTabProps> = ({
                 <div className="font-medium text-slate-900 dark:text-slate-100">
                   Active — write to <code>/opt/nginx/conf.d/</code> and reload
                 </div>
-                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                <div className="mt-1 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
                   On save, wslproxy runs <code>openresty -t</code> against
                   the new config and (if it passes) schedules a reload.
                   Turn this off to stage changes without touching live

--- a/openresty-admin-next/src/components/servers/RulePreview.tsx
+++ b/openresty-admin-next/src/components/servers/RulePreview.tsx
@@ -151,7 +151,7 @@ const RulePreview: React.FC<RulePreviewProps> = ({ ruleId, className }) => {
   if (error || !summary) {
     return (
       <div
-        className={`mt-2 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200 ${className ?? ""}`}
+        className={`mt-2 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-200 ${className ?? ""}`}
         role="alert"
       >
         <ShieldAlert className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
@@ -179,7 +179,7 @@ const RulePreview: React.FC<RulePreviewProps> = ({ ruleId, className }) => {
         <div className="min-w-0 flex-1 space-y-0.5">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-slate-700 dark:text-slate-300">
             {summary.pathLine && (
-              <span className="truncate font-mono text-xs">
+              <span className="truncate font-mono text-sm">
                 {summary.pathLine}
               </span>
             )}
@@ -190,18 +190,18 @@ const RulePreview: React.FC<RulePreviewProps> = ({ ruleId, className }) => {
               />
             )}
             {summary.targetLine && (
-              <span className="truncate font-mono text-xs text-slate-600 dark:text-slate-400">
+              <span className="truncate font-mono text-sm text-slate-700 dark:text-slate-300">
                 {summary.targetLine}
               </span>
             )}
             {!summary.pathLine && !summary.targetLine && (
-              <span className="text-xs italic text-slate-400">
+              <span className="text-sm italic text-slate-600 dark:text-slate-400">
                 {summary.meta.description}
               </span>
             )}
           </div>
           {summary.conditionsLine && (
-            <div className="truncate text-xs text-slate-500 dark:text-slate-400">
+            <div className="truncate text-sm text-slate-600 dark:text-slate-400">
               {summary.conditionsLine}
             </div>
           )}
@@ -211,7 +211,7 @@ const RulePreview: React.FC<RulePreviewProps> = ({ ruleId, className }) => {
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className="mt-0.5 inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-primary-600 hover:bg-primary-50 hover:text-primary-700 dark:text-primary-400 dark:hover:bg-primary-900/20 dark:hover:text-primary-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/30"
+          className="mt-0.5 inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-sm font-medium text-primary-600 hover:bg-primary-50 hover:text-primary-700 dark:text-primary-400 dark:hover:bg-primary-900/20 dark:hover:text-primary-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/30"
           aria-label={`View details for rule ${rule?.name ?? ruleId}`}
         >
           <Eye className="h-3.5 w-3.5" aria-hidden="true" />

--- a/openresty-admin-next/src/components/servers/ServerRulesTab.tsx
+++ b/openresty-admin-next/src/components/servers/ServerRulesTab.tsx
@@ -119,14 +119,14 @@ const ServerRulesTab: React.FC<ServerRulesTabProps> = ({
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               Server Rules
             </h2>
-            <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+            <p className="mt-0.5 text-sm text-slate-600 dark:text-slate-300">
               Select and configure rules for this server
             </p>
           </div>
         </Card.Header>
         <Card.Body>
           {ruleOptions.length === 0 ? (
-            <p className="py-4 text-center text-sm italic text-slate-400 dark:text-slate-500">
+            <p className="py-4 text-center text-sm italic text-slate-600 dark:text-slate-400">
               No rules available. Create rules first to assign them to this
               server.
             </p>
@@ -159,7 +159,7 @@ const ServerRulesTab: React.FC<ServerRulesTabProps> = ({
               <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
                 Match Conditions
               </h2>
-              <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+              <p className="mt-0.5 text-sm text-slate-600 dark:text-slate-300">
                 Combine additional rules with the assigned rule using AND / OR.
               </p>
             </div>
@@ -175,7 +175,7 @@ const ServerRulesTab: React.FC<ServerRulesTabProps> = ({
           </Card.Header>
           <Card.Body>
             {form.match_cases.length === 0 ? (
-              <p className="py-4 text-center text-sm italic text-slate-400 dark:text-slate-500">
+              <p className="py-4 text-center text-sm italic text-slate-600 dark:text-slate-400">
                 No match conditions configured.
               </p>
             ) : (
@@ -237,8 +237,8 @@ const ServerRulesTab: React.FC<ServerRulesTabProps> = ({
           to combine with — avoids rendering an empty card with no
           useful state. */}
       {form.rules && ruleOptions.length === 1 && (
-        <div className="flex items-start gap-2 rounded-lg border border-dashed border-slate-200 bg-slate-50 p-3 text-xs text-slate-500 dark:border-slate-700 dark:bg-slate-800/30 dark:text-slate-400">
-          <ListFilter className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <div className="flex items-start gap-2 rounded-lg border border-dashed border-slate-200 bg-slate-50 p-3 text-sm leading-relaxed text-slate-600 dark:border-slate-700 dark:bg-slate-800/30 dark:text-slate-300">
+          <ListFilter className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
           <span>
             Create at least one more rule to unlock <em>Match Conditions</em>.
           </span>

--- a/openresty-admin-next/src/components/servers/WafProtectionTab.tsx
+++ b/openresty-admin-next/src/components/servers/WafProtectionTab.tsx
@@ -159,25 +159,25 @@ const WafProtectionTab: React.FC<WafProtectionTabProps> = ({
 
                   <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
                     <div>
-                      <dt className="text-xs text-slate-500 dark:text-slate-400">Anomaly Threshold</dt>
+                      <dt className="text-sm text-slate-600 dark:text-slate-300">Anomaly Threshold</dt>
                       <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">
                         {selectedPolicy.anomaly_threshold ?? "N/A"}
                       </dd>
                     </div>
                     <div>
-                      <dt className="text-xs text-slate-500 dark:text-slate-400">Paranoia Level</dt>
+                      <dt className="text-sm text-slate-600 dark:text-slate-300">Paranoia Level</dt>
                       <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">
                         {selectedPolicy.paranoia_level ?? "N/A"}
                       </dd>
                     </div>
                     <div>
-                      <dt className="text-xs text-slate-500 dark:text-slate-400">Body Inspection</dt>
+                      <dt className="text-sm text-slate-600 dark:text-slate-300">Body Inspection</dt>
                       <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">
                         {selectedPolicy.body_inspection ? "Yes" : "No"}
                       </dd>
                     </div>
                     <div>
-                      <dt className="text-xs text-slate-500 dark:text-slate-400">Rules Count</dt>
+                      <dt className="text-sm text-slate-600 dark:text-slate-300">Rules Count</dt>
                       <dd className="text-sm font-medium text-slate-900 dark:text-slate-100">
                         {selectedPolicy.waf_rules?.length ?? 0}
                       </dd>

--- a/openresty-admin-next/src/components/servers/sections/ConfigPreview.tsx
+++ b/openresty-admin-next/src/components/servers/sections/ConfigPreview.tsx
@@ -54,7 +54,7 @@ const ConfigPreview: React.FC<ConfigPreviewProps> = ({ config, className }) => {
 
       <pre
         className={cn(
-          "w-full overflow-auto rounded-lg border p-4 text-xs leading-relaxed",
+          "w-full overflow-auto rounded-lg border p-4 text-sm leading-relaxed",
           "bg-slate-900 text-green-400 border-slate-700",
           "dark:bg-slate-950 dark:border-slate-800",
           "font-mono whitespace-pre-wrap break-words",

--- a/openresty-admin-next/src/components/servers/sections/LocationBlockEditor.tsx
+++ b/openresty-admin-next/src/components/servers/sections/LocationBlockEditor.tsx
@@ -186,7 +186,7 @@ const LocationBlockEditor: React.FC<LocationBlockEditorProps> = ({
             {/* Directives */}
             <div className="space-y-2 pl-6">
               <div className="flex items-center justify-between">
-                <span className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide">
+                <span className="text-sm font-medium text-slate-600 dark:text-slate-300">
                   Directives
                 </span>
                 <Button

--- a/openresty-admin-next/src/components/servers/sections/PopMultiSelect.tsx
+++ b/openresty-admin-next/src/components/servers/sections/PopMultiSelect.tsx
@@ -177,7 +177,7 @@ export default function PopMultiSelect({
         <div className="space-y-4">
           {grouped.map(([region, regionPops]) => (
             <div key={region}>
-              <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-slate-600 dark:text-slate-300">
                 {region}
                 <span className="text-slate-400">·</span>
                 <span className="font-normal normal-case">


### PR DESCRIPTION
## Summary
- Raise type size/contrast on Servers, Rules, Logs, System Status, and Settings
- Soften tiny uppercase section labels; align AI troubleshoot accents with copper primary
- Keep list/form density intact while making paths, helpers, and log rows easier to scan

## Test plan
- [ ] Servers list + edit (rules tab, nginx hints, config preview)
- [ ] Rules list path column + rule form sections
- [ ] Logs access/error tables, filters, AI panel (light/dark)
- [ ] System Status panels and Settings env vars


Made with [Cursor](https://cursor.com)