### PR TITLE
style(next): finish corporate blue accent sweep

### DIFF
--- a/openresty-admin-next/public/logo-color.svg
+++ b/openresty-admin-next/public/logo-color.svg
@@ -1,8 +1,8 @@
 <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#6366f1" />
-      <stop offset="100%" stop-color="#8b5cf6" />
+      <stop offset="0%" stop-color="#5493d6" />
+      <stop offset="100%" stop-color="#1e4c88" />
     </linearGradient>
   </defs>
   <!-- Shield background -->

--- a/openresty-admin-next/src/app/global-error.tsx
+++ b/openresty-admin-next/src/app/global-error.tsx
@@ -70,7 +70,7 @@ export default function GlobalError({
               border: "none",
               padding: "0.625rem 1.25rem",
               borderRadius: 8,
-              background: "#6366f1",
+              background: "#255fa8",
               color: "white",
               fontWeight: 500,
               fontSize: "0.875rem",

--- a/openresty-admin-next/src/components/dashboard/TrafficChart.tsx
+++ b/openresty-admin-next/src/components/dashboard/TrafficChart.tsx
@@ -82,8 +82,8 @@ const TrafficChart: React.FC<TrafficChartProps> = ({ chartData, loading }) => {
           <AreaChart data={data}>
             <defs>
               <linearGradient id="colorRequests" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#6366f1" stopOpacity={0.3} />
-                <stop offset="95%" stopColor="#6366f1" stopOpacity={0} />
+                <stop offset="5%" stopColor="#255fa8" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#255fa8" stopOpacity={0} />
               </linearGradient>
               <linearGradient id="colorSuccess" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="5%" stopColor="#10b981" stopOpacity={0.2} />
@@ -112,7 +112,7 @@ const TrafficChart: React.FC<TrafficChartProps> = ({ chartData, loading }) => {
               type="monotone"
               dataKey="requests"
               name="Requests"
-              stroke="#6366f1"
+              stroke="#255fa8"
               fill="url(#colorRequests)"
               strokeWidth={2}
             />


### PR DESCRIPTION
## Summary
- Update TrafficChart, global-error, and public logo SVG to the new corporate blue

## Test plan
- [ ] Traffic chart stroke uses blue
- [ ] Favicon/public logo matches admin brand


Made with [Cursor](https://cursor.com)