### PR TITLE
style(next): corporate blue primary for admin

### DIFF
--- a/openresty-admin-next/next.config.ts
+++ b/openresty-admin-next/next.config.ts
@@ -1,9 +1,18 @@
 import type { NextConfig } from "next";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import bundleAnalyzer from "@next/bundle-analyzer";
 
 const withBundleAnalyzer = bundleAnalyzer({
   enabled: process.env.ANALYZE === "true",
 });
+
+// Pin the app root so a stray package-lock.json in a parent directory
+// (e.g. $HOME) cannot pull Turbopack / standalone tracing up the tree.
+// Without this, `output: "standalone"` nests server.js under
+// `.next/standalone/<relative-path>/server.js` and Ansible's verify
+// step fails looking for `.next/standalone/server.js`.
+const appRoot = path.dirname(fileURLToPath(import.meta.url));
 
 // ─── Content Security Policy ────────────────────────────────────────────
 // Admin is a first-party app — no third-party scripts, no inline JS
@@ -80,6 +89,10 @@ function buildSwaggerCsp(): string {
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  outputFileTracingRoot: appRoot,
+  turbopack: {
+    root: appRoot,
+  },
 
   // Build-time type checking of <Link href>, useRouter().push() etc.
   // All hrefs must resolve to real app-router routes — typos become

--- a/openresty-admin-next/src/app/globals.css
+++ b/openresty-admin-next/src/app/globals.css
@@ -2,19 +2,19 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
-/* Brand tokens aligned with the public landing page (html/index.html). */
+/* Brand tokens — corporate blue primary for the Next.js admin. */
 @theme {
-  --color-primary-50: #fdf4ef;
-  --color-primary-100: #fbe6d9;
-  --color-primary-200: #f5c9b0;
-  --color-primary-300: #eba67d;
-  --color-primary-400: #dc7d4a;
-  --color-primary-500: #c45c26;
-  --color-primary-600: #9a4519;
-  --color-primary-700: #7a3715;
-  --color-primary-800: #652f15;
-  --color-primary-900: #542914;
-  --color-primary-950: #2d1409;
+  --color-primary-50: #eef5fc;
+  --color-primary-100: #d6e8f8;
+  --color-primary-200: #b5d4f1;
+  --color-primary-300: #87b7e6;
+  --color-primary-400: #5493d6;
+  --color-primary-500: #3476c2;
+  --color-primary-600: #255fa8;
+  --color-primary-700: #1e4c88;
+  --color-primary-800: #1c4171;
+  --color-primary-900: #1b385f;
+  --color-primary-950: #12233f;
 
   --color-accent-50: #ecf8f6;
   --color-accent-100: #d0efe9;

--- a/openresty-admin-next/src/app/icon.svg
+++ b/openresty-admin-next/src/app/icon.svg
@@ -1,8 +1,8 @@
 <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#6366f1" />
-      <stop offset="100%" stop-color="#8b5cf6" />
+      <stop offset="0%" stop-color="#5493d6" />
+      <stop offset="100%" stop-color="#1e4c88" />
     </linearGradient>
   </defs>
   <!-- Shield background -->

--- a/openresty-admin-next/src/components/Logo.tsx
+++ b/openresty-admin-next/src/components/Logo.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-/* WSLProxy logo — copper brand aligned with the public landing page. */
+/* WSLProxy logo — corporate blue brand for the Next.js admin. */
 
 const GRADIENT_ID = "wslproxy-logo-gradient";
 
@@ -22,7 +22,7 @@ const Logo: React.FC<LogoProps> = ({
   className,
 }) => {
   const wordmarkColor = theme === "dark" ? "#eef2f6" : "#0b1c2c";
-  const accentColor = "#c45c26";
+  const accentColor = "#255fa8";
   const gradientId = GRADIENT_ID;
 
   if (variant === "icon") {
@@ -39,8 +39,8 @@ const Logo: React.FC<LogoProps> = ({
         <title>{title}</title>
         <defs>
           <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#c45c26" />
-            <stop offset="100%" stopColor="#1a7a6d" />
+            <stop offset="0%" stopColor="#5493d6" />
+            <stop offset="100%" stopColor="#1e4c88" />
           </linearGradient>
         </defs>
         <path
@@ -75,8 +75,8 @@ const Logo: React.FC<LogoProps> = ({
       <title>{title}</title>
       <defs>
         <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
-          <stop offset="0%" stopColor="#c45c26" />
-          <stop offset="100%" stopColor="#1a7a6d" />
+          <stop offset="0%" stopColor="#5493d6" />
+          <stop offset="100%" stopColor="#1e4c88" />
         </linearGradient>
       </defs>
       <g transform="translate(2, 2)">

--- a/openresty-admin-next/src/components/dashboard/GeoTrafficMap.tsx
+++ b/openresty-admin-next/src/components/dashboard/GeoTrafficMap.tsx
@@ -227,7 +227,7 @@ const GEO_URL =
 const COLOR_SCALE = [
   "#e0e7ff", // primary-100 equivalent
   "#a5b4fc", // primary-300
-  "#6366f1", // primary-500
+  "#255fa8", // primary-600 corporate blue
   "#4338ca", // primary-700
 ];
 

--- a/openresty-admin-next/src/lib/dashboard/constants.ts
+++ b/openresty-admin-next/src/lib/dashboard/constants.ts
@@ -13,12 +13,12 @@
    ────────────────────────────────────────────────────────────────────────── */
 
 export const COLORS = {
-  primary: "#6366f1", // indigo
+  primary: "#255fa8", // corporate blue
   success: "#10b981", // emerald
   warning: "#f59e0b", // amber
   error: "#ef4444", // red
   orange: "#f97316", // orange — latency 500-1000
-  secondary: "#8b5cf6", // violet
+  secondary: "#1a7a6d", // teal accent
   cyan: "#06b6d4",
   pink: "#ec4899",
   lime: "#84cc16",


### PR DESCRIPTION
## Summary
- Replace copper/terracotta primary palette with corporate blue (`#255fa8` family)
- Update Logo, favicon, and chart primary colors to match
- Include Next.js standalone root pin so local dashboard deploys find `server.js`

## Test plan
- [ ] Login / sidebar / primary buttons read as blue in light and dark
- [ ] Logo wordmark + shield use blue (not copper)
- [ ] Redeploy `dashboard-next` / `dashboard` to see live


Made with [Cursor](https://cursor.com)