### PR TITLE
fix(api): stop JSON bodies losing '=' chars; never crash on unpadded base64

### DIFF
--- a/api/gateway_ack.lua
+++ b/api/gateway_ack.lua
@@ -43,7 +43,7 @@ local function serve_error(settings_obj, page_type)
     if page_type == "conf_mismatch" then
         ngx.status = ngx.HTTP_FORBIDDEN
     end
-    ngx.say(Base64.decode(html))
+    ngx.say(Base64DecodeSafe(html) or "Service unavailable")
 end
 
 -- ─── Cache check ────────────────────────────────────────────────────────────
@@ -164,7 +164,7 @@ else
     if fallback_msg then
         ngx.header["Content-Type"] = (settings.nginx and settings.nginx.content_type) or "text/html"
         ngx.status = ngx.HTTP_FORBIDDEN
-        ngx.say(Base64.decode(fallback_msg))
+        ngx.say(Base64DecodeSafe(fallback_msg) or "Forbidden")
     else
         serve_error(settings, "conf_mismatch")
     end

--- a/api/gateway_resp.lua
+++ b/api/gateway_resp.lua
@@ -56,7 +56,7 @@ if selectedRule.statusCode == nil then
 elseif selectedRule.statusCode == 200 or selectedRule.statusCode == 403 then
     ngx.header["Content-Type"] = "text/html"
     ngx.status = selectedRule.statusCode
-    ngx.say(Base64.decode(selectedRule.message))
+    ngx.say(Base64DecodeSafe(selectedRule.message) or "")
 elseif selectedRule.statusCode == 301 then
     if selectedRule.redirectUri == nil then
         ngx.say("Redirect url not found: ")

--- a/api/helpers.lua
+++ b/api/helpers.lua
@@ -600,6 +600,32 @@ end
 
 -- Convert payloads to Lua table
 function Helper.GetPayloads(body)
+    -- Prefer the raw request body over ngx.req.get_post_args():
+    -- form parsing splits the body at the first literal "=" (and decodes
+    -- "+" to space), so rebuilding JSON from key .. value silently drops
+    -- that "=" — corrupting any base64 field (e.g. a rule's
+    -- jwt_token_validation_key losing its padding) for clients that send
+    -- plain JSON without the admin UI's = escaping. get_body_data()
+    -- is nil unless the dispatcher already called ngx.req.read_body(),
+    -- so GET handlers passing uri_args fall through to the legacy path.
+    local raw = ngx.req.get_body_data()
+    if not raw then
+        local body_file = ngx.req.get_body_file()
+        if body_file then
+            local f = io.open(body_file, "rb")
+            if f then
+                raw = f:read("*a")
+                f:close()
+            end
+        end
+    end
+    if raw then
+        local ok, decoded = pcall(Cjson.decode, raw)
+        if ok and type(decoded) == "table" then
+            return decoded
+        end
+    end
+
     local keyset = {}
     local n = 0
     for k, v in pairs(body) do

--- a/api/init.lua
+++ b/api/init.lua
@@ -4,6 +4,25 @@ JWT = require "resty.jwt"
 LFS = require("lfs")
 Base64 = require "base64"
 
+-- Base64.decode throws ("attempt to perform arithmetic on a nil value")
+-- on input whose "=" padding was lost in transit, which would turn one
+-- corrupt rule field into a 500 on every request of the vhost. Re-pad to
+-- a multiple of 4 and pcall so request-path callers can never crash on
+-- stored data; returns nil when the value is genuinely undecodable.
+function Base64DecodeSafe(s)
+  s = tostring(s or "")
+  local rem = #s % 4
+  if rem > 0 then
+    s = s .. string.rep("=", 4 - rem)
+  end
+  local ok, decoded = pcall(Base64.decode, s)
+  if ok then
+    return decoded
+  end
+  ngx.log(ngx.WARN, "Base64DecodeSafe: undecodable base64 value")
+  return nil
+end
+
 local configPath = os.getenv("NGINX_CONFIG_DIR") or "/opt/nginx/"
 -- Ensure trailing slash for path concatenation
 if configPath:sub(-1) ~= "/" then

--- a/api/rule_auth.lua
+++ b/api/rule_auth.lua
@@ -59,7 +59,7 @@ function M.authenticate(rule)
         return true
     end
 
-    local passphrase = Base64.decode(tostring(rule.jwt_token_validation_key))
+    local passphrase = Base64DecodeSafe(rule.jwt_token_validation_key)
     local token_source = rule.jwt_token_validation
     local token_value_name = tostring(rule.jwt_token_validation_value)
 


### PR DESCRIPTION
## Why

https://www.diytaxreturn.co.uk kept returning 500 after every rules push / redeploy, even though the rule JSON in git (diy-tax-return-uk `.github/wslproxy/data`) was correct.

**Root cause:** `Helper.GetPayloads` rebuilt JSON request bodies from `ngx.req.get_post_args()`. Form parsing splits the body at the first literal `=`, and re-concatenating `key .. value` silently deletes that `=`. The react-admin UI dodges this by pre-escaping `=` as `=`, but plain-JSON clients (curl, the diy-tax-return-uk `wslproxy-register-domains` import workflow) hit it on every save.

Concretely: the diytax S3 rule's `jwt_token_validation_key` was stored as `L2luZGV4Lmh0bWw` instead of `L2luZGV4Lmh0bWw=`, and the shipped `base64.lua` throws `attempt to perform arithmetic on a nil value` on unpadded input → **every request to the vhost 500'd**. Re-importing the fixed rule from git re-corrupted it, which is why the site kept breaking after each "fix".

## What

- `helpers.lua` — `GetPayloads` now prefers the raw body (`ngx.req.get_body_data`/`get_body_file`) and `Cjson.decode`s it directly, preserving `=`, `+`, `&` byte-for-byte. Falls back to the legacy post-args reconstruction for GET handlers passing uri args and non-JSON bodies, so all ~20 call sites keep working unchanged.
- `init.lua` — new `Base64DecodeSafe` global (re-pad to %4 + `pcall`); already-corrupt stored rules self-heal at decode time, undecodable values degrade to a logged warning instead of a worker crash.
- `rule_auth.lua`, `gateway_ack.lua`, `gateway_resp.lua` — request-path decode sites switched to `Base64DecodeSafe`.

## Live remediation already applied on pop1 (18.133.126.242)

- Restored `=` padding in 4 corrupt rule files.
- Repointed `host:www.diytaxreturn.co.uk` + `host:diytaxreturn.co.uk` to the git-canonical rule id `5c63f6fa-112a-0661-70a6-87ca57535d8f` (was a live-only duplicate `93893825-…`).
- Moved 3 orphan duplicate rules aside (backups in `/tmp/rulefix-backup-20260810`).
- Site verified 200 on www + apex.

## Verification

- All 5 files syntax-checked with pop1's luajit.
- `Base64DecodeSafe` functest on pop1: padded, unpadded (self-heal), nil, and garbage inputs all pass without throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)