### PR TITLE
fix(ci): WAF live preflight uses / not /health

### DIFF
--- a/.github/workflows/waf-validate.yml
+++ b/.github/workflows/waf-validate.yml
@@ -108,8 +108,10 @@ jobs:
       - name: Preflight connectivity
         run: |
           set -e
-          for url in "${{ steps.hosts.outputs.secure }}/health" \
-                     "${{ steps.hosts.outputs.open }}/health"; do
+          # Use / (not /health): payments.fictionally.org has no /health route.
+          for base in "${{ steps.hosts.outputs.secure }}" \
+                      "${{ steps.hosts.outputs.open }}"; do
+            url="${base}/"
             code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$url" || echo 000)
             echo "$url → $code"
             if [ "$code" != "200" ]; then

--- a/examples/wslproxy-waf-demo/test_waf_live.py
+++ b/examples/wslproxy-waf-demo/test_waf_live.py
@@ -193,8 +193,7 @@ CASES: list[Case] = [
     # Controls
     Case("benign-products", "none", "GET", "/products?cat=deposit",
          expect="allow"),
-    Case("benign-health", "none", "GET", "/health", expect="allow",
-         check_open=True),
+    Case("benign-home", "none", "GET", "/", expect="allow"),
     Case("bola-idor-business-logic", "none", "GET", "/api/accounts/9999",
          expect="allow",
          notes="signature WAF cannot stop object-level authz flaws"),
@@ -251,11 +250,12 @@ class WafLiveTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         # Connectivity smoke — fail fast if DNS/TLS is broken.
-        st, _, _ = fire(cls.secure, "GET", "/health", None, {}, None)
+        # Prefer / over /health: payments.fictionally.org has no /health route.
+        st, _, _ = fire(cls.secure, "GET", "/", None, {}, None)
         if st == 0:
             raise unittest.SkipTest(f"secure host unreachable: {cls.secure}")
         if not cls.skip_open:
-            st2, _, _ = fire(cls.open_host, "GET", "/health", None, {}, None)
+            st2, _, _ = fire(cls.open_host, "GET", "/", None, {}, None)
             if st2 == 0:
                 raise unittest.SkipTest(f"open host unreachable: {cls.open_host}")
 


### PR DESCRIPTION
## Summary
- `payments.fictionally.org/health` returns 404; preflight and connectivity smoke now use `/`
- Replace benign `/health` assertion with `/`

## Test plan
- [ ] Re-run **WAF — validate & live attack matrix** workflow_dispatch


Made with [Cursor](https://cursor.com)