### PR TITLE
feat(observability): WSLProxy Grafana dashboard suite + auto-deploy on merge

### DIFF
--- a/.github/workflows/deploy-grafana-dashboards.yml
+++ b/.github/workflows/deploy-grafana-dashboards.yml
@@ -1,0 +1,66 @@
+# Deploys the WSLProxy Grafana dashboard suite (observability/grafana/)
+# to the central obs Grafana whenever dashboard code lands on main.
+#
+# Secrets / variables (repo-level):
+#   GRAFANA_ADMIN_PASSWORD  (secret)  admin password for the target Grafana
+#   GRAFANA_URL             (variable, optional) defaults to the central
+#                           obs Grafana at grafana.workstation.co.uk
+#
+# The deploy script is idempotent (stable dashboard uids + overwrite), so
+# re-runs and manual dispatches are always safe.
+name: Deploy Grafana Dashboards
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "observability/grafana/**"
+      - ".github/workflows/deploy-grafana-dashboards.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: grafana-dashboards
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy dashboards to Grafana
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Verify generated dashboards are in sync with the generator
+        run: |
+          python3 observability/grafana/generate_dashboards.py
+          if ! git diff --exit-code observability/grafana/dashboards/; then
+            echo "::error::observability/grafana/dashboards/*.json is stale — run generate_dashboards.py and commit the result"
+            exit 1
+          fi
+
+      - name: Deploy to Grafana
+        env:
+          GRAFANA_URL: ${{ vars.GRAFANA_URL || 'https://grafana.workstation.co.uk' }}
+          GRAFANA_USER: admin
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+        run: ./observability/grafana/deploy.sh
+
+      - name: Smoke-check deployed dashboards
+        env:
+          GRAFANA_URL: ${{ vars.GRAFANA_URL || 'https://grafana.workstation.co.uk' }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_ADMIN_PASSWORD }}
+        run: |
+          fail=0
+          for f in observability/grafana/dashboards/*.json; do
+            uid=$(basename "$f" .json)
+            code=$(curl -sS -o /dev/null -w '%{http_code}' -u "admin:${GRAFANA_PASSWORD}" \
+              "${GRAFANA_URL%/}/api/dashboards/uid/${uid}")
+            if [ "$code" = "200" ]; then
+              echo "✓ ${uid}"
+            else
+              echo "::error::dashboard ${uid} not retrievable (HTTP ${code})"
+              fail=1
+            fi
+          done
+          exit $fail

--- a/observability/grafana/README.md
+++ b/observability/grafana/README.md
@@ -1,0 +1,54 @@
+# WSLProxy Grafana dashboards
+
+Dashboards-as-code for the metrics every WSLProxy edge exports at
+`/metrics` (see `api/prometheus_metrics.lua`). Deployed to the central
+obs Grafana at **https://grafana.workstation.co.uk** (folder *WSLProxy*).
+
+## The suite
+
+| Dashboard (uid) | What it shows |
+|---|---|
+| `wslproxy-edge-overview` | Golden signals per edge: RPS, 4xx/5xx rates, latency percentiles, connections, response sizes |
+| `wslproxy-backends` | Rule-routed backend health/throughput/latency (`wslproxy_backend_*`) + raw nginx upstreams (`nginx_proxy_*`) |
+| `wslproxy-cache` | Hit ratio, hits/misses/stores/bypasses, per-host and per-extension breakdowns |
+| `wslproxy-vhosts` | Per-domain traffic, errors, p95, endpoint breakdown; `$host` variable |
+| `wslproxy-security` | Suspicious requests, WAF inspection cost, 403 blocks, top client IPs, login failures |
+| `wslproxy-admin-api` | Control-plane `/api` usage, error rates, auth attempts |
+
+All dashboards have a `$pop` variable (edge selector). Data source is the
+obs Prometheus (uid `prometheus`), which scrapes the edges under
+`job="wslproxy-edges"` — the scrape job lives in
+`diy-tax-return-infra/kubernetes/observability/values-kube-prometheus-stack.yaml`.
+To monitor a new edge, add its `host:443` there (with a `pop` label) and
+re-run that repo's bootstrap script; the dashboards pick it up
+automatically via the `pop` label.
+
+## Editing
+
+The JSONs in `dashboards/` are **generated** — edit
+`generate_dashboards.py`, regenerate, and commit both:
+
+```console
+$ python3 observability/grafana/generate_dashboards.py
+```
+
+(The deploy workflow fails if the JSONs are stale relative to the
+generator.) Ad-hoc edits made in the Grafana UI are overwritten on the
+next deploy — port them into the generator.
+
+## Deploying
+
+Merging to `main` with changes under `observability/grafana/**` triggers
+`.github/workflows/deploy-grafana-dashboards.yml`, which upserts every
+dashboard through the Grafana HTTP API (stable uids, `overwrite: true`)
+and smoke-checks each one. Manual run: dispatch that workflow, or:
+
+```console
+$ GRAFANA_URL=https://grafana.workstation.co.uk \
+  GRAFANA_USER=admin GRAFANA_PASSWORD=... \
+  ./observability/grafana/deploy.sh
+```
+
+Credentials: repo secret `GRAFANA_ADMIN_PASSWORD` (admin password of the
+target Grafana — the `obs-grafana-admin` secret in the k3s1 `prod`
+namespace), optional repo variable `GRAFANA_URL`.

--- a/observability/grafana/dashboards/wslproxy-admin-api.json
+++ b/observability/grafana/dashboards/wslproxy-admin-api.json
@@ -1,0 +1,537 @@
+{
+  "description": "Control-plane usage: /api endpoint traffic, error rates, and login activity.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 52,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(api_calls_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "API calls / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.25
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 53,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(api_calls_total{job=\"wslproxy-edges\", pop=~\"$pop\", status=~\"[45]..\"}[$__rate_interval])) / sum(rate(api_calls_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "API error rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 54,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(api_auth_attempts_total{job=\"wslproxy-edges\", pop=~\"$pop\", result=\"success\"}[$__rate_interval])) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Logins ok / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 55,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(api_auth_attempts_total{job=\"wslproxy-edges\", pop=~\"$pop\", result!=\"success\"}[$__rate_interval])) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Logins failed / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(15, sum by (endpoint) (rate(api_calls_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top-15 API endpoints by rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 57,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (status) (rate(api_calls_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "API calls by status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 58,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum by (endpoint) (rate(api_calls_total{job=\"wslproxy-edges\", pop=~\"$pop\", status=~\"[45]..\"}[$__rate_interval])))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "API 4xx/5xx by endpoint",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 59,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (method) (rate(api_calls_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "API calls by method",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "wslproxy",
+    "generated"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "includeAll": true,
+        "label": "Edge (pop)",
+        "multi": true,
+        "name": "pop",
+        "query": {
+          "query": "label_values(up{job=\"wslproxy-edges\"}, pop)",
+          "refId": "var-pop"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "WSLProxy / Admin API",
+  "uid": "wslproxy-admin-api"
+}

--- a/observability/grafana/dashboards/wslproxy-backends.json
+++ b/observability/grafana/dashboards/wslproxy-backends.json
@@ -1,0 +1,744 @@
+{
+  "description": "Traffic-router backends (rule-level) and raw nginx upstreams: health, throughput, latency, errors.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(wslproxy_backend_healthy{job=\"wslproxy-edges\", pop=~\"$pop\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Healthy backends",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count(wslproxy_backend_healthy{job=\"wslproxy-edges\", pop=~\"$pop\"} == 0) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Unhealthy backends",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(wslproxy_backend_response_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend p95 response",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(wslproxy_backend_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\", status=~\"5..\"}[$__rate_interval])) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend 5xx / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "healthy"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "red",
+                        "text": "DOWN"
+                      },
+                      "1": {
+                        "color": "green",
+                        "text": "UP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 18,
+      "options": {
+        "showHeader": true,
+        "sortBy": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "wslproxy_backend_healthy{job=\"wslproxy-edges\", pop=~\"$pop\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Backend health (rule-routed backends)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "address": true,
+              "instance": true,
+              "job": true
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (backend_label) (rate(wslproxy_backend_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{backend_label}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend requests/sec by backend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (backend_label) (rate(wslproxy_backend_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\", status=~\"5..\"}[$__rate_interval]))",
+          "legendFormat": "{{backend_label}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend errors/sec (5xx) by backend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, backend_label) (rate(wslproxy_backend_response_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "{{backend_label}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend p95 response time by backend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (status) (rate(wslproxy_backend_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Backend request status breakdown",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (upstream) (rate(nginx_proxy_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ],
+      "title": "nginx proxy requests/sec by upstream",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, upstream) (rate(nginx_proxy_response_time_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "{{upstream}}",
+          "refId": "A"
+        }
+      ],
+      "title": "nginx proxy p95 response time by upstream",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "wslproxy",
+    "generated"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "includeAll": true,
+        "label": "Edge (pop)",
+        "multi": true,
+        "name": "pop",
+        "query": {
+          "query": "label_values(up{job=\"wslproxy-edges\"}, pop)",
+          "refId": "var-pop"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "WSLProxy / Backends & Upstreams",
+  "uid": "wslproxy-backends"
+}

--- a/observability/grafana/dashboards/wslproxy-cache.json
+++ b/observability/grafana/dashboards/wslproxy-cache.json
@@ -1,0 +1,737 @@
+{
+  "description": "Static-content cache effectiveness: hit ratio, operations, per-host and per-extension breakdowns.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 0,
+        "y": 0
+      },
+      "id": 25,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) / (sum(rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) + sum(rate(nginx_cache_misses_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache hit ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 5,
+        "y": 0
+      },
+      "id": 26,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Hits / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 10,
+        "y": 0
+      },
+      "id": 27,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_cache_misses_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Misses / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 15,
+        "y": 0
+      },
+      "id": 28,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_cache_stores_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Stores / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 29,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(nginx_cache_enabled{job=\"wslproxy-edges\", pop=~\"$pop\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Hosts with cache on",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) / (sum(rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) + sum(rate(nginx_cache_misses_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "hit ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Hit ratio over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "hits",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_cache_misses_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "misses",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_cache_stores_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "stores",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_cache_bypasses_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "bypasses",
+          "refId": "D"
+        }
+      ],
+      "title": "Cache operations/sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum by (host) (rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top-10 hosts by cache hits",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (host) (rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) / (sum by (host) (rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) + sum by (host) (rate(nginx_cache_misses_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) > 0)",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Hit ratio by host (active hosts)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (extension) (rate(nginx_cache_hits_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{extension}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cache hits by file extension",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum by (host) (rate(nginx_cache_bypasses_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Bypasses/sec by host",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "wslproxy",
+    "generated"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "includeAll": true,
+        "label": "Edge (pop)",
+        "multi": true,
+        "name": "pop",
+        "query": {
+          "query": "label_values(up{job=\"wslproxy-edges\"}, pop)",
+          "refId": "var-pop"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "WSLProxy / Cache",
+  "uid": "wslproxy-cache"
+}

--- a/observability/grafana/dashboards/wslproxy-edge-overview.json
+++ b/observability/grafana/dashboards/wslproxy-edge-overview.json
@@ -1,0 +1,875 @@
+{
+  "description": "Golden signals for every WSLProxy edge: traffic, errors, latency, saturation.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_http_5xx_errors_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) / sum(rate(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx error rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_http_4xx_errors_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) / sum(rate(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "4xx error rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "p95 latency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(nginx_http_connections{job=\"wslproxy-edges\", pop=~\"$pop\"})",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Active connections",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count(up{job=\"wslproxy-edges\", pop=~\"$pop\"} == 1)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Edges up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (pop) (rate(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{pop}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests/sec by edge",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (status) (rate(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests/sec by status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.90, sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(nginx_http_request_duration_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Request latency percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (pop) (rate(nginx_http_4xx_errors_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "4xx {{pop}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (pop) (rate(nginx_http_5xx_errors_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "5xx {{pop}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Errors/sec (4xx vs 5xx) by edge",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 20
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (state) (nginx_http_connections{job=\"wslproxy-edges\", pop=~\"$pop\"})",
+          "legendFormat": "{{state}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Connections by state",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 20
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, pop) (rate(nginx_http_response_size_bytes_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "{{pop}}",
+          "refId": "A"
+        }
+      ],
+      "title": "p95 response size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 20
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (method) (rate(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests/sec by method",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "wslproxy",
+    "generated"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "includeAll": true,
+        "label": "Edge (pop)",
+        "multi": true,
+        "name": "pop",
+        "query": {
+          "query": "label_values(up{job=\"wslproxy-edges\"}, pop)",
+          "refId": "var-pop"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "WSLProxy / Edge Overview",
+  "uid": "wslproxy-edge-overview"
+}

--- a/observability/grafana/dashboards/wslproxy-security.json
+++ b/observability/grafana/dashboards/wslproxy-security.json
@@ -1,0 +1,659 @@
+{
+  "description": "Threat surface: suspicious traffic, WAF cost, blocked requests, noisy client IPs, login abuse.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 42,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_http_suspicious_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Suspicious req / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "id": 43,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(nginx_http_4xx_errors_total{job=\"wslproxy-edges\", pop=~\"$pop\", status=\"403\"}[$__rate_interval])) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "403 blocks / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 4,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "id": 44,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(nginx_waf_inspection_duration_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "WAF p95 inspection",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "decimals": 3,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "id": 45,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(api_auth_attempts_total{job=\"wslproxy-edges\", pop=~\"$pop\", result!=\"success\"}[$__rate_interval])) OR on() vector(0)",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed logins / sec",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 46,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (reason) (rate(nginx_http_suspicious_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Suspicious requests by reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 47,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum by (host) (rate(nginx_http_suspicious_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Suspicious requests by host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 48,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum by (ip) (rate(nginx_http_requests_by_ip_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "{{ip}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top-10 client IPs by request rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(10, sum by (host) (rate(nginx_http_4xx_errors_total{job=\"wslproxy-edges\", pop=~\"$pop\", status=\"403\"}[$__rate_interval])))",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "403 blocks by host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 50,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, host) (rate(nginx_waf_inspection_duration_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval])))",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "WAF inspection p95 by host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "normal"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 51,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (result) (rate(api_auth_attempts_total{job=\"wslproxy-edges\", pop=~\"$pop\"}[$__rate_interval]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Auth attempts by result",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "wslproxy",
+    "generated"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "includeAll": true,
+        "label": "Edge (pop)",
+        "multi": true,
+        "name": "pop",
+        "query": {
+          "query": "label_values(up{job=\"wslproxy-edges\"}, pop)",
+          "refId": "var-pop"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "WSLProxy / Security & WAF",
+  "uid": "wslproxy-security"
+}

--- a/observability/grafana/dashboards/wslproxy-vhosts.json
+++ b/observability/grafana/dashboards/wslproxy-vhosts.json
@@ -1,0 +1,511 @@
+{
+  "description": "Per-domain view: which virtual hosts get the traffic, the errors, and the slow requests.",
+  "editable": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(15, sum by (host) (rate(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\", host=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top-15 hosts by requests/sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(15, sum by (host) (rate(nginx_http_errors_total{job=\"wslproxy-edges\", pop=~\"$pop\", host=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors/sec by host (4xx+5xx)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, host) (rate(nginx_http_request_duration_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\", host=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "p95 latency by host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (host) (rate(nginx_http_5xx_errors_total{job=\"wslproxy-edges\", pop=~\"$pop\", host=~\"$host\"}[$__rate_interval]))",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "5xx/sec by host",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {},
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "req/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx/s"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "reqps"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p95 (s)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 40,
+      "options": {
+        "showHeader": true,
+        "sortBy": []
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (host) (rate(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\", host=~\"$host\"}[1h]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (host) (rate(nginx_http_5xx_errors_total{job=\"wslproxy-edges\", pop=~\"$pop\", host=~\"$host\"}[1h]))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le, host) (rate(nginx_http_request_duration_seconds_bucket{job=\"wslproxy-edges\", pop=~\"$pop\", host=~\"$host\"}[1h])))",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "range": false,
+          "refId": "C"
+        }
+      ],
+      "title": "Per-host traffic summary (1h)",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "host",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true
+            },
+            "renameByName": {
+              "Value #A": "req/s",
+              "Value #B": "5xx/s",
+              "Value #C": "p95 (s)"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 8,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "topk(15, sum by (endpoint) (rate(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\", host=~\"$host\"}[$__rate_interval])))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Requests/sec by endpoint (selected hosts)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "wslproxy",
+    "generated"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "includeAll": true,
+        "label": "Edge (pop)",
+        "multi": true,
+        "name": "pop",
+        "query": {
+          "query": "label_values(up{job=\"wslproxy-edges\"}, pop)",
+          "refId": "var-pop"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "includeAll": true,
+        "label": "Virtual host",
+        "multi": true,
+        "name": "host",
+        "query": {
+          "query": "label_values(nginx_http_requests_total{job=\"wslproxy-edges\", pop=~\"$pop\"}, host)",
+          "refId": "var-host"
+        },
+        "refresh": 2,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "WSLProxy / Virtual Hosts",
+  "uid": "wslproxy-vhosts"
+}

--- a/observability/grafana/deploy.sh
+++ b/observability/grafana/deploy.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Deploy the WSLProxy dashboard suite to Grafana.
+#
+# Idempotent: ensures the Prometheus datasource and the "WSLProxy" folder
+# exist, then upserts every dashboards/*.json (overwrite=true, stable
+# uids). Run locally or from CI:
+#
+#   GRAFANA_URL=https://grafana.workstation.co.uk \
+#   GRAFANA_USER=admin GRAFANA_PASSWORD=... ./deploy.sh
+set -euo pipefail
+
+GRAFANA_URL="${GRAFANA_URL:?set GRAFANA_URL}"
+GRAFANA_USER="${GRAFANA_USER:-admin}"
+GRAFANA_PASSWORD="${GRAFANA_PASSWORD:?set GRAFANA_PASSWORD}"
+# In-cluster Prometheus the datasource should point at if it has to be
+# created. On the central obs stack the DS already exists (uid
+# "prometheus") and this is never used.
+PROM_URL="${PROM_URL:-http://obs-prometheus.prod:9090/}"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+api() { # method path [json-file]
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" -H 'Content-Type: application/json'
+              -X "$method" "${GRAFANA_URL%/}${path}" -w '\n%{http_code}')
+  [ -n "$body" ] && args+=(--data-binary "@${body}")
+  curl "${args[@]}"
+}
+
+check() { # "label" response  → fails the script on non-2xx
+  local label="$1" resp="$2"
+  local code="${resp##*$'\n'}" body="${resp%$'\n'*}"
+  if [ "${code:0:1}" != "2" ]; then
+    echo "✗ ${label}: HTTP ${code}: ${body}" >&2
+    exit 1
+  fi
+  echo "✓ ${label}"
+}
+
+echo "── Grafana: ${GRAFANA_URL}"
+
+# 1. Ensure the Prometheus datasource (uid "prometheus") exists.
+ds_code=$(curl -sS -o /dev/null -w '%{http_code}' -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" \
+  "${GRAFANA_URL%/}/api/datasources/uid/prometheus")
+if [ "$ds_code" = "404" ]; then
+  tmp=$(mktemp)
+  cat > "$tmp" <<EOF
+{"name": "Prometheus", "uid": "prometheus", "type": "prometheus",
+ "url": "${PROM_URL}", "access": "proxy", "isDefault": true}
+EOF
+  check "create Prometheus datasource" "$(api POST /api/datasources "$tmp")"
+  rm -f "$tmp"
+else
+  echo "✓ Prometheus datasource present (HTTP ${ds_code})"
+fi
+
+# 2. Ensure the WSLProxy folder.
+folder_code=$(curl -sS -o /dev/null -w '%{http_code}' -u "${GRAFANA_USER}:${GRAFANA_PASSWORD}" \
+  "${GRAFANA_URL%/}/api/folders/wslproxy")
+if [ "$folder_code" = "404" ]; then
+  tmp=$(mktemp)
+  echo '{"uid": "wslproxy", "title": "WSLProxy"}' > "$tmp"
+  check "create WSLProxy folder" "$(api POST /api/folders "$tmp")"
+  rm -f "$tmp"
+else
+  echo "✓ WSLProxy folder present (HTTP ${folder_code})"
+fi
+
+# 3. Upsert every dashboard.
+fail=0
+for f in "$DIR"/dashboards/*.json; do
+  name=$(basename "$f" .json)
+  tmp=$(mktemp)
+  python3 - "$f" > "$tmp" <<'EOF'
+import json, sys
+d = json.load(open(sys.argv[1]))
+d.pop("id", None)          # never pin a numeric id — uid is the identity
+print(json.dumps({"dashboard": d, "folderUid": "wslproxy",
+                  "overwrite": True, "message": "deployed by observability/grafana/deploy.sh"}))
+EOF
+  resp=$(api POST /api/dashboards/db "$tmp"); rm -f "$tmp"
+  code="${resp##*$'\n'}"
+  if [ "${code:0:1}" = "2" ]; then
+    echo "✓ dashboard ${name}"
+  else
+    echo "✗ dashboard ${name}: HTTP ${code}: ${resp%$'\n'*}" >&2
+    fail=1
+  fi
+done
+exit $fail

--- a/observability/grafana/generate_dashboards.py
+++ b/observability/grafana/generate_dashboards.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Generate the WSLProxy Grafana dashboard suite into dashboards/.
+
+The dashboards target the metrics the OpenResty exporter serves at
+/metrics on every edge (see api/prometheus_metrics.lua), scraped by the
+central obs Prometheus under job="wslproxy-edges" with a `pop` label per
+edge (lon1, pop1, ...). Re-run after editing and commit the JSONs:
+
+    python3 observability/grafana/generate_dashboards.py
+"""
+import json
+import os
+
+OUT = os.path.join(os.path.dirname(__file__), "dashboards")
+DS = {"type": "prometheus", "uid": "prometheus"}
+JOB = 'job="wslproxy-edges"'
+POP = 'pop=~"$pop"'
+SEL = f"{JOB}, {POP}"
+_id = 0
+
+
+def nid():
+    global _id
+    _id += 1
+    return _id
+
+
+def target(expr, legend="", ref="A", instant=False, fmt="time_series"):
+    t = {"refId": ref, "expr": expr, "legendFormat": legend, "datasource": DS}
+    if instant:
+        t["instant"] = True
+        t["range"] = False
+    if fmt != "time_series":
+        t["format"] = fmt
+    return t
+
+
+def panel(ptype, title, gridPos, targets, unit="short", **kw):
+    p = {
+        "id": nid(),
+        "type": ptype,
+        "title": title,
+        "gridPos": gridPos,
+        "datasource": DS,
+        "targets": targets,
+        "fieldConfig": {
+            "defaults": {"unit": unit, "custom": {}, "color": {"mode": "palette-classic"}},
+            "overrides": kw.pop("overrides", []),
+        },
+        "options": kw.pop("options", {}),
+    }
+    p.update(kw)
+    return p
+
+
+def ts(title, gridPos, targets, unit="short", stacked=False, fillOpacity=8, **kw):
+    p = panel("timeseries", title, gridPos, targets, unit, **kw)
+    p["fieldConfig"]["defaults"]["custom"] = {
+        "drawStyle": "line",
+        "lineWidth": 1,
+        "fillOpacity": fillOpacity,
+        "showPoints": "never",
+        "stacking": {"mode": "normal" if stacked else "none"},
+    }
+    p["options"] = {
+        "legend": {"displayMode": "table", "placement": "bottom",
+                   "calcs": ["mean", "max", "lastNotNull"]},
+        "tooltip": {"mode": "multi", "sort": "desc"},
+    }
+    return p
+
+
+def stat(title, gridPos, targets, unit="short", thresholds=None, decimals=None):
+    p = panel("stat", title, gridPos, targets, unit)
+    if decimals is not None:
+        p["fieldConfig"]["defaults"]["decimals"] = decimals
+    p["fieldConfig"]["defaults"]["color"] = {"mode": "thresholds"}
+    p["fieldConfig"]["defaults"]["thresholds"] = thresholds or {
+        "mode": "absolute", "steps": [{"color": "green", "value": None}]}
+    p["options"] = {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": False},
+        "orientation": "auto", "textMode": "auto", "colorMode": "value",
+        "graphMode": "area", "justifyMode": "auto",
+    }
+    return p
+
+
+def table(title, gridPos, targets, unit="short", overrides=None, transformations=None):
+    p = panel("table", title, gridPos, targets, unit, overrides=overrides or [])
+    p["options"] = {"showHeader": True, "sortBy": []}
+    if transformations:
+        p["transformations"] = transformations
+    return p
+
+
+def pop_var():
+    return {
+        "name": "pop", "label": "Edge (pop)", "type": "query", "datasource": DS,
+        "query": {"query": f'label_values(up{{{JOB}}}, pop)', "refId": "var-pop"},
+        "refresh": 2, "includeAll": True, "multi": True, "sort": 1,
+        "current": {"selected": True, "text": ["All"], "value": ["$__all"]},
+    }
+
+
+def host_var():
+    return {
+        "name": "host", "label": "Virtual host", "type": "query", "datasource": DS,
+        "query": {"query": f'label_values(nginx_http_requests_total{{{JOB}, {POP}}}, host)',
+                  "refId": "var-host"},
+        "refresh": 2, "includeAll": True, "multi": True, "sort": 1,
+        "current": {"selected": True, "text": ["All"], "value": ["$__all"]},
+    }
+
+
+def dashboard(uid, title, panels, variables=None, description=""):
+    return {
+        "uid": uid,
+        "title": title,
+        "description": description,
+        "tags": ["wslproxy", "generated"],
+        "timezone": "browser",
+        "schemaVersion": 39,
+        "refresh": "30s",
+        "time": {"from": "now-6h", "to": "now"},
+        "editable": True,
+        "templating": {"list": variables or [pop_var()]},
+        "panels": panels,
+    }
+
+
+RATE = "$__rate_interval"
+
+
+def q(metric, extra="", rng=RATE):
+    filt = SEL + (", " + extra if extra else "")
+    return f"rate({metric}{{{filt}}}[{rng}])"
+
+
+def hq(quant, bucket, by="", extra=""):
+    filt = SEL + (", " + extra if extra else "")
+    grp = "le" + (", " + by if by else "")
+    return (f"histogram_quantile({quant}, sum by ({grp}) "
+            f"(rate({bucket}{{{filt}}}[{RATE}])))")
+
+
+# ── 1. Edge Overview ────────────────────────────────────────────────────────
+overview = dashboard(
+    "wslproxy-edge-overview", "WSLProxy / Edge Overview",
+    [
+        stat("Requests / sec", {"h": 4, "w": 4, "x": 0, "y": 0},
+             [target(f"sum({q('nginx_http_requests_total')})")], "reqps", decimals=1),
+        stat("5xx error rate", {"h": 4, "w": 4, "x": 4, "y": 0},
+             [target(f"sum({q('nginx_http_5xx_errors_total')}) / sum({q('nginx_http_requests_total')})")],
+             "percentunit",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None},
+                                            {"color": "yellow", "value": 0.01},
+                                            {"color": "red", "value": 0.05}]}, decimals=2),
+        stat("4xx error rate", {"h": 4, "w": 4, "x": 8, "y": 0},
+             [target(f"sum({q('nginx_http_4xx_errors_total')}) / sum({q('nginx_http_requests_total')})")],
+             "percentunit",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None},
+                                            {"color": "yellow", "value": 0.05},
+                                            {"color": "red", "value": 0.20}]}, decimals=2),
+        stat("p95 latency", {"h": 4, "w": 4, "x": 12, "y": 0},
+             [target(hq("0.95", "nginx_http_request_duration_seconds_bucket"))], "s",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None},
+                                            {"color": "yellow", "value": 0.5},
+                                            {"color": "red", "value": 2}]}, decimals=3),
+        stat("Active connections", {"h": 4, "w": 4, "x": 16, "y": 0},
+             [target(f"sum(nginx_http_connections{{{SEL}}})")], "short"),
+        stat("Edges up", {"h": 4, "w": 4, "x": 20, "y": 0},
+             [target(f"count(up{{{SEL}}} == 1)")], "short",
+             {"mode": "absolute", "steps": [{"color": "red", "value": None},
+                                            {"color": "green", "value": 2}]}),
+        ts("Requests/sec by edge", {"h": 8, "w": 12, "x": 0, "y": 4},
+           [target(f"sum by (pop) ({q('nginx_http_requests_total')})", "{{pop}}")], "reqps"),
+        ts("Requests/sec by status", {"h": 8, "w": 12, "x": 12, "y": 4},
+           [target(f"sum by (status) ({q('nginx_http_requests_total')})", "{{status}}")],
+           "reqps", stacked=True),
+        ts("Request latency percentiles", {"h": 8, "w": 12, "x": 0, "y": 12},
+           [target(hq("0.50", "nginx_http_request_duration_seconds_bucket"), "p50", "A"),
+            target(hq("0.90", "nginx_http_request_duration_seconds_bucket"), "p90", "B"),
+            target(hq("0.99", "nginx_http_request_duration_seconds_bucket"), "p99", "C")], "s"),
+        ts("Errors/sec (4xx vs 5xx) by edge", {"h": 8, "w": 12, "x": 12, "y": 12},
+           [target(f"sum by (pop) ({q('nginx_http_4xx_errors_total')})", "4xx {{pop}}", "A"),
+            target(f"sum by (pop) ({q('nginx_http_5xx_errors_total')})", "5xx {{pop}}", "B")], "reqps"),
+        ts("Connections by state", {"h": 8, "w": 8, "x": 0, "y": 20},
+           [target(f"sum by (state) (nginx_http_connections{{{SEL}}})", "{{state}}")], "short"),
+        ts("p95 response size", {"h": 8, "w": 8, "x": 8, "y": 20},
+           [target(hq("0.95", "nginx_http_response_size_bytes_bucket", "pop"), "{{pop}}")], "bytes"),
+        ts("Requests/sec by method", {"h": 8, "w": 8, "x": 16, "y": 20},
+           [target(f"sum by (method) ({q('nginx_http_requests_total')})", "{{method}}")],
+           "reqps", stacked=True),
+    ],
+    description="Golden signals for every WSLProxy edge: traffic, errors, latency, saturation.",
+)
+
+# ── 2. Backends & Upstreams ─────────────────────────────────────────────────
+backends = dashboard(
+    "wslproxy-backends", "WSLProxy / Backends & Upstreams",
+    [
+        stat("Healthy backends", {"h": 4, "w": 6, "x": 0, "y": 0},
+             [target(f"sum(wslproxy_backend_healthy{{{SEL}}})")], "short",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None}]}),
+        stat("Unhealthy backends", {"h": 4, "w": 6, "x": 6, "y": 0},
+             [target(f"count(wslproxy_backend_healthy{{{SEL}}} == 0) OR on() vector(0)")], "short",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None},
+                                            {"color": "red", "value": 1}]}),
+        stat("Backend p95 response", {"h": 4, "w": 6, "x": 12, "y": 0},
+             [target(hq("0.95", "wslproxy_backend_response_seconds_bucket"))], "s", decimals=3),
+        stat("Backend 5xx / sec", {"h": 4, "w": 6, "x": 18, "y": 0},
+             [target(f"sum({q('wslproxy_backend_requests_total', 'status=~\"5..\"')}) OR on() vector(0)")],
+             "reqps",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None},
+                                            {"color": "red", "value": 1}]}, decimals=2),
+        table("Backend health (rule-routed backends)", {"h": 9, "w": 24, "x": 0, "y": 4},
+              [target(f"wslproxy_backend_healthy{{{SEL}}}", instant=True, fmt="table")],
+              overrides=[{
+                  "matcher": {"id": "byName", "options": "Value"},
+                  "properties": [
+                      {"id": "displayName", "value": "healthy"},
+                      {"id": "mappings", "value": [
+                          {"type": "value",
+                           "options": {"0": {"text": "DOWN", "color": "red"},
+                                       "1": {"text": "UP", "color": "green"}}}]},
+                      {"id": "custom.cellOptions", "value": {"type": "color-background"}},
+                  ]}],
+              transformations=[{"id": "organize", "options": {
+                  "excludeByName": {"Time": True, "__name__": True, "job": True,
+                                    "instance": True, "address": True},
+                  "renameByName": {}}}]),
+        ts("Backend requests/sec by backend", {"h": 8, "w": 12, "x": 0, "y": 13},
+           [target(f"sum by (backend_label) ({q('wslproxy_backend_requests_total')})",
+                   "{{backend_label}}")], "reqps"),
+        ts("Backend errors/sec (5xx) by backend", {"h": 8, "w": 12, "x": 12, "y": 13},
+           [target(f"sum by (backend_label) ({q('wslproxy_backend_requests_total', 'status=~\"5..\"')})",
+                   "{{backend_label}}")], "reqps"),
+        ts("Backend p95 response time by backend", {"h": 8, "w": 12, "x": 0, "y": 21},
+           [target(hq("0.95", "wslproxy_backend_response_seconds_bucket", "backend_label"),
+                   "{{backend_label}}")], "s"),
+        ts("Backend request status breakdown", {"h": 8, "w": 12, "x": 12, "y": 21},
+           [target(f"sum by (status) ({q('wslproxy_backend_requests_total')})", "{{status}}")],
+           "reqps", stacked=True),
+        ts("nginx proxy requests/sec by upstream", {"h": 8, "w": 12, "x": 0, "y": 29},
+           [target(f"sum by (upstream) ({q('nginx_proxy_requests_total')})", "{{upstream}}")], "reqps"),
+        ts("nginx proxy p95 response time by upstream", {"h": 8, "w": 12, "x": 12, "y": 29},
+           [target(hq("0.95", "nginx_proxy_response_time_seconds_bucket", "upstream"),
+                   "{{upstream}}")], "s"),
+    ],
+    description="Traffic-router backends (rule-level) and raw nginx upstreams: health, throughput, latency, errors.",
+)
+
+# ── 3. Cache ────────────────────────────────────────────────────────────────
+CACHE_HITS = q("nginx_cache_hits_total")
+CACHE_MISS = q("nginx_cache_misses_total")
+cache = dashboard(
+    "wslproxy-cache", "WSLProxy / Cache",
+    [
+        stat("Cache hit ratio", {"h": 4, "w": 5, "x": 0, "y": 0},
+             [target(f"sum({CACHE_HITS}) / (sum({CACHE_HITS}) + sum({CACHE_MISS}))")],
+             "percentunit",
+             {"mode": "absolute", "steps": [{"color": "red", "value": None},
+                                            {"color": "yellow", "value": 0.5},
+                                            {"color": "green", "value": 0.8}]}, decimals=2),
+        stat("Hits / sec", {"h": 4, "w": 5, "x": 5, "y": 0},
+             [target(f"sum({CACHE_HITS})")], "reqps", decimals=1),
+        stat("Misses / sec", {"h": 4, "w": 5, "x": 10, "y": 0},
+             [target(f"sum({CACHE_MISS})")], "reqps", decimals=1),
+        stat("Stores / sec", {"h": 4, "w": 5, "x": 15, "y": 0},
+             [target(f"sum({q('nginx_cache_stores_total')})")], "reqps", decimals=1),
+        stat("Hosts with cache on", {"h": 4, "w": 4, "x": 20, "y": 0},
+             [target(f"sum(nginx_cache_enabled{{{SEL}}})")], "short"),
+        ts("Hit ratio over time", {"h": 8, "w": 12, "x": 0, "y": 4},
+           [target(f"sum({CACHE_HITS}) / (sum({CACHE_HITS}) + sum({CACHE_MISS}))", "hit ratio")],
+           "percentunit"),
+        ts("Cache operations/sec", {"h": 8, "w": 12, "x": 12, "y": 4},
+           [target(f"sum({CACHE_HITS})", "hits", "A"),
+            target(f"sum({CACHE_MISS})", "misses", "B"),
+            target(f"sum({q('nginx_cache_stores_total')})", "stores", "C"),
+            target(f"sum({q('nginx_cache_bypasses_total')})", "bypasses", "D")],
+           "reqps", stacked=True),
+        ts("Top-10 hosts by cache hits", {"h": 8, "w": 12, "x": 0, "y": 12},
+           [target(f"topk(10, sum by (host) ({CACHE_HITS}))", "{{host}}")], "reqps"),
+        ts("Hit ratio by host (active hosts)", {"h": 8, "w": 12, "x": 12, "y": 12},
+           [target(f"sum by (host) ({CACHE_HITS}) / "
+                   f"(sum by (host) ({CACHE_HITS}) + sum by (host) ({CACHE_MISS}) > 0)",
+                   "{{host}}")], "percentunit"),
+        ts("Cache hits by file extension", {"h": 8, "w": 12, "x": 0, "y": 20},
+           [target(f"sum by (extension) ({CACHE_HITS})", "{{extension}}")], "reqps", stacked=True),
+        ts("Bypasses/sec by host", {"h": 8, "w": 12, "x": 12, "y": 20},
+           [target(f"topk(10, sum by (host) ({q('nginx_cache_bypasses_total')}))", "{{host}}")],
+           "reqps"),
+    ],
+    description="Static-content cache effectiveness: hit ratio, operations, per-host and per-extension breakdowns.",
+)
+
+# ── 4. Virtual Hosts ────────────────────────────────────────────────────────
+HOSTSEL = SEL + ', host=~"$host"'
+vhosts = dashboard(
+    "wslproxy-vhosts", "WSLProxy / Virtual Hosts",
+    [
+        ts("Top-15 hosts by requests/sec", {"h": 9, "w": 12, "x": 0, "y": 0},
+           [target(f"topk(15, sum by (host) (rate(nginx_http_requests_total{{{HOSTSEL}}}[{RATE}])))",
+                   "{{host}}")], "reqps"),
+        ts("Errors/sec by host (4xx+5xx)", {"h": 9, "w": 12, "x": 12, "y": 0},
+           [target(f"topk(15, sum by (host) (rate(nginx_http_errors_total{{{HOSTSEL}}}[{RATE}])))",
+                   "{{host}}")], "reqps"),
+        ts("p95 latency by host", {"h": 9, "w": 12, "x": 0, "y": 9},
+           [target("histogram_quantile(0.95, sum by (le, host) "
+                   f"(rate(nginx_http_request_duration_seconds_bucket{{{HOSTSEL}}}[{RATE}])))",
+                   "{{host}}")], "s"),
+        ts("5xx/sec by host", {"h": 9, "w": 12, "x": 12, "y": 9},
+           [target(f"sum by (host) (rate(nginx_http_5xx_errors_total{{{HOSTSEL}}}[{RATE}]))",
+                   "{{host}}")], "reqps"),
+        table("Per-host traffic summary (1h)", {"h": 10, "w": 24, "x": 0, "y": 18},
+              [target(f"sum by (host) (rate(nginx_http_requests_total{{{HOSTSEL}}}[1h]))",
+                      ref="A", instant=True, fmt="table"),
+               target(f"sum by (host) (rate(nginx_http_5xx_errors_total{{{HOSTSEL}}}[1h]))",
+                      ref="B", instant=True, fmt="table"),
+               target("histogram_quantile(0.95, sum by (le, host) "
+                      f"(rate(nginx_http_request_duration_seconds_bucket{{{HOSTSEL}}}[1h])))",
+                      ref="C", instant=True, fmt="table")],
+              transformations=[
+                  {"id": "joinByField", "options": {"byField": "host", "mode": "outer"}},
+                  {"id": "organize", "options": {
+                      "excludeByName": {"Time": True, "Time 1": True, "Time 2": True,
+                                        "Time 3": True},
+                      "renameByName": {"Value #A": "req/s", "Value #B": "5xx/s",
+                                       "Value #C": "p95 (s)"}}}],
+              overrides=[{"matcher": {"id": "byName", "options": "req/s"},
+                          "properties": [{"id": "unit", "value": "reqps"},
+                                         {"id": "decimals", "value": 3}]},
+                         {"matcher": {"id": "byName", "options": "5xx/s"},
+                          "properties": [{"id": "unit", "value": "reqps"},
+                                         {"id": "decimals", "value": 3}]},
+                         {"matcher": {"id": "byName", "options": "p95 (s)"},
+                          "properties": [{"id": "unit", "value": "s"},
+                                         {"id": "decimals", "value": 3}]}]),
+        ts("Requests/sec by endpoint (selected hosts)", {"h": 9, "w": 24, "x": 0, "y": 28},
+           [target(f"topk(15, sum by (endpoint) (rate(nginx_http_requests_total{{{HOSTSEL}}}[{RATE}])))",
+                   "{{endpoint}}")], "reqps"),
+    ],
+    [pop_var(), host_var()],
+    description="Per-domain view: which virtual hosts get the traffic, the errors, and the slow requests.",
+)
+
+# ── 5. Security & WAF ───────────────────────────────────────────────────────
+security = dashboard(
+    "wslproxy-security", "WSLProxy / Security & WAF",
+    [
+        stat("Suspicious req / sec", {"h": 4, "w": 6, "x": 0, "y": 0},
+             [target(f"sum({q('nginx_http_suspicious_requests_total')}) OR on() vector(0)")],
+             "reqps",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None},
+                                            {"color": "yellow", "value": 0.5},
+                                            {"color": "red", "value": 5}]}, decimals=2),
+        stat("403 blocks / sec", {"h": 4, "w": 6, "x": 6, "y": 0},
+             [target(f"sum({q('nginx_http_4xx_errors_total', 'status=\"403\"')}) OR on() vector(0)")],
+             "reqps", decimals=2),
+        stat("WAF p95 inspection", {"h": 4, "w": 6, "x": 12, "y": 0},
+             [target(hq("0.95", "nginx_waf_inspection_duration_seconds_bucket"))], "s",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None},
+                                            {"color": "yellow", "value": 0.01},
+                                            {"color": "red", "value": 0.1}]}, decimals=4),
+        stat("Failed logins / sec", {"h": 4, "w": 6, "x": 18, "y": 0},
+             [target(f"sum({q('api_auth_attempts_total', 'result!=\"success\"')}) OR on() vector(0)")],
+             "reqps", decimals=3),
+        ts("Suspicious requests by reason", {"h": 8, "w": 12, "x": 0, "y": 4},
+           [target(f"sum by (reason) ({q('nginx_http_suspicious_requests_total')})",
+                   "{{reason}}")], "reqps", stacked=True),
+        ts("Suspicious requests by host", {"h": 8, "w": 12, "x": 12, "y": 4},
+           [target(f"topk(10, sum by (host) ({q('nginx_http_suspicious_requests_total')}))",
+                   "{{host}}")], "reqps"),
+        ts("Top-10 client IPs by request rate", {"h": 8, "w": 12, "x": 0, "y": 12},
+           [target(f"topk(10, sum by (ip) ({q('nginx_http_requests_by_ip_total')}))",
+                   "{{ip}}")], "reqps"),
+        ts("403 blocks by host", {"h": 8, "w": 12, "x": 12, "y": 12},
+           [target(f"topk(10, sum by (host) ({q('nginx_http_4xx_errors_total', 'status=\"403\"')}))",
+                   "{{host}}")], "reqps"),
+        ts("WAF inspection p95 by host", {"h": 8, "w": 12, "x": 0, "y": 20},
+           [target(hq("0.95", "nginx_waf_inspection_duration_seconds_bucket", "host"),
+                   "{{host}}")], "s"),
+        ts("Auth attempts by result", {"h": 8, "w": 12, "x": 12, "y": 20},
+           [target(f"sum by (result) ({q('api_auth_attempts_total')})", "{{result}}")],
+           "reqps", stacked=True),
+    ],
+    description="Threat surface: suspicious traffic, WAF cost, blocked requests, noisy client IPs, login abuse.",
+)
+
+# ── 6. Admin API ────────────────────────────────────────────────────────────
+admin_api = dashboard(
+    "wslproxy-admin-api", "WSLProxy / Admin API",
+    [
+        stat("API calls / sec", {"h": 4, "w": 6, "x": 0, "y": 0},
+             [target(f"sum({q('api_calls_total')})")], "reqps", decimals=2),
+        stat("API error rate", {"h": 4, "w": 6, "x": 6, "y": 0},
+             [target(f"sum({q('api_calls_total', 'status=~\"[45]..\"')}) / sum({q('api_calls_total')})")],
+             "percentunit",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None},
+                                            {"color": "yellow", "value": 0.05},
+                                            {"color": "red", "value": 0.25}]}, decimals=2),
+        stat("Logins ok / sec", {"h": 4, "w": 6, "x": 12, "y": 0},
+             [target(f"sum({q('api_auth_attempts_total', 'result=\"success\"')}) OR on() vector(0)")],
+             "reqps", decimals=3),
+        stat("Logins failed / sec", {"h": 4, "w": 6, "x": 18, "y": 0},
+             [target(f"sum({q('api_auth_attempts_total', 'result!=\"success\"')}) OR on() vector(0)")],
+             "reqps",
+             {"mode": "absolute", "steps": [{"color": "green", "value": None},
+                                            {"color": "red", "value": 0.1}]}, decimals=3),
+        ts("Top-15 API endpoints by rate", {"h": 9, "w": 12, "x": 0, "y": 4},
+           [target(f"topk(15, sum by (endpoint) ({q('api_calls_total')}))", "{{endpoint}}")],
+           "reqps"),
+        ts("API calls by status", {"h": 9, "w": 12, "x": 12, "y": 4},
+           [target(f"sum by (status) ({q('api_calls_total')})", "{{status}}")],
+           "reqps", stacked=True),
+        ts("API 4xx/5xx by endpoint", {"h": 9, "w": 12, "x": 0, "y": 13},
+           [target(f"topk(10, sum by (endpoint) ({q('api_calls_total', 'status=~\"[45]..\"')}))",
+                   "{{endpoint}}")], "reqps"),
+        ts("API calls by method", {"h": 9, "w": 12, "x": 12, "y": 13},
+           [target(f"sum by (method) ({q('api_calls_total')})", "{{method}}")],
+           "reqps", stacked=True),
+    ],
+    description="Control-plane usage: /api endpoint traffic, error rates, and login activity.",
+)
+
+ALL = [overview, backends, cache, vhosts, security, admin_api]
+
+if __name__ == "__main__":
+    os.makedirs(OUT, exist_ok=True)
+    for d in ALL:
+        path = os.path.join(OUT, d["uid"] + ".json")
+        with open(path, "w") as f:
+            json.dump(d, f, indent=2, sort_keys=True)
+            f.write("\n")
+        print(f"wrote {path} ({len(d['panels'])} panels)")


### PR DESCRIPTION
## What

- **observability/grafana/** — dashboards-as-code for the WSLProxy `/metrics` exporter:
  - `generate_dashboards.py` — single source for the suite; emits the committed JSONs
  - `dashboards/*.json` — 6 dashboards, 59 panels: **Edge Overview** (RPS, 4xx/5xx, latency percentiles, connections), **Backends & Upstreams** (health table, per-backend throughput/latency/errors), **Cache** (hit ratio, ops, per-host/extension), **Virtual Hosts** (`$host` variable, per-domain table), **Security & WAF** (suspicious traffic, top client IPs, WAF cost, login failures), **Admin API** (endpoint usage, error rates)
  - `deploy.sh` — idempotent: ensures Prometheus datasource + WSLProxy folder, upserts dashboards by stable uid
- **.github/workflows/deploy-grafana-dashboards.yml** — on merge to main touching `observability/grafana/**`: regenerates to prove JSONs aren't stale, deploys via Grafana API, smoke-checks each uid. Also `workflow_dispatch`.

## Already live

- Scrape job `wslproxy-edges` (lon1.pop0.uk + pop1.diytaxreturn.co.uk, 30s, `pop` label) added to the obs kube-prometheus-stack values in diy-tax-return-infra and helm-applied — both targets **UP**.
- Dashboards deployed to https://grafana.workstation.co.uk (folder **WSLProxy**) and queries verified returning live data from both pops.
- Repo secret `GRAFANA_ADMIN_PASSWORD` + variable `GRAFANA_URL` set.

Merging this PR will trigger the new workflow — that run is the end-to-end verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)