### PR TITLE
refactor(api): first-class PostgreSQL storage + layered driver/repository split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,11 +110,13 @@ Resources (each has list/get/create/update/delete): **servers, rules, secrets, i
 
 Special endpoints: `/api/user/login`, `/api/cache/*`, `/api/varnish/*`, `/api/traffic/*`, `/api/ai/analyze`, `/api/logs/{access,errors}`, `/api/topology/graph`, `/api/openresty_status`, `/api/push-data`, `/api/mcp/*`.
 
-The core persister is `CreateUpdateRecord(json_val, uuid, key_name, folder_name, method)` around **api.lua:1918**. It:
+The core persister is `CreateUpdateRecord(json_val, uuid, key_name, folder_name, method)`. It:
 1. Strips empty values, base64-encodes sensitive fields (secrets, JWT key, server `.config`, `varnish_vcl_config`)
-2. Writes to both Redis (if `storage_type: redis`) AND disk (`data/{folder_name}/{envProfile}/{uuid}.json`)
+2. Persists via `Repo.save` (`api/repo/` + `api/storage/` drivers). `storage_type: disk` writes JSON files; `redis` and `pgsql` dual-write to the remote store **and** on-disk JSON. Disk JSON remains the request-path source of truth (`rule_loader.lua` still reads files).
 3. For servers: also writes compiled conf to `data/servers/{env}/conf/{server_name}.conf`
 4. If `config_status: true`, copies conf to `/opt/nginx/conf.d/{server_name}.conf`, runs `openresty -t`, creates reboot flag file
+
+**Storage layer:** `api/storage/{driver,disk_driver,redis_driver,pgsql_driver,dual_writer}.lua` plus `api/repo/{servers,rules,secrets,generic}.lua`. PostgreSQL uses typed tables + `raw_json` (see `infra/pgsql/migrations/`). Apply with `scripts/pg-migrate.sh`; import existing disk JSON with `scripts/pg-import-from-disk.sh`. Do not auto-migrate on boot. `pgsql_storage.lua` remains a Redis-hash facade over `config_store` for leftover callers.
 
 ---
 

--- a/api/api.lua
+++ b/api/api.lua
@@ -15,6 +15,8 @@ local CRManager = require("cr_manager")
 local AuditLogger = require("audit_logger")
 local Pops = require("pops")
 local DnsManager = require("dns_manager")
+local Storage = require("storage")
+local Repo = require("repo")
 
 local settings = Helper.settings()
 local storageTypeOverride = settings.settings or os.getenv("STORAGE_TYPE")
@@ -525,36 +527,27 @@ local function validateWafPolicyPayload(payloads)
     return errors
 end
 
-local red = {}
+local store_ok, store_err = pcall(function()
+    Storage.init(settings)
+end)
+if not store_ok then
+    ngx.log(ngx.ERR, "failed to init storage: ", tostring(store_err))
+    Errors.throwError("failed to connect to storage: " .. tostring(store_err), ngx.HTTP_BAD_GATEWAY)
+end
 
+-- Redis client is only used for resty.session listing (session:* keys).
+-- CRUD goes through Repo / storage drivers.
+local red = nil
 if settings.storage_type == "redis" then
     local redis = require "resty.redis"
     red = redis:new()
     red:set_timeout(1000)
-
-    local redisHost = settings.env_vars.REDIS_HOST or os.getenv("REDIS_HOST")
-    if redisHost == nil then
-        redisHost = "localhost"
-    end
-
+    local redisHost = (settings.env_vars and settings.env_vars.REDIS_HOST) or os.getenv("REDIS_HOST") or "localhost"
     local ok, err = red:connect(redisHost, 6379)
     if not ok then
-        ngx.log(ngx.ERR, "failed to connect to Redis: ", err)
-        Errors.throwError("failed to connect to Redis: " .. err, ngx.HTTP_BAD_GATEWAY)
+        ngx.log(ngx.ERR, "failed to connect to Redis (sessions): ", err)
     end
-elseif settings.storage_type == "pgsql" then
-    local PgStorage = require("pgsql_storage")
-    local pg_config = settings.pgsql or {}
-    local store, pg_err = PgStorage.new(pg_config)
-    if not store then
-        ngx.log(ngx.ERR, "failed to connect to PostgreSQL: ", pg_err)
-        Errors.throwError("failed to connect to PostgreSQL: " .. tostring(pg_err), ngx.HTTP_BAD_GATEWAY)
-    end
-    red = store
 end
-
--- useRemoteStorage: true for redis and pgsql (both use the `red` interface)
-local useRemoteStorage = settings.storage_type == "redis" or settings.storage_type == "pgsql"
 
 local function removeServerFromRule(oldRuleId, serverId, envProfile)
     -- Accept either a single rule ID (string) or an array of rule IDs,
@@ -574,13 +567,8 @@ local function removeServerFromRule(oldRuleId, serverId, envProfile)
 
     local loadRules = nil
     if oldRuleId and oldRuleId ~= nil and type(oldRuleId) ~= "userdata" then
-        if useRemoteStorage then
-            loadRules = red:hget("request_rules_" .. envProfile, oldRuleId)
-        else
-            loadRules = Helper.getDataFromFile(configPath .. "data/rules/" .. envProfile .. "/" .. oldRuleId .. ".json")
-        end
-        if loadRules and loadRules ~= "null" and type(loadRules) == "string" then
-            loadRules = cjson.decode(loadRules)
+        loadRules = Repo.get("rules", envProfile, oldRuleId)
+        if type(loadRules) == "table" then
             -- Guard: rule JSON may not have a `.servers` field yet if
             -- no server has ever been linked to it.  Without this
             -- check, `#loadRules.servers` raises "attempt to get
@@ -600,12 +588,7 @@ local function removeServerFromRule(oldRuleId, serverId, envProfile)
                     i = i + 1
                 end
             end
-            if useRemoteStorage then
-                red:hset("request_rules_" .. envProfile, oldRuleId, cjson.encode(loadRules))
-            else
-                Helper.setDataToFile(configPath .. "data/rules/" .. envProfile .. "/" .. oldRuleId .. ".json", loadRules,
-                    configPath .. "data/rules")
-            end
+            Repo.save("rules", envProfile, oldRuleId, loadRules, { skip_strip = true })
         end
     end
 end
@@ -627,22 +610,10 @@ local function updateServerInRules(ruleId, serverId, Rtype, envProfile)
         return
     end
 
-    local getRules, ruleErr = nil, nil
-    if useRemoteStorage then
-        getRules, ruleErr = red:hget("request_rules_" .. envProfile, ruleId)
-    else
-        getRules, ruleErr = Helper.getDataFromFile(configPath .. "data/rules/" .. envProfile .. "/" .. ruleId .. ".json")
-    end
-    if getRules and getRules ~= "null" and type(getRules) == "string" then
-        getRules = cjson.decode(getRules)
-        local getServer = nil
-        if useRemoteStorage then
-            getServer = red:hget("servers_" .. envProfile, serverId)
-        else
-            getServer = Helper.getDataFromFile(configPath .. "data/servers/" .. envProfile .. "/" .. serverId .. ".json")
-        end
-        if getServer and getServer ~= "null" and type(getServer) == "string" then
-            getServer = cjson.decode(getServer)
+    local getRules = Repo.get("rules", envProfile, ruleId)
+    if type(getRules) == "table" then
+        local getServer = Repo.get("servers", envProfile, serverId)
+        if type(getServer) == "table" then
             if Rtype == "rules" and getServer.rules ~= nil and getServer.rules ~= ruleId then
                 removeServerFromRule(getServer.rules, serverId, envProfile)
             end
@@ -664,36 +635,19 @@ local function updateServerInRules(ruleId, serverId, Rtype, envProfile)
         end
         if isServer == true then
             table.insert(getRules.servers, serverId)
-            if useRemoteStorage then
-                red:hset("request_rules_" .. envProfile, ruleId, cjson.encode(getRules))
-            else
-                Helper.setDataToFile(configPath .. "data/rules/" .. envProfile .. "/" .. ruleId .. ".json", getRules,
-                    configPath .. "data/rules")
-            end
+            Repo.save("rules", envProfile, ruleId, getRules, { skip_strip = true })
         end
     end
 end
 
 local function deleteRuleFromServer(ruleId, envProfile)
-    local getRule = nil
-    if useRemoteStorage then
-        getRule = red:hget("request_rules_" .. envProfile, ruleId)
-    else
-        getRule = Helper.getDataFromFile(configPath .. "data/rules/" .. envProfile .. "/" .. ruleId .. ".json")
-    end
-    if getRule and getRule ~= "null" and type(getRule) == "string" then
-        getRule = cjson.decode(getRule)
+    local getRule = Repo.get("rules", envProfile, ruleId)
+    if type(getRule) == "table" then
         -- Remove the rules from all servers that are using it as a statement or case
         if getRule.servers and getRule.servers ~= nil then
             for _, server in ipairs(getRule.servers) do
-                local getServer = nil
-                if useRemoteStorage then
-                    getServer = red:hget("servers_" .. envProfile, server)
-                else
-                    Helper.getDataFromFile(configPath .. "data/servers/" .. envProfile .. "/" .. server .. ".json")
-                end
-                if getServer and getServer ~= "null" and type(getServer) == "string" then
-                    getServer = cjson.decode(getServer)
+                local getServer = Repo.get("servers", envProfile, server)
+                if type(getServer) == "table" then
                     if getServer.rules == ruleId then
                         getServer.rules = nil
                     else
@@ -706,13 +660,7 @@ local function deleteRuleFromServer(ruleId, envProfile)
                             end
                         end
                     end
-                    if useRemoteStorage then
-                        red:hset("servers_" .. envProfile, server, cjson.encode(getServer))
-                    else
-                        Helper.setDataToFile(configPath .. "data/servers/" .. envProfile .. "/" .. server .. ".json",
-                            getServer,
-                            configPath .. "data/servers")
-                    end
+                    Repo.save("servers", envProfile, server, getServer, { skip_strip = true })
                 end
             end
         end
@@ -720,71 +668,58 @@ local function deleteRuleFromServer(ruleId, envProfile)
 end
 
 local function deleteServerFromRules(ruleId, serverId, envProfile)
-    local getRule = nil
-    if useRemoteStorage then
-        getRule = red:hget("request_rules_" .. envProfile, ruleId)
-    else
-        getRule = Helper.getDataFromFile(configPath .. "data/rules/" .. envProfile .. "/" .. ruleId .. ".json")
-    end
-    if getRule and getRule ~= "null" and type(getRule) == "string" then
-        getRule = cjson.decode(getRule)
+    local getRule = Repo.get("rules", envProfile, ruleId)
+    if type(getRule) == "table" then
         if getRule.servers ~= nil and type(getRule.servers) == "table" then
             for _, server in ipairs(getRule.servers) do
                 if server == serverId then
                     table.remove(getRule.servers, _)
                 end
             end
-            if useRemoteStorage then
-                red:hset("request_rules_" .. envProfile, ruleId, cjson.encode(getRule))
-            else
-                Helper.setDataToFile(configPath .. "data/rules/" .. envProfile .. "/" .. ruleId .. ".json", getRule,
-                    configPath .. "data/rules")
-            end
+            Repo.save("rules", envProfile, ruleId, getRule, { skip_strip = true })
         end
     end
 end
 
--- ─── Redis-backed sibling of listFromDisk ────────────────────────────────
---
--- Previously this did its own (broken) paginate-then-filter inline.  We
--- now load the full hash with one HSCAN pass and delegate the
--- filter / sort / paginate pipeline to listPaginationLocal so disk and
--- redis paths share the same correct semantics.  Loading everything
--- before paginating is necessary for the q-filter to find records that
--- live past the requested page — see the rationale in
--- listPaginationLocal.  In practice the hash sizes here are small
--- (servers / rules per installation are typically <1000 records).
-local function listWithPagination(recordsKey, cursor, pageSize, pageNumber, qParams)
-    local allRecords = {}
+-- Forward declaration: listWithPagination runs after this local is assigned.
+local listPaginationLocal
 
-    local totalKeys, hlenErr = red:hlen(recordsKey)
-    if not totalKeys or hlenErr or totalKeys == 0 then
-        if hlenErr then
-            ngx.log(ngx.INFO, "Failed to retrieve total number of records: ", hlenErr)
-        end
+-- Map historical redis hash names / disk directory prefixes onto repo
+-- resource ids.  listWithPagination and listFromDisk both scan via Repo
+-- so disk / redis / pgsql share listPaginationLocal semantics.
+local REDIS_KEY_RESOURCE = {
+    servers = "servers",
+    request_rules = "rules",
+    secrets = "secrets",
+    instances = "instances",
+    upstreams = "upstreams",
+    waf_rules = "waf_rules",
+    waf_policies = "waf_policies",
+    waf_events = "waf_events",
+    users = "users",
+    pops = "pops",
+    bookmarks = "bookmarks",
+    company_logo = "company_logo",
+}
+
+local function resource_from_redis_key(recordsKey)
+    if REDIS_KEY_RESOURCE[recordsKey] then
+        return REDIS_KEY_RESOURCE[recordsKey], nil
+    end
+    local base, env = tostring(recordsKey):match("^(.*)_(.+)$")
+    if base and REDIS_KEY_RESOURCE[base] then
+        return REDIS_KEY_RESOURCE[base], env
+    end
+    return base or recordsKey, env
+end
+
+local function listWithPagination(recordsKey, cursor, pageSize, pageNumber, qParams)
+    local resource, env = resource_from_redis_key(recordsKey)
+    local allRecords, err = Repo.scan(resource, env)
+    if not allRecords then
+        ngx.log(ngx.INFO, "Failed to retrieve records: ", tostring(err))
         return {}, 0
     end
-
-    -- Full HSCAN pass — no early break.  COUNT 200 is a hint to the
-    -- redis cursor; the actual number returned per round-trip may
-    -- differ.  Loop until the cursor returns to "0".
-    local nextCursor = cursor or "0"
-    repeat
-        local res, scanErr = red:hscan(recordsKey, nextCursor, "COUNT", 200)
-        if not res then
-            ngx.log(ngx.INFO, "Failed to retrieve records: ", scanErr)
-            return {}, 0
-        end
-        nextCursor = res[1]
-        for i = 1, #res[2], 2 do
-            local recordValue = res[2][i + 1]
-            local ok, dataRecord = pcall(cjson.decode, recordValue)
-            if ok and type(dataRecord) == "table" then
-                allRecords[#allRecords + 1] = dataRecord
-            end
-        end
-    until nextCursor == "0"
-
     return listPaginationLocal(allRecords, pageSize, pageNumber, qParams)
 end
 
@@ -808,7 +743,7 @@ end
 -- "match.rules.path") broadens the q match across multiple columns.
 -- Falls back to a single-field match on qParams.type.key_name so
 -- callers that haven't been updated still work.
-local function listPaginationLocal(data, pageSize, pageNumber, qParams)
+listPaginationLocal = function(data, pageSize, pageNumber, qParams)
     qParams = qParams or {}
 
     -- Resolve a dotted path against a nested record (e.g.
@@ -945,7 +880,7 @@ local function login(args)
             ngx.header["Set-Cookie"] = buildAuthCookie(token, AUTH_COOKIE_MAX_AGE)
 
             ngx.status = ngx.OK
-            if useRemoteStorage then
+            if settings.storage_type == "redis" then
                 local session = require "resty.session".new()
                 session:set_subject("Users")
                 session:set(payloads.email, cjson.encode(payloads))
@@ -1036,42 +971,16 @@ end
 -- Servers APIs
 
 local function listFromDisk(directory, pageSize, pageNumber, qParams)
-    local files = {}
-    -- Run the 'ls' command to get a list of filenames
-    local output, error = io.popen("ls " .. configPath .. "data/" .. directory .. ""):read("*all")
-    for filename in string.gmatch(output, "[^\r\n]+") do
-        if filename:match("%.json$") then
-            table.insert(files, filename)
-        end
+    -- directory is historically "servers/prod", "rules/int", "waf_policies/prod"
+    local resource, env = tostring(directory):match("^([^/]+)/?(.*)$")
+    if env == "" then
+        env = nil
     end
-
-    local jsonData, data = {}, {}
-    for _, filename in ipairs(files) do
-        local filePath = configPath .. "data/" .. directory .. "/" .. filename
-        local fileAttr = lfs.attributes(filePath)
-        if fileAttr then
-            if fileAttr.mode == "file" then
-                local file, fileErr = io.open(filePath, "rb")
-                if file == nil then
-                    return ngx.say(cjson.encode({
-                        data = {},
-                        total = 0
-                    }))
-                else
-                    local jsonString = file:read "*a"
-                    file:close()
-
-                    if jsonString and jsonString ~= "" then
-                        data = cjson.decode(jsonString)
-                    end
-                    if data ~= nil and data ~= ngx.null and data ~= "null" then
-                        jsonData[_] = data
-                    end
-                end
-            end
-        end
+    local jsonData, err = Repo.scan(resource, env)
+    if not jsonData then
+        ngx.log(ngx.WARN, "listFromDisk scan failed: ", tostring(err))
+        jsonData = {}
     end
-
     local diskData, count = listPaginationLocal(jsonData, pageSize, pageNumber, qParams)
     return diskData, count
 end
@@ -1146,58 +1055,24 @@ end
 
 local function listServer(args, id)
     local envProfile = args.envprofile ~= nil and args.envprofile or "prod"
-    if settings then
-        if settings.storage_type == "disk" then
-            local jsonData, dataErr = Helper.getDataFromFile(configPath ..
-                "data/servers/" .. envProfile .. "/" .. id .. ".json")
-            if dataErr ~= nil then
-                ngx.say(cjson.encode({
-                    data = {}
-                }))
-            else
-                jsonData = cjson.decode(jsonData)
-                if jsonData.config then
-                    local configDec, decodeErr = Helper.decodeBase64(jsonData.config)
-                    if decodeErr ~= nil then
-                        jsonData.config = configDec
-                    end
-                end
-                if jsonData.varnish_vcl_config then
-                    local vclDec, decodeErr = Helper.decodeBase64(jsonData.varnish_vcl_config)
-                    if decodeErr ~= nil then
-                        jsonData.varnish_vcl_config = vclDec
-                    end
-                end
-                ngx.say(cjson.encode({
-                    data = jsonData
-                }))
-            end
-        else
-            --     local server, dataErr = Helper.getDataFromFile(configPath .. "data/servers/" .. envProfile .. "/" .. id .. ".json")
-            --     if dataErr or dataErr ~= nil then
-            local server = red:hget("servers_" .. envProfile, id)
-            -- end
-            if type(server) == "string" then
-                server = cjson.decode(server)
-                if server.config then
-                    local configDec, decodeErr = Helper.decodeBase64(server.config)
-                    if decodeErr ~= nil then
-                        server.config = configDec
-                    end
-                end
-
-                if server.varnish_vcl_config then
-                    local vclDec, decodeErr = Helper.decodeBase64(server.varnish_vcl_config)
-                    if decodeErr ~= nil then
-                        server.varnish_vcl_config = vclDec
-                    end
-                end
-                ngx.say(cjson.encode({
-                    data = server
-                }))
-            end
+    local jsonData = Repo.get("servers", envProfile, id)
+    if type(jsonData) ~= "table" then
+        ngx.say(cjson.encode({ data = {} }))
+        return
+    end
+    if jsonData.config then
+        local configDec, decodeErr = Helper.decodeBase64(jsonData.config)
+        if decodeErr ~= nil then
+            jsonData.config = configDec
         end
     end
+    if jsonData.varnish_vcl_config then
+        local vclDec, decodeErr = Helper.decodeBase64(jsonData.varnish_vcl_config)
+        if decodeErr ~= nil then
+            jsonData.varnish_vcl_config = vclDec
+        end
+    end
+    ngx.say(cjson.encode({ data = jsonData }))
 end
 
 local function listSecrets(args)
@@ -1264,41 +1139,17 @@ end
 
 local function listSecret(args, id)
     local envProfile = args.envprofile ~= nil and args.envprofile or "prod"
-    if settings then
-        if settings.storage_type == "disk" then
-            local jsonData, dataErr = Helper.getDataFromFile(configPath ..
-                "data/secrets/" .. envProfile .. "/" .. id .. ".json")
-            if dataErr ~= nil then
-                ngx.say(cjson.encode({
-                    data = {}
-                }))
-            else
-                jsonData = cjson.decode(jsonData)
-                if jsonData.secrets then
-                    for sIdx, secret in ipairs(jsonData.secrets) do
-                        jsonData.secrets[sIdx].value = Base64.decode(jsonData.secrets[sIdx].value)
-                    end
-                end
-                ngx.say(cjson.encode({
-                    data = jsonData
-                }))
-            end
-        else
-            --     local server, dataErr = Helper.getDataFromFile(configPath .. "data/servers/" .. envProfile .. "/" .. id .. ".json")
-            --     if dataErr or dataErr ~= nil then
-            local server = red:hget("secrets_" .. envProfile, id)
-            -- end
-            if type(server) == "string" then
-                server = cjson.decode(server)
-                if server.config then
-                    server.config = Base64.decode(server.config)
-                end
-                ngx.say(cjson.encode({
-                    data = server
-                }))
-            end
+    local jsonData = Repo.get("secrets", envProfile, id)
+    if type(jsonData) ~= "table" then
+        ngx.say(cjson.encode({ data = {} }))
+        return
+    end
+    if jsonData.secrets then
+        for sIdx, secret in ipairs(jsonData.secrets) do
+            jsonData.secrets[sIdx].value = Base64.decode(jsonData.secrets[sIdx].value)
         end
     end
+    ngx.say(cjson.encode({ data = jsonData }))
 end
 
 
@@ -1366,41 +1217,17 @@ end
 
 local function listInstance(args, id)
     local envProfile = args.envprofile ~= nil and args.envprofile or "prod"
-    if settings then
-        if settings.storage_type == "disk" then
-            local jsonData, dataErr = Helper.getDataFromFile(configPath ..
-                "data/instances/" .. envProfile .. "/" .. id .. ".json")
-            if dataErr ~= nil then
-                ngx.say(cjson.encode({
-                    data = {}
-                }))
-            else
-                jsonData = cjson.decode(jsonData)
-                if jsonData.secrets then
-                    for sIdx, secret in ipairs(jsonData.secrets) do
-                        jsonData.secrets[sIdx].value = Base64.decode(jsonData.secrets[sIdx].value)
-                    end
-                end
-                ngx.say(cjson.encode({
-                    data = jsonData
-                }))
-            end
-        else
-            --     local server, dataErr = Helper.getDataFromFile(configPath .. "data/servers/" .. envProfile .. "/" .. id .. ".json")
-            --     if dataErr or dataErr ~= nil then
-            local server = red:hget("instances_" .. envProfile, id)
-            -- end
-            if type(server) == "string" then
-                server = cjson.decode(server)
-                if server.config then
-                    server.config = Base64.decode(server.config)
-                end
-                ngx.say(cjson.encode({
-                    data = server
-                }))
-            end
+    local jsonData = Repo.get("instances", envProfile, id)
+    if type(jsonData) ~= "table" then
+        ngx.say(cjson.encode({ data = {} }))
+        return
+    end
+    if jsonData.secrets then
+        for sIdx, secret in ipairs(jsonData.secrets) do
+            jsonData.secrets[sIdx].value = Base64.decode(jsonData.secrets[sIdx].value)
         end
     end
+    ngx.say(cjson.encode({ data = jsonData }))
 end
 
 
@@ -1637,53 +1464,26 @@ local function createDeleteServer(body, uuid)
         envProfile = payloads.envProfile
     end
 
-    if settings then
-        if uuid ~= "" and uuid ~= nil then
-            if settings.storage_type == "disk" then
-                os.remove(configPath .. "data/servers/" .. envProfile .. "/" .. uuid .. ".json")
-            else
-                -- os.remove(configPath .. "data/servers/" .. envProfile .. "/" .. uuid .. ".json")
-                local oldDomain, oldDmnErr = red:hget("servers_" .. envProfile, uuid)
-                if oldDomain and oldDomain ~= "null" and type(oldDomain) == "string" then
-                    oldDomain = cjson.decode(oldDomain)
-                    oldServerName = oldDomain.server_name
-                    if oldDomain.rules ~= nil then
-                        deleteServerFromRules(oldDomain.rules, uuid, envProfile)
-                    end
-                    if oldDomain.match_cases ~= nil and type(next(oldDomain.match_cases)) ~= nil then
-                        for _, matchCase in pairs(oldDomain.match_cases) do
-                            deleteServerFromRules(matchCase.statement, uuid, envProfile)
-                        end
-                    end
-                else
-                    ngx.log(ngx.ERR, "Error while getting domain from redis: ", oldDmnErr)
-                end
-                red:hdel("servers_" .. envProfile, uuid)
+    local function unlink_and_delete_server(sid)
+        local oldDomain = Repo.get("servers", envProfile, sid)
+        if type(oldDomain) == "table" then
+            oldServerName = oldDomain.server_name
+            if oldDomain.rules ~= nil then
+                deleteServerFromRules(oldDomain.rules, sid, envProfile)
             end
-        elseif payloads and payloads.ids.ids and #payloads.ids.ids > 0 then
-            for value = 1, #payloads.ids.ids do
-                if settings.storage_type == "disk" then
-                    os.remove(configPath .. "data/servers/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json")
-                else
-                    -- os.remove(configPath .. "data/servers/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json")
-                    local oldDomain, oldDmnErr = red:hget("servers_" .. envProfile, payloads.ids.ids[value])
-                    if oldDomain and oldDomain ~= "null" and type(oldDomain) == "string" then
-                        oldDomain = cjson.decode(oldDomain)
-                        oldServerName = oldDomain.server_name
-                        if oldDomain.rules ~= nil then
-                            deleteServerFromRules(oldDomain.rules, uuid, envProfile)
-                        end
-                        if oldDomain.match_cases ~= nil and type(next(oldDomain.match_cases)) ~= nil then
-                            for _, matchCase in pairs(oldDomain.match_cases) do
-                                deleteServerFromRules(matchCase.statement, uuid, envProfile)
-                            end
-                        end
-                    else
-                        ngx.log(ngx.ERR, "Error while getting domain from redis: ", oldDmnErr)
-                    end
-                    red:hdel("servers_" .. envProfile, payloads.ids.ids[value])
+            if oldDomain.match_cases ~= nil and type(next(oldDomain.match_cases)) ~= nil then
+                for _, matchCase in pairs(oldDomain.match_cases) do
+                    deleteServerFromRules(matchCase.statement, sid, envProfile)
                 end
             end
+        end
+        Repo.delete("servers", envProfile, sid)
+    end
+    if uuid ~= "" and uuid ~= nil then
+        unlink_and_delete_server(uuid)
+    elseif payloads and payloads.ids.ids and #payloads.ids.ids > 0 then
+        for value = 1, #payloads.ids.ids do
+            unlink_and_delete_server(payloads.ids.ids[value])
         end
     end
     ngx.say(cjson.encode({
@@ -1739,29 +1539,7 @@ local function listUsers(args)
     -- Retrieve a page of records using HSCAN
     local cursor = "0"
     local recordCount, totalRecords = 0, 0
-    if settings then
-        if settings.storage_type == "disk" then
-            local file, err = io.open(configPath .. "data/users.json", "rb")
-            if file == nil then
-                ngx.say(cjson.encode({
-                    data = {},
-                    total = 0
-                }))
-                ngx.exit(ngx.HTTP_OK)
-            else
-                local jsonString = file:read "*a"
-                file:close()
-                users = cjson.decode(jsonString)
-                local currentPageData, totalPages = listPaginationLocal(users, pageSize, pageNumber, qParams)
-                users, totalRecords = currentPageData, totalPages
-            end
-        else
-            local recordsKey = "users"
-            local records, totalCount = listWithPagination(recordsKey, cursor, pageSize, pageNumber, qParams)
-            users = records
-            totalRecords = totalCount
-        end
-    end
+    users, totalRecords = listWithPagination("users", cursor, pageSize, pageNumber, qParams)
     -- Sort applied inside listPaginationLocal / listWithPagination.
     ngx.say(cjson.encode({
         data = users,
@@ -1771,38 +1549,14 @@ local function listUsers(args)
 end
 
 local function listUser(args, uuid)
-    if settings then
-        if settings.storage_type == "disk" then
-            local file, err = io.open(configPath .. "data/users.json", "rb")
-            if file == nil then
-                Errors.throwError("Couldn't read file: " .. err, ngx.HTTP_INTERNAL_SERVER_ERROR)
-            else
-                local jsonString = file:read "*a"
-                file:close()
-                local users = cjson.decode(jsonString)
-                for key, value in pairs(users) do
-                    if users[key]["id"] == uuid then
-                        ngx.say({ cjson.encode({
-                            data = value
-                        }) })
-                        ngx.exit(ngx.HTTP_OK)
-                    end
-                end
-            end
-        else
-            local user, err = red:hget("users", uuid)
-            if user then
-                user = cjson.decode(user)
-                ngx.say(cjson.encode({
-                    data = user
-                }))
-                ngx.exit(ngx.HTTP_OK)
-            end
-            if err then
-                Errors.throwError(err, ngx.HTTP_INTERNAL_SERVER_ERROR)
-            end
-        end
+    local user, err = Repo.get("users", nil, uuid)
+    if type(user) == "table" then
+        ngx.say(cjson.encode({
+            data = user
+        }))
+        ngx.exit(ngx.HTTP_OK)
     end
+    Errors.throwError(err or "user not found", ngx.HTTP_NOT_FOUND)
 end
 
 local function createUpdateUser(body, uuid)
@@ -1814,51 +1568,14 @@ local function createUpdateUser(body, uuid)
         ---@diagnostic disable-next-line: param-type-mismatch
         payloads.created_at = os.time(os.date("!*t"))
     end
-    if settings then
-        if uuid ~= "" and uuid ~= nil then
-            if settings.storage_type == "disk" then
-                local users = createUserInDisk(payloads, uuid)
-                ngx.say(cjson.encode({
-                    data = users
-                }))
-                ngx.exit(ngx.HTTP_OK)
-            else
-                local redis_json = {}
-                redis_json[getUuid] = cjson.encode(payloads)
-                local inserted, err = red:hmset("users", redis_json)
-                if inserted then
-                    ngx.say(cjson.encode({
-                        data = payloads
-                    }))
-                    ngx.exit(ngx.HTTP_OK)
-                end
-                if err then
-                    Errors.throwError(err, ngx.HTTP_INTERNAL_SERVER_ERROR)
-                end
-            end
-        else
-            local users = createUserInDisk(payloads, uuid)
-            if settings.storage_type == "disk" then
-                ngx.say(cjson.encode({
-                    data = users
-                }))
-                ngx.exit(ngx.HTTP_OK)
-            end
-
-            local redis_json = {}
-            redis_json[getUuid] = cjson.encode(payloads)
-            local inserted, err = red:hmset("users", redis_json)
-            if inserted then
-                ngx.say(cjson.encode({
-                    data = payloads
-                }))
-                ngx.exit(ngx.HTTP_OK)
-            end
-            if err then
-                Errors.throwError(err, ngx.HTTP_INTERNAL_SERVER_ERROR)
-            end
-        end
+    local inserted, err = Repo.save("users", nil, getUuid, payloads, { skip_strip = true })
+    if inserted then
+        ngx.say(cjson.encode({
+            data = payloads
+        }))
+        ngx.exit(ngx.HTTP_OK)
     end
+    Errors.throwError(err or "failed to save user", ngx.HTTP_INTERNAL_SERVER_ERROR)
 end
 
 local function deleteUserInDisk(uuid)
@@ -1891,44 +1608,21 @@ end
 local function deleteUsers(args, uuid)
     local payloads = Helper.GetPayloads(args)
     local restUsers = {}
-    if settings then
-        if uuid ~= "" and uuid ~= nil then
-            if settings.storage_type == "disk" then
-                restUsers = deleteUserInDisk(uuid)
-            else
-                local del, err = red:hdel("users", uuid)
-                if del then
-                    restUsers = del
-                end
-                if err then
-                    Errors.throwError(err, ngx.HTTP_INTERNAL_SERVER_ERROR)
-                end
-            end
-        elseif payloads and payloads.ids and #payloads.ids > 0 then
-            if settings then
-                if settings.storage_type == "disk" then
-                    restUsers = deleteUserInDisk(payloads.ids)
-                else
-                    for value = 1, #payloads.ids do
-                        restUsers = red:hdel("users", payloads.ids[value])
-                    end
-                end
-            end
+    if uuid ~= "" and uuid ~= nil then
+        local del, err = Repo.delete("users", nil, uuid)
+        if err then
+            Errors.throwError(err, ngx.HTTP_INTERNAL_SERVER_ERROR)
         end
-        if settings.storage_type == "disk" then
-            local writableFile, writableErr = io.open(configPath .. "data/users.json", "w")
-            if writableFile == nil then
-                Errors.throwError("Couldn't write file: " .. writableErr, ngx.HTTP_INTERNAL_SERVER_ERROR)
-            else
-                writableFile:write(cjson.encode(restUsers))
-                writableFile:close()
-            end
+        restUsers = del
+    elseif payloads and payloads.ids and #payloads.ids > 0 then
+        for value = 1, #payloads.ids do
+            restUsers = Repo.delete("users", nil, payloads.ids[value])
         end
-        ngx.say(cjson.encode({
-            data = (type(restUsers) == "table" and restUsers or { restUsers })
-        }))
-        ngx.exit(ngx.HTTP_OK)
     end
+    ngx.say(cjson.encode({
+        data = (type(restUsers) == "table" and restUsers or { restUsers })
+    }))
+    ngx.exit(ngx.HTTP_OK)
 end
 -- HTTP Request rules:
 local function listRules(args)
@@ -1991,47 +1685,20 @@ end
 
 local function listRule(args, uuid)
     local envProfile = args.envprofile ~= nil and args.envprofile or "prod"
-    if settings then
-        if settings.storage_type == "disk" then
-            local jsonData, dataErr = Helper.getDataFromFile(configPath ..
-                "data/rules/" .. envProfile .. "/" .. uuid .. ".json")
-            if dataErr == nil then
-                local resultData = cjson.decode(jsonData)
-                if resultData.match.rules.jwt_token_validation_value ~= nil and
-                    resultData.match.rules.jwt_token_validation_key ~= nil then
-                    resultData.match.rules.jwt_token_validation_key =
-                        Base64.decode(resultData.match.rules.jwt_token_validation_key)
-                end
-                -- S3 keys are now stored as plaintext (schema v2) — no decoding needed
-                ngx.say(cjson.encode({
-                    data = resultData
-                }))
-            else
-                Errors.throwError("Error" .. dataErr, ngx.HTTP_INTERNAL_SERVER_ERROR)
-            end
-        else
-            -- local exist_value, Rerr = Helper.getDataFromFile(configPath .. "data/rules/" .. envProfile .. "/" .. uuid .. ".json")
-            -- if exist_value == nil or Rerr then
-            local exist_value, Rerr = red:hget("request_rules_" .. envProfile, uuid)
-            -- end
-            exist_value = cjson.decode(exist_value)
-            -- if exist_value.match.response.message then
-            --     exist_value.match.response.message = Base64.decode(exist_value.match.response.message)
-            -- end
-
-            if exist_value.match.rules.jwt_token_validation_value ~= nil and
-                exist_value.match.rules.jwt_token_validation_key ~= nil then
-                exist_value.match.rules.jwt_token_validation_key =
-                    Base64.decode(exist_value.match.rules.jwt_token_validation_key)
-            end
-            -- S3 keys are now stored as plaintext (schema v2) — no decoding needed
-
-            ngx.say({ cjson.encode({
-                data = exist_value
-            }) })
-        end
+    local exist_value = Repo.get("rules", envProfile, uuid)
+    if type(exist_value) ~= "table" then
+        Errors.throwError("Rule not found", ngx.HTTP_NOT_FOUND)
+        return
     end
-    -- end
+    if exist_value.match and exist_value.match.rules
+        and exist_value.match.rules.jwt_token_validation_value ~= nil
+        and exist_value.match.rules.jwt_token_validation_key ~= nil then
+        exist_value.match.rules.jwt_token_validation_key =
+            Base64.decode(exist_value.match.rules.jwt_token_validation_key)
+    end
+    ngx.say(cjson.encode({
+        data = exist_value
+    }))
 end
 
 local function createDeleteRules(body, uuid)
@@ -2046,27 +1713,12 @@ local function createDeleteRules(body, uuid)
         envProfile = payloads.envProfile
     end
     if uuid ~= "" and uuid ~= nil then
-        if settings then
-            if settings.storage_type == "disk" then
-                os.remove(configPath .. "data/rules/" .. envProfile .. "/" .. uuid .. ".json")
-            else
-                deleteRuleFromServer(uuid, envProfile)
-                red:hdel("request_rules_" .. envProfile, uuid)
-            end
-        end
+        deleteRuleFromServer(uuid, envProfile)
+        Repo.delete("rules", envProfile, uuid)
     elseif payloads and payloads.ids.ids and #payloads.ids.ids > 0 then
         for value = 1, #payloads.ids.ids do
-            if settings then
-                if useRemoteStorage then
-                    deleteRuleFromServer(payloads.ids.ids[value], envProfile)
-                    red:hdel("request_rules_" .. envProfile, payloads.ids.ids[value])
-                else
-                    os.remove(configPath .. "data/rules/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json")
-                    local command = "rm -f " ..
-                        configPath .. "data/rules/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json"
-                    os.execute(command)
-                end
-            end
+            deleteRuleFromServer(payloads.ids.ids[value], envProfile)
+            Repo.delete("rules", envProfile, payloads.ids.ids[value])
         end
     end
 
@@ -2087,25 +1739,10 @@ local function createDeleteSecrets(body, uuid)
         envProfile = payloads.envProfile
     end
     if uuid ~= "" and uuid ~= nil then
-        if settings then
-            if settings.storage_type == "disk" then
-                os.remove(configPath .. "data/secrets/" .. envProfile .. "/" .. uuid .. ".json")
-            else
-                red:hdel("secrets_" .. envProfile, uuid)
-            end
-        end
+        Repo.delete("secrets", envProfile, uuid)
     elseif payloads and payloads.ids.ids and #payloads.ids.ids > 0 then
         for value = 1, #payloads.ids.ids do
-            if settings then
-                if useRemoteStorage then
-                    red:hdel("secrets_" .. envProfile, payloads.ids.ids[value])
-                else
-                    os.remove(configPath .. "data/secrets/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json")
-                    local command = "rm -f " ..
-                        configPath .. "data/secrets/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json"
-                    os.execute(command)
-                end
-            end
+            Repo.delete("secrets", envProfile, payloads.ids.ids[value])
         end
     end
 
@@ -2125,25 +1762,10 @@ local function createDeleteInstances(body, uuid)
         envProfile = payloads.envProfile
     end
     if uuid ~= "" and uuid ~= nil then
-        if settings then
-            if settings.storage_type == "disk" then
-                os.remove(configPath .. "data/instances/" .. envProfile .. "/" .. uuid .. ".json")
-            else
-                red:hdel("instances_" .. envProfile, uuid)
-            end
-        end
+        Repo.delete("instances", envProfile, uuid)
     elseif payloads and payloads.ids.ids and #payloads.ids.ids > 0 then
         for value = 1, #payloads.ids.ids do
-            if settings then
-                if useRemoteStorage then
-                    red:hdel("instances_" .. envProfile, payloads.ids.ids[value])
-                else
-                    os.remove(configPath .. "data/instances/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json")
-                    local command = "rm -f " ..
-                        configPath .. "data/instances/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json"
-                    os.execute(command)
-                end
-            end
+            Repo.delete("instances", envProfile, payloads.ids.ids[value])
         end
     end
 
@@ -2198,14 +1820,8 @@ CreateUpdateRecord = function(json_val, uuid, key_name, folder_name, method)
 
     local redis_json, domainJson = {}, {}
     if key_name == 'servers' and json_val.server_name then
-        local getDomain = ""
-        if useRemoteStorage then
-            getDomain = red:hget(key_name .. "_" .. envProfile, json_val.id)
-        else
-            getDomain = Helper.getDataFromFile(configPath ..
-                "data/servers/" .. envProfile .. "/" .. json_val.id .. ".json")
-        end
-        if getDomain and getDomain ~= nil and type(getDomain) == "string" and method == "create" then
+        local getDomain = Repo.get("servers", envProfile, json_val.id)
+        if type(getDomain) == "table" and method == "create" then
             ngx.status = ngx.HTTP_CONFLICT
             formatResponse = {
                 message = string.format(
@@ -2215,14 +1831,8 @@ CreateUpdateRecord = function(json_val, uuid, key_name, folder_name, method)
             return formatResponse
         end
         if method == "update" and json_val.id ~= "host:" .. json_val.server_name then
-            local previousDomain = ""
-            if useRemoteStorage then
-                previousDomain = red:hget(key_name .. "_" .. envProfile, "host:" .. json_val.server_name)
-            else
-                previousDomain = Helper.getDataFromFile(configPath ..
-                    "data/servers/" .. envProfile .. "/host:" .. json_val.server_name .. ".json")
-            end
-            if previousDomain and previousDomain ~= nil and type(previousDomain) == "string" then
+            local previousDomain = Repo.get("servers", envProfile, "host:" .. json_val.server_name)
+            if type(previousDomain) == "table" then
                 ngx.status = ngx.HTTP_CONFLICT
                 formatResponse = {
                     message = string.format(
@@ -2244,12 +1854,15 @@ CreateUpdateRecord = function(json_val, uuid, key_name, folder_name, method)
     end
 
     local filePathDir = configPath .. "data/" .. folder_name .. "/" .. envProfile
-    -- HS 28/08/2024 This part of the code need to be refactor or optimise
-    if useRemoteStorage then
-        redis_json[uuid] = cjson.encode(json_val)
-        red:hmset(key_name .. "_" .. envProfile, redis_json)
+    local persist_ok, persist_err = Repo.save(folder_name, envProfile, uuid, json_val, {
+        skip_strip = true,
+        encode_sensitive = false,
+    })
+    if not persist_ok then
+        ngx.log(ngx.ERR, "CreateUpdateRecord persist failed: ", tostring(persist_err))
+        ngx.status = ngx.HTTP_INTERNAL_SERVER_ERROR
+        return { message = "persist failed: " .. tostring(persist_err) }
     end
-    Helper.setDataToFile(filePathDir .. "/" .. uuid .. ".json", json_val, filePathDir)
     if key_name == "servers" then
         local configString = Base64.decode(json_val.config)
         Helper.setDataToFile(filePathDir .. "/conf/" .. json_val.server_name .. ".conf", Helper.cleanString(configString),
@@ -2372,15 +1985,13 @@ end
 
 local function listWafRule(args, uuid)
     local envProfile = args.envprofile ~= nil and args.envprofile or "prod"
-    local jsonData, dataErr = Helper.getDataFromFile(configPath ..
-        "data/waf_rules/" .. envProfile .. "/" .. uuid .. ".json")
-    if dataErr == nil then
-        local resultData = cjson.decode(jsonData)
+    local resultData = Repo.get("waf_rules", envProfile, uuid)
+    if type(resultData) == "table" then
         ngx.say(cjson.encode({
             data = resultData
         }))
     else
-        Errors.throwError("WAF rule not found: " .. tostring(dataErr), ngx.HTTP_NOT_FOUND)
+        Errors.throwError("WAF rule not found", ngx.HTTP_NOT_FOUND)
     end
 end
 
@@ -2426,10 +2037,10 @@ local function createDeleteWafRules(body, uuid)
         envProfile = payloads.envProfile
     end
     if uuid ~= "" and uuid ~= nil then
-        os.remove(configPath .. "data/waf_rules/" .. envProfile .. "/" .. uuid .. ".json")
+        Repo.delete("waf_rules", envProfile, uuid)
     elseif payloads and payloads.ids and payloads.ids.ids and #payloads.ids.ids > 0 then
         for value = 1, #payloads.ids.ids do
-            os.remove(configPath .. "data/waf_rules/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json")
+            Repo.delete("waf_rules", envProfile, payloads.ids.ids[value])
         end
     end
     ngx.say(cjson.encode({
@@ -2482,15 +2093,13 @@ end
 
 local function listWafPolicy(args, uuid)
     local envProfile = args.envprofile ~= nil and args.envprofile or "prod"
-    local jsonData, dataErr = Helper.getDataFromFile(configPath ..
-        "data/waf_policies/" .. envProfile .. "/" .. uuid .. ".json")
-    if dataErr == nil then
-        local resultData = cjson.decode(jsonData)
+    local resultData = Repo.get("waf_policies", envProfile, uuid)
+    if type(resultData) == "table" then
         ngx.say(cjson.encode({
             data = resultData
         }))
     else
-        Errors.throwError("WAF policy not found: " .. tostring(dataErr), ngx.HTTP_NOT_FOUND)
+        Errors.throwError("WAF policy not found", ngx.HTTP_NOT_FOUND)
     end
 end
 
@@ -2536,10 +2145,10 @@ local function createDeleteWafPolicies(body, uuid)
         envProfile = payloads.envProfile
     end
     if uuid ~= "" and uuid ~= nil then
-        os.remove(configPath .. "data/waf_policies/" .. envProfile .. "/" .. uuid .. ".json")
+        Repo.delete("waf_policies", envProfile, uuid)
     elseif payloads and payloads.ids and payloads.ids.ids and #payloads.ids.ids > 0 then
         for value = 1, #payloads.ids.ids do
-            os.remove(configPath .. "data/waf_policies/" .. envProfile .. "/" .. payloads.ids.ids[value] .. ".json")
+            Repo.delete("waf_policies", envProfile, payloads.ids.ids[value])
         end
     end
     ngx.say(cjson.encode({
@@ -2757,29 +2366,13 @@ end
 
 local function listUpstream(args, id)
     local envProfile = args.envprofile ~= nil and args.envprofile or "prod"
-    if settings then
-        if settings.storage_type == "disk" then
-            local jsonData, dataErr = Helper.getDataFromFile(configPath ..
-                "data/upstreams/" .. envProfile .. "/" .. id .. ".json")
-            if dataErr ~= nil then
-                ngx.say(cjson.encode({
-                    data = {}
-                }))
-            else
-                jsonData = cjson.decode(jsonData)
-                ngx.say(cjson.encode({
-                    data = jsonData
-                }))
-            end
-        else
-            local upstream = red:hget("upstreams_" .. envProfile, id)
-            if type(upstream) == "string" then
-                upstream = cjson.decode(upstream)
-                ngx.say(cjson.encode({
-                    data = upstream
-                }))
-            end
-        end
+    local upstream = Repo.get("upstreams", envProfile, id)
+    if type(upstream) == "table" then
+        ngx.say(cjson.encode({
+            data = upstream
+        }))
+    else
+        ngx.say(cjson.encode({ data = {} }))
     end
 end
 
@@ -2930,47 +2523,15 @@ local function writeUpstreamConfigFile(envProfile)
     ngx.log(ngx.INFO, "writeUpstreamConfigFile - Regenerating config for profile: ", envProfile)
     ngx.log(ngx.INFO, "writeUpstreamConfigFile - Upstreams directory: ", upstreamsDir)
 
-    if settings.storage_type == "disk" then
-        -- Read all upstream files from disk
-        local files, filesErr = Helper.getFilesInDirectory(upstreamsDir)
-        if filesErr then
-            ngx.log(ngx.WARN, "Error reading upstreams directory: ", filesErr)
-            -- Continue with empty list - directory might be newly created
-            files = {}
-        end
-        ngx.log(ngx.INFO, "writeUpstreamConfigFile - Found ", files and #files or 0, " files in directory")
-
-        if files then
-            for _, file in ipairs(files) do
-                ngx.log(ngx.DEBUG, "writeUpstreamConfigFile - Processing file: ", file)
-                if file:match("%.json$") and not file:match("upstreams%.conf") then
-                    local jsonData, readErr = Helper.getDataFromFile(upstreamsDir .. "/" .. file)
-                    if jsonData then
-                        local decodeOk, upstream = pcall(cjson.decode, jsonData)
-                        if decodeOk and upstream and upstream.enabled ~= false then
-                            table.insert(allUpstreams, upstream)
-                            ngx.log(ngx.INFO, "writeUpstreamConfigFile - Added upstream: ", upstream.name or "unknown")
-                        elseif not decodeOk then
-                            ngx.log(ngx.WARN, "Failed to decode upstream JSON file: ", file, " - ", upstream)
-                        end
-                    elseif readErr then
-                        ngx.log(ngx.WARN, "Failed to read upstream file: ", file, " - ", readErr)
-                    end
-                end
-            end
-        end
-    else
-        -- Read from Redis
-        local allRecords, redisErr = red:hgetall("upstreams_" .. envProfile)
-        if redisErr then
-            ngx.log(ngx.WARN, "Redis error reading upstreams: ", redisErr)
-        end
-        if allRecords and type(allRecords) == "table" then
-            for i = 1, #allRecords, 2 do
-                local decodeOk, upstream = pcall(cjson.decode, allRecords[i + 1])
-                if decodeOk and upstream and upstream.enabled ~= false then
-                    table.insert(allUpstreams, upstream)
-                end
+    local scanned, scanErr = Repo.scan("upstreams", envProfile)
+    if scanErr then
+        ngx.log(ngx.WARN, "storage error reading upstreams: ", tostring(scanErr))
+    end
+    if scanned then
+        for _, upstream in ipairs(scanned) do
+            if upstream and upstream.enabled ~= false then
+                table.insert(allUpstreams, upstream)
+                ngx.log(ngx.INFO, "writeUpstreamConfigFile - Added upstream: ", upstream.name or "unknown")
             end
         end
     end
@@ -3140,32 +2701,13 @@ local function deleteUpstreamInternal(args, uuid, envProfile)
     local decodedUuid = ngx.unescape_uri(uuid)
     ngx.log(ngx.INFO, "Deleting upstream: ", decodedUuid, " from profile: ", envProfile)
 
-    if settings.storage_type == "disk" then
-        local filePath = configPath .. "data/upstreams/" .. envProfile .. "/" .. decodedUuid .. ".json"
-        ngx.log(ngx.INFO, "Attempting to delete file: ", filePath)
-
-        -- Check if file exists first
-        if not Helper.isFileExists(filePath) then
-            ngx.log(ngx.WARN, "Upstream file not found: ", filePath)
-            return { deleted = false, id = decodedUuid, error = "Upstream not found" }
-        end
-
-        local ok, err = os.remove(filePath)
-        if ok then
-            restUpstreams = { deleted = true, id = decodedUuid }
-            ngx.log(ngx.INFO, "Successfully deleted upstream file: ", filePath)
-        else
-            ngx.log(ngx.ERR, "Failed to delete upstream file: ", filePath, " - ", err)
-            restUpstreams = { deleted = false, id = decodedUuid, error = err or "Unknown error" }
-        end
+    local del, err = Repo.delete("upstreams", envProfile, decodedUuid)
+    if del then
+        restUpstreams = { deleted = true, id = decodedUuid }
+        ngx.log(ngx.INFO, "Successfully deleted upstream: ", decodedUuid)
     else
-        local del, err = red:hdel("upstreams_" .. envProfile, decodedUuid)
-        if del and del > 0 then
-            restUpstreams = { deleted = true, id = decodedUuid }
-        else
-            ngx.log(ngx.WARN, "Failed to delete upstream from Redis: ", err or "not found")
-            restUpstreams = { deleted = false, id = decodedUuid, error = err or "Upstream not found" }
-        end
+        ngx.log(ngx.WARN, "Failed to delete upstream: ", err or "not found")
+        restUpstreams = { deleted = false, id = decodedUuid, error = err or "Upstream not found" }
     end
 
     return restUpstreams
@@ -3232,7 +2774,7 @@ local function listSessions(args)
     params = params.params
     local allsessions, sessions = {}, {}
     local records = {}
-    if useRemoteStorage then
+    if settings.storage_type == "redis" and red then
         local exist_values, err = red:scan(0, "match", "session:*") -- red:keys("session:*")
         if exist_values[2] ~= nil then
             for key, value in pairs(exist_values[2]) do
@@ -3283,10 +2825,10 @@ end
 -- Settings section
 
 local function listSettings(args, uuid)
-    local settingsLogo = red:hget("company_logo", uuid)
-    if settingsLogo and settingsLogo ~= "null" and type(settingsLogo) == "string" then
+    local settingsLogo = Repo.get("company_logo", nil, uuid)
+    if type(settingsLogo) == "table" then
         ngx.say(cjson.encode({
-            data = cjson.decode(settingsLogo)
+            data = settingsLogo
         }))
     end
 end
@@ -3300,9 +2842,8 @@ local function createUpdateSettings(body, uuid)
         body.id = Helper.generate_uuid()
         settingUUID = body.id
     end
-    settingsJson[settingUUID] = cjson.encode(body)
-    local savingToRedis = red:hmset("company_logo", settingsJson)
-    if savingToRedis and savingToRedis ~= nil and type(savingToRedis) == "string" then
+    local saved = Repo.save("company_logo", nil, settingUUID, body, { skip_strip = true })
+    if saved then
         return ngx.say(cjson.encode({
             data = body
         }))
@@ -3321,15 +2862,11 @@ local function importProjects(args)
         if not Helper.isDirectoryExists(pathDir) then
             Helper.createDirectoryRecursive(pathDir)
         end
-        if useRemoteStorage then
-            formattedJson[value.id] = cjson.encode(value)
-            red:hmset(redisKey .. "_" .. value.profile_id, formattedJson)
-            response = Helper.setDataToFile(
-                pathDir .. "/" .. value.id .. ".json", value, pathDir)
-        else
-            response = Helper.setDataToFile(
-                pathDir .. "/" .. value.id .. ".json", value, pathDir)
-        end
+        local import_resource = args.dataType == "rules" and "rules" or args.dataType
+        response = Repo.save(import_resource, value.profile_id, value.id, value, {
+            skip_strip = true,
+            encode_sensitive = false,
+        })
 
         -- Bulk-import SSL wire-up.  Before this call, importing a
         -- server record with ssl_enabled=true silently landed on

--- a/api/init.lua
+++ b/api/init.lua
@@ -70,6 +70,17 @@ end
 -- Determine storage type at init time (not in callback)
 local use_redis_storage = settings and settings.storage_type == "redis"
 
+-- pgsql is fail-loud at worker init: refuse to start if Postgres is down.
+if settings and settings.storage_type == "pgsql" then
+  local ok, err = pcall(function()
+    require("storage").init(settings)
+  end)
+  if not ok then
+    ngx.log(ngx.EMERG, "pgsql storage init failed: ", err)
+    error("pgsql storage unavailable: " .. tostring(err))
+  end
+end
+
 -- Actionable operator warning when settings.json still holds the legacy
 -- reboot-flag path.  api/server-conf.lua rewrites LEGACY_REBOOT_FLAG →
 -- DEFAULT_REBOOT_FLAG at call time so this alone doesn't break saves —

--- a/api/pgsql_storage.lua
+++ b/api/pgsql_storage.lua
@@ -1,5 +1,8 @@
 -- pgsql_storage.lua
--- PostgreSQL storage backend for WSLProxy
+-- LEGACY Redis-hash facade over config_store JSONB.
+-- Admin CRUD now goes through api/storage/pgsql_driver.lua (typed tables +
+-- raw_json) via api/repo. Keep this module so any leftover hash-API caller
+-- still works; do not add new call sites.
 --
 -- Provides a Redis-compatible hash interface so it can replace the `red`
 -- object in api.lua without changing any call-site code.

--- a/api/ready.lua
+++ b/api/ready.lua
@@ -30,13 +30,24 @@ if sf then
     end
 end
 
-local ready = settings_ok
+local storage_health = { ok = true, storage_type = "disk" }
+local ok_store, store_h = pcall(function()
+    return require("storage").health()
+end)
+if ok_store and type(store_h) == "table" then
+    storage_health = store_h
+elseif not ok_store then
+    storage_health = { ok = false, detail = tostring(store_h) }
+end
+
+local ready = settings_ok and storage_health.ok ~= false
 
 if ready then
     ngx.status = 200
     ngx.say(cjson.encode({
         ready = true,
         config_version = config_version,
+        storage = storage_health,
         timestamp = os.date("!%Y-%m-%dT%H:%M:%SZ")
     }))
 else
@@ -44,7 +55,8 @@ else
     ngx.say(cjson.encode({
         ready = false,
         config_version = config_version,
-        reason = "settings not loaded",
+        reason = settings_ok and (storage_health.detail or "storage unhealthy") or "settings not loaded",
+        storage = storage_health,
         timestamp = os.date("!%Y-%m-%dT%H:%M:%SZ")
     }))
 end

--- a/api/repo/codec.lua
+++ b/api/repo/codec.lua
@@ -1,0 +1,81 @@
+-- Encode/decode of sensitive fields that historically lived in CreateUpdateRecord.
+-- Sensitive values are stored base64-encoded on disk/redis/pgsql; the API
+-- request/response contract is unchanged (callers still send/receive the
+-- same shape as before — CreateUpdateRecord encoded before persist).
+
+local _M = {}
+
+local SENSITIVE = {
+    amazon_s3_secret_key = true,
+    jwt_token_validation_value = true,
+    jwt_secret = true,
+    password = true,
+    secret = true,
+    secret_key = true,
+    varnish_vcl_config = true,
+}
+
+local function should_encode(k, v)
+    if type(v) ~= "string" or v == "" then
+        return false
+    end
+    if SENSITIVE[k] then
+        return true
+    end
+    if k == "config" then
+        return true
+    end
+    return false
+end
+
+local function walk(tbl, fn)
+    if type(tbl) ~= "table" then
+        return tbl
+    end
+    local out = {}
+    for k, v in pairs(tbl) do
+        if type(v) == "table" then
+            out[k] = walk(v, fn)
+        else
+            out[k] = fn(k, v)
+        end
+    end
+    return out
+end
+
+function _M.encode_sensitive(record)
+    if type(record) ~= "table" then
+        return record
+    end
+    return walk(record, function(k, v)
+        if should_encode(k, v) then
+            -- already looks encoded? leave it; CreateUpdateRecord historically
+            -- always re-encoded. Keep that: callers pass plaintext or already-b64.
+            local encoded
+            if Base64 and Base64.encode then
+                encoded = Base64.encode(v)
+            elseif ngx and ngx.encode_base64 then
+                encoded = ngx.encode_base64(v)
+            end
+            return encoded or v
+        end
+        return v
+    end)
+end
+
+function _M.strip_empty(record)
+    if type(record) ~= "table" then
+        return record
+    end
+    local out = {}
+    for k, v in pairs(record) do
+        if type(v) == "table" then
+            out[k] = _M.strip_empty(v)
+        elseif v ~= "" then
+            out[k] = v
+        end
+    end
+    return out
+end
+
+return _M

--- a/api/repo/generic.lua
+++ b/api/repo/generic.lua
@@ -1,0 +1,63 @@
+-- Generic repository: encode on write, persist via the storage driver,
+-- return Lua tables. Resource-specific repos wrap this for side-effects.
+
+local Storage = require("storage")
+local Codec = require("repo.codec")
+
+local _M = {}
+
+local function driver()
+    return Storage.get_driver()
+end
+
+function _M.get(resource, env, id)
+    return driver():get(resource, env, id)
+end
+
+function _M.list(resource, env, filter, sort, pagination)
+    return driver():list(resource, env, filter, sort, pagination)
+end
+
+function _M.create(resource, env, id, record, opts)
+    opts = opts or {}
+    local rec = record
+    if not opts.skip_strip then
+        rec = Codec.strip_empty(rec)
+    end
+    if opts.encode_sensitive then
+        rec = Codec.encode_sensitive(rec)
+    end
+    rec.id = rec.id or id
+    return driver():create(resource, env, id, rec)
+end
+
+function _M.update(resource, env, id, record, opts)
+    opts = opts or {}
+    local rec = record
+    if not opts.skip_strip then
+        rec = Codec.strip_empty(rec)
+    end
+    if opts.encode_sensitive then
+        rec = Codec.encode_sensitive(rec)
+    end
+    rec.id = rec.id or id
+    return driver():update(resource, env, id, rec)
+end
+
+function _M.delete(resource, env, id)
+    return driver():delete(resource, env, id)
+end
+
+function _M.exists(resource, env, id)
+    return driver():exists(resource, env, id)
+end
+
+function _M.scan(resource, env)
+    local res, err = driver():list(resource, env, {}, {}, nil)
+    if not res then
+        return nil, err
+    end
+    return res.records or {}
+end
+
+return _M

--- a/api/repo/init.lua
+++ b/api/repo/init.lua
@@ -1,0 +1,95 @@
+-- Repository facade used by the admin API (api.lua).
+-- Resource-specific modules handle encode/side-effect policy; persistence
+-- always goes through the storage driver (disk, or redis/pgsql + disk).
+
+local Generic = require("repo.generic")
+local Servers = require("repo.servers")
+local Rules = require("repo.rules")
+local Secrets = require("repo.secrets")
+local Storage = require("storage")
+
+local _M = {
+    servers = Servers,
+    rules = Rules,
+    secrets = Secrets,
+}
+
+local SPECIAL = {
+    servers = Servers,
+    rules = Rules,
+    secrets = Secrets,
+}
+
+function _M.for_resource(resource)
+    return SPECIAL[resource]
+end
+
+function _M.get(resource, env, id)
+    local spec = SPECIAL[resource]
+    if spec then
+        return spec.get(env, id)
+    end
+    return Generic.get(resource, env, id)
+end
+
+function _M.list(resource, env, filter, sort, pagination)
+    local spec = SPECIAL[resource]
+    if spec then
+        return spec.list(env, filter, sort, pagination)
+    end
+    return Generic.list(resource, env, filter, sort, pagination)
+end
+
+function _M.create(resource, env, id, record)
+    local spec = SPECIAL[resource]
+    if spec then
+        return spec.create(env, id, record)
+    end
+    return Generic.create(resource, env, id, record)
+end
+
+function _M.update(resource, env, id, record)
+    local spec = SPECIAL[resource]
+    if spec then
+        return spec.update(env, id, record)
+    end
+    return Generic.update(resource, env, id, record)
+end
+
+function _M.delete(resource, env, id)
+    local spec = SPECIAL[resource]
+    if spec then
+        return spec.delete(env, id)
+    end
+    return Generic.delete(resource, env, id)
+end
+
+function _M.exists(resource, env, id)
+    local spec = SPECIAL[resource]
+    if spec then
+        return spec.exists(env, id)
+    end
+    return Generic.exists(resource, env, id)
+end
+
+function _M.save(resource, env, id, record, opts)
+    opts = opts or {}
+    -- Always upsert through generic so callers that already encoded
+    -- (CreateUpdateRecord) can skip a second encode pass.
+    return Generic.update(resource, env, id, record, opts)
+end
+
+function _M.scan(resource, env)
+    return Generic.scan(resource, env)
+end
+
+function _M.health()
+    return Storage.health()
+end
+
+function _M.storage_type()
+    Storage.get_driver()
+    return Storage.type
+end
+
+return _M

--- a/api/repo/rules.lua
+++ b/api/repo/rules.lua
@@ -1,0 +1,37 @@
+local Generic = require("repo.generic")
+
+local RESOURCE = "rules"
+
+local _M = {}
+
+function _M.get(env, id)
+    return Generic.get(RESOURCE, env, id)
+end
+
+function _M.list(env, filter, sort, pagination)
+    return Generic.list(RESOURCE, env, filter, sort, pagination)
+end
+
+function _M.create(env, id, record, opts)
+    record._schema_version = record._schema_version or 2
+    opts = opts or {}
+    if opts.encode_sensitive == nil then opts.encode_sensitive = true end
+    return Generic.create(RESOURCE, env, id, record, opts)
+end
+
+function _M.update(env, id, record, opts)
+    record._schema_version = record._schema_version or 2
+    opts = opts or {}
+    if opts.encode_sensitive == nil then opts.encode_sensitive = true end
+    return Generic.update(RESOURCE, env, id, record, opts)
+end
+
+function _M.delete(env, id)
+    return Generic.delete(RESOURCE, env, id)
+end
+
+function _M.exists(env, id)
+    return Generic.exists(RESOURCE, env, id)
+end
+
+return _M

--- a/api/repo/secrets.lua
+++ b/api/repo/secrets.lua
@@ -1,0 +1,35 @@
+local Generic = require("repo.generic")
+
+local RESOURCE = "secrets"
+
+local _M = {}
+
+function _M.get(env, id)
+    return Generic.get(RESOURCE, env, id)
+end
+
+function _M.list(env, filter, sort, pagination)
+    return Generic.list(RESOURCE, env, filter, sort, pagination)
+end
+
+function _M.create(env, id, record, opts)
+    opts = opts or {}
+    if opts.encode_sensitive == nil then opts.encode_sensitive = true end
+    return Generic.create(RESOURCE, env, id, record, opts)
+end
+
+function _M.update(env, id, record, opts)
+    opts = opts or {}
+    if opts.encode_sensitive == nil then opts.encode_sensitive = true end
+    return Generic.update(RESOURCE, env, id, record, opts)
+end
+
+function _M.delete(env, id)
+    return Generic.delete(RESOURCE, env, id)
+end
+
+function _M.exists(env, id)
+    return Generic.exists(RESOURCE, env, id)
+end
+
+return _M

--- a/api/repo/servers.lua
+++ b/api/repo/servers.lua
@@ -1,0 +1,39 @@
+-- Server repository. Persistence via generic repo; nginx conf compile and
+-- reboot-flag side-effects stay in api.lua (CreateUpdateRecord) so this
+-- module does not pull Conf / openresty -t into the storage layer.
+
+local Generic = require("repo.generic")
+
+local RESOURCE = "servers"
+
+local _M = {}
+
+function _M.get(env, id)
+    return Generic.get(RESOURCE, env, id)
+end
+
+function _M.list(env, filter, sort, pagination)
+    return Generic.list(RESOURCE, env, filter, sort, pagination)
+end
+
+function _M.create(env, id, record, opts)
+    opts = opts or {}
+    if opts.encode_sensitive == nil then opts.encode_sensitive = true end
+    return Generic.create(RESOURCE, env, id, record, opts)
+end
+
+function _M.update(env, id, record, opts)
+    opts = opts or {}
+    if opts.encode_sensitive == nil then opts.encode_sensitive = true end
+    return Generic.update(RESOURCE, env, id, record, opts)
+end
+
+function _M.delete(env, id)
+    return Generic.delete(RESOURCE, env, id)
+end
+
+function _M.exists(env, id)
+    return Generic.exists(RESOURCE, env, id)
+end
+
+return _M

--- a/api/storage/disk_driver.lua
+++ b/api/storage/disk_driver.lua
@@ -1,0 +1,231 @@
+-- Disk JSON driver. Source of truth for the request path (rule_loader
+-- still reads these files). Every CRUD write from the dual_writer lands here.
+
+local cjson = Cjson or require("cjson")
+local Helper = require("helpers")
+local Driver = require("storage.driver")
+local Query = require("storage.query")
+
+local _M = {}
+
+local function log_err(...)
+    if ngx and ngx.log then
+        ngx.log(ngx.ERR, ...)
+    end
+end
+
+local function decode_record(raw)
+    if raw == nil or raw == "" then
+        return nil
+    end
+    if type(raw) == "table" then
+        return raw
+    end
+    local ok, decoded = pcall(cjson.decode, raw)
+    if ok and type(decoded) == "table" then
+        return decoded
+    end
+    return nil, "invalid json"
+end
+
+local function record_id(rec, fallback)
+    if type(rec) ~= "table" then
+        return fallback
+    end
+    return rec.id or rec.uuid or rec.name or fallback
+end
+
+local function list_json_files(dir)
+    local files = {}
+    local ls = io.popen('ls -a "' .. dir .. '" 2>/dev/null')
+    if not ls then
+        return files
+    end
+    for name in ls:lines() do
+        if name ~= "." and name ~= ".." and name ~= "conf"
+            and not name:match("^%.")
+            and name:match("%.json$") then
+            files[#files + 1] = name
+        end
+    end
+    ls:close()
+    return files
+end
+
+local function read_array_file(path)
+    local raw = Helper.getDataFromFile(path)
+    if not raw or raw == "" then
+        return {}
+    end
+    local recs = decode_record(raw)
+    if type(recs) ~= "table" then
+        return {}
+    end
+    -- users.json is historically a map keyed by id, or an array.
+    if recs[1] ~= nil or next(recs) == nil then
+        return recs
+    end
+    local arr = {}
+    for k, v in pairs(recs) do
+        if type(v) == "table" then
+            v.id = v.id or k
+            arr[#arr + 1] = v
+        end
+    end
+    return arr
+end
+
+local function write_array_file(path, records)
+    local dir = path:match("(.+)/[^/]+$")
+    -- setDataToFile JSON-encodes tables itself; do not pre-encode.
+    Helper.setDataToFile(path, records, dir, "json")
+    return true
+end
+
+function _M.new(opts)
+    opts = opts or {}
+    local self = {
+        config_path = opts.config_path or os.getenv("NGINX_CONFIG_DIR") or "/opt/nginx/",
+    }
+    if self.config_path:sub(-1) ~= "/" then
+        self.config_path = self.config_path .. "/"
+    end
+    setmetatable(self, { __index = _M })
+    return self
+end
+
+function _M:get(resource, env, id)
+    local meta = Driver.meta(resource)
+    if not meta then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    if meta.array_file then
+        local path = Driver.disk_dir(self.config_path, resource, env)
+        local recs = read_array_file(path)
+        for _, rec in ipairs(recs) do
+            if tostring(record_id(rec)) == tostring(id) then
+                return rec
+            end
+        end
+        return nil
+    end
+    local dir = Driver.disk_dir(self.config_path, resource, env)
+    local path = dir .. "/" .. tostring(id) .. ".json"
+    local raw = Helper.getDataFromFile(path)
+    if not raw or raw == "" then
+        return nil
+    end
+    return decode_record(raw)
+end
+
+function _M:list(resource, env, filter, sort, pagination)
+    local meta = Driver.meta(resource)
+    if not meta then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    local records = {}
+    if meta.array_file then
+        local path = Driver.disk_dir(self.config_path, resource, env)
+        records = read_array_file(path)
+    else
+        local dir = Driver.disk_dir(self.config_path, resource, env)
+        for _, name in ipairs(list_json_files(dir)) do
+            local raw = Helper.getDataFromFile(dir .. "/" .. name)
+            local rec = decode_record(raw)
+            if rec then
+                rec.id = rec.id or name:gsub("%.json$", "")
+                records[#records + 1] = rec
+            end
+        end
+    end
+    local page, total = Query.paginate(records, filter, sort, pagination)
+    return { records = page, total = total }
+end
+
+function _M:create(resource, env, id, record)
+    return self:update(resource, env, id, record)
+end
+
+function _M:update(resource, env, id, record)
+    local meta = Driver.meta(resource)
+    if not meta then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    if type(record) ~= "table" then
+        return nil, "record must be a table"
+    end
+    record.id = record.id or id
+    if meta.array_file then
+        local path = Driver.disk_dir(self.config_path, resource, env)
+        local recs = read_array_file(path)
+        local found = false
+        for i, rec in ipairs(recs) do
+            if tostring(record_id(rec)) == tostring(id) then
+                recs[i] = record
+                found = true
+                break
+            end
+        end
+        if not found then
+            recs[#recs + 1] = record
+        end
+        write_array_file(path, recs)
+        return record
+    end
+    local dir = Driver.disk_dir(self.config_path, resource, env)
+    local path = dir .. "/" .. tostring(id) .. ".json"
+    -- setDataToFile JSON-encodes tables itself (and throws on IO failure).
+    Helper.setDataToFile(path, record, dir, "json")
+    return record
+end
+
+function _M:delete(resource, env, id)
+    local meta = Driver.meta(resource)
+    if not meta then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    if meta.array_file then
+        local path = Driver.disk_dir(self.config_path, resource, env)
+        local recs = read_array_file(path)
+        local kept = {}
+        local found = false
+        for _, rec in ipairs(recs) do
+            if tostring(record_id(rec)) == tostring(id) then
+                found = true
+            else
+                kept[#kept + 1] = rec
+            end
+        end
+        if not found then
+            return true
+        end
+        write_array_file(path, kept)
+        return true
+    end
+    local dir = Driver.disk_dir(self.config_path, resource, env)
+    local path = dir .. "/" .. tostring(id) .. ".json"
+    os.remove(path)
+    return true
+end
+
+function _M:exists(resource, env, id)
+    local rec, err = self:get(resource, env, id)
+    if err then
+        return false, err
+    end
+    return rec ~= nil
+end
+
+function _M:health()
+    local t0 = os.clock()
+    local path = self.config_path .. "data/settings.json"
+    local f = io.open(path, "r")
+    if not f then
+        return { ok = false, latency_ms = 0, detail = "settings.json unreadable" }
+    end
+    f:close()
+    local ms = (os.clock() - t0) * 1000
+    return { ok = true, latency_ms = ms, detail = "disk" }
+end
+
+return _M

--- a/api/storage/driver.lua
+++ b/api/storage/driver.lua
@@ -1,0 +1,71 @@
+-- Storage driver contract.
+--
+-- Every backend (disk, redis, pgsql) implements:
+--   get(resource, env, id)                 → record|nil, err
+--   list(resource, env, filter, sort, pag) → {records, total}|nil, err
+--   create(resource, env, id, record)      → record|nil, err
+--   update(resource, env, id, record)      → record|nil, err
+--   delete(resource, env, id)              → true|nil, err
+--   exists(resource, env, id)              → boolean, err
+--   health()                               → {ok=bool, latency_ms=n, detail=s}
+--
+-- Records are always Lua tables. Drivers never return JSON strings.
+-- `env` is the profile id (prod/int/test/...). Global resources
+-- (users, pops) ignore env for the on-disk path / redis key suffix.
+
+local _M = {}
+
+_M.RESOURCES = {
+    servers      = { redis = "servers",        disk = "servers",      scoped = true,  redis_scoped = true },
+    rules        = { redis = "request_rules",  disk = "rules",        scoped = true,  redis_scoped = true },
+    secrets      = { redis = "secrets",        disk = "secrets",      scoped = true,  redis_scoped = true },
+    instances    = { redis = "instances",      disk = "instances",    scoped = true,  redis_scoped = true },
+    upstreams    = { redis = "upstreams",      disk = "upstreams",    scoped = true,  redis_scoped = true },
+    waf_rules    = { redis = "waf_rules",      disk = "waf_rules",    scoped = true,  redis_scoped = true },
+    waf_policies = { redis = "waf_policies",   disk = "waf_policies", scoped = true,  redis_scoped = true },
+    waf_events   = { redis = "waf_events",     disk = "waf_events",   scoped = true,  redis_scoped = true },
+    users        = { redis = "users",          disk = "users",        scoped = false, redis_scoped = false, array_file = true },
+    pops         = { redis = "pops",           disk = "pops",         scoped = false, redis_scoped = false },
+    bookmarks    = { redis = "bookmarks",      disk = "bookmarks",    scoped = false, redis_scoped = false, array_file = true },
+    profiles     = { redis = "profiles",       disk = "profiles",     scoped = false, redis_scoped = false },
+    company_logo = { redis = "company_logo",   disk = "company_logo", scoped = false, redis_scoped = false },
+}
+
+function _M.meta(resource)
+    return _M.RESOURCES[resource]
+end
+
+function _M.redis_hash(resource, env)
+    local m = _M.RESOURCES[resource]
+    if not m then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    if m.redis_scoped then
+        return m.redis .. "_" .. tostring(env or "prod")
+    end
+    return m.redis
+end
+
+function _M.disk_dir(config_path, resource, env)
+    local m = _M.RESOURCES[resource]
+    if not m then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    local root = config_path or "/opt/nginx/"
+    if root:sub(-1) ~= "/" then
+        root = root .. "/"
+    end
+    if m.array_file then
+        return root .. "data/" .. m.disk .. ".json", true
+    end
+    if m.scoped then
+        return root .. "data/" .. m.disk .. "/" .. tostring(env or "prod")
+    end
+    return root .. "data/" .. m.disk
+end
+
+function _M.not_impl(name)
+    return nil, "driver method not implemented: " .. tostring(name)
+end
+
+return _M

--- a/api/storage/dual_writer.lua
+++ b/api/storage/dual_writer.lua
@@ -1,0 +1,122 @@
+-- Dual writer: primary (redis or pgsql) + disk.
+-- Writes go primary first, then disk. Disk failure rolls the primary
+-- write back. Reads prefer primary and fall back to disk.
+
+local DiskDriver = require("storage.disk_driver")
+
+local _M = {}
+
+function _M.new(opts)
+    opts = opts or {}
+    if not opts.primary then
+        error("dual_writer requires primary driver")
+    end
+    local self = {
+        primary = opts.primary,
+        disk = opts.disk or DiskDriver.new({ config_path = opts.config_path }),
+        mode = opts.mode or "remote+disk",
+    }
+    setmetatable(self, { __index = _M })
+    return self
+end
+
+function _M:get(resource, env, id)
+    local rec, err = self.primary:get(resource, env, id)
+    if rec then
+        return rec
+    end
+    if err then
+        if ngx and ngx.log then
+            ngx.log(ngx.WARN, "dual_writer primary get failed, falling back to disk: ", tostring(err))
+        end
+    end
+    return self.disk:get(resource, env, id)
+end
+
+function _M:list(resource, env, filter, sort, pagination)
+    local res, err = self.primary:list(resource, env, filter, sort, pagination)
+    if res then
+        return res
+    end
+    if err and ngx and ngx.log then
+        ngx.log(ngx.WARN, "dual_writer primary list failed, falling back to disk: ", tostring(err))
+    end
+    return self.disk:list(resource, env, filter, sort, pagination)
+end
+
+function _M:create(resource, env, id, record)
+    local prev = select(1, self.primary:get(resource, env, id))
+    local rec, err = self.primary:create(resource, env, id, record)
+    if not rec then
+        return nil, err
+    end
+    local disk_rec, disk_err = self.disk:create(resource, env, id, record)
+    if not disk_rec then
+        if prev then
+            self.primary:update(resource, env, id, prev)
+        else
+            self.primary:delete(resource, env, id)
+        end
+        return nil, disk_err or "disk write failed"
+    end
+    return rec
+end
+
+function _M:update(resource, env, id, record)
+    local prev = select(1, self.primary:get(resource, env, id))
+    local rec, err = self.primary:update(resource, env, id, record)
+    if not rec then
+        return nil, err
+    end
+    local disk_rec, disk_err = self.disk:update(resource, env, id, record)
+    if not disk_rec then
+        if prev then
+            self.primary:update(resource, env, id, prev)
+        else
+            self.primary:delete(resource, env, id)
+        end
+        return nil, disk_err or "disk write failed"
+    end
+    return rec
+end
+
+function _M:delete(resource, env, id)
+    local prev = select(1, self.primary:get(resource, env, id))
+    local ok, err = self.primary:delete(resource, env, id)
+    if not ok then
+        return nil, err
+    end
+    local dok, derr = self.disk:delete(resource, env, id)
+    if not dok then
+        if prev then
+            self.primary:update(resource, env, id, prev)
+        end
+        return nil, derr or "disk delete failed"
+    end
+    return true
+end
+
+function _M:exists(resource, env, id)
+    local ok, err = self.primary:exists(resource, env, id)
+    if ok then
+        return true
+    end
+    if err then
+        return self.disk:exists(resource, env, id)
+    end
+    return self.disk:exists(resource, env, id)
+end
+
+function _M:health()
+    local p = self.primary:health()
+    local d = self.disk:health()
+    return {
+        ok = p.ok and d.ok,
+        latency_ms = (p.latency_ms or 0) + (d.latency_ms or 0),
+        detail = (p.detail or "?") .. "+" .. (d.detail or "disk"),
+        primary = p,
+        disk = d,
+    }
+end
+
+return _M

--- a/api/storage/init.lua
+++ b/api/storage/init.lua
@@ -1,0 +1,88 @@
+-- Storage bootstrap. Picks disk / redis / pgsql from settings.storage_type.
+-- Redis and pgsql modes wrap the remote driver in a dual_writer so every
+-- CRUD mutation still emits on-disk JSON (request-path source of truth).
+
+local Helper = require("helpers")
+local DiskDriver = require("storage.disk_driver")
+local RedisDriver = require("storage.redis_driver")
+local PgsqlDriver = require("storage.pgsql_driver")
+local DualWriter = require("storage.dual_writer")
+
+local _M = {
+    type = "disk",
+    driver = nil,
+    settings = nil,
+}
+
+local function config_path()
+    local p = os.getenv("NGINX_CONFIG_DIR") or "/opt/nginx/"
+    if p:sub(-1) ~= "/" then
+        p = p .. "/"
+    end
+    return p
+end
+
+local function load_settings(existing)
+    if existing and type(existing) == "table" then
+        return existing
+    end
+    local ok, settings = pcall(Helper.settings)
+    if ok and type(settings) == "table" then
+        return settings
+    end
+    return {}
+end
+
+function _M.init(settings)
+    settings = load_settings(settings)
+    _M.settings = settings
+    local stype = settings.storage_type or "disk"
+    _M.type = stype
+    local cpath = config_path()
+    local disk = DiskDriver.new({ config_path = cpath })
+
+    if stype == "redis" then
+        local primary = RedisDriver.new({ settings = settings })
+        local red, err = primary:connect()
+        if not red then
+            if ngx then
+                ngx.log(ngx.ERR, "redis storage connect failed: ", tostring(err))
+                if ngx.status then
+                    -- per-request bootstrap (api.lua): fail the request
+                end
+            end
+            error("redis storage unavailable: " .. tostring(err))
+        end
+        _M.driver = DualWriter.new({ primary = primary, disk = disk, mode = "redis+disk" })
+    elseif stype == "pgsql" then
+        local primary = PgsqlDriver.new({ settings = settings })
+        local pg, err = primary:connect()
+        if not pg then
+            if ngx and ngx.log then
+                ngx.log(ngx.EMERG, "pgsql storage connect failed: ", tostring(err))
+            end
+            error("pgsql storage unavailable: " .. tostring(err))
+        end
+        _M.driver = DualWriter.new({ primary = primary, disk = disk, mode = "pgsql+disk" })
+    else
+        _M.type = "disk"
+        _M.driver = disk
+    end
+    return _M.driver
+end
+
+function _M.get_driver()
+    if not _M.driver then
+        _M.init()
+    end
+    return _M.driver
+end
+
+function _M.health()
+    local d = _M.get_driver()
+    local h = d:health()
+    h.storage_type = _M.type
+    return h
+end
+
+return _M

--- a/api/storage/pgsql_driver.lua
+++ b/api/storage/pgsql_driver.lua
@@ -1,0 +1,556 @@
+-- PostgreSQL driver. Typed tables + raw_json safety valve.
+-- Reads reconstruct the record from raw_json (full round-trip), falling
+-- back to typed columns if raw_json is missing. Writes always persist
+-- both typed columns and the complete JSON document.
+
+local cjson = Cjson or require("cjson")
+local Driver = require("storage.driver")
+local Query = require("storage.query")
+
+local _M = {}
+
+local TABLE_MAP = {
+    servers      = "servers",
+    rules        = "rules",
+    secrets      = "secrets",
+    instances    = "instances",
+    upstreams    = "upstreams",
+    waf_rules    = "waf_rules",
+    waf_policies = "waf_policies",
+    waf_events   = "waf_events",
+    users        = "users",
+    pops         = "pops",
+    bookmarks    = "bookmarks",
+    profiles     = "profiles",
+    company_logo = "company_logo",
+}
+
+local SCOPED = {
+    servers = true, rules = true, secrets = true, instances = true,
+    upstreams = true, waf_rules = true, waf_policies = true, waf_events = true,
+}
+
+local function esc(s)
+    if s == nil then
+        return "NULL"
+    end
+    s = tostring(s):gsub("'", "''")
+    return "'" .. s .. "'"
+end
+
+local function json_esc(tbl)
+    local ok, encoded = pcall(cjson.encode, tbl)
+    if not ok then
+        return "NULL"
+    end
+    return esc(encoded)
+end
+
+local function bool_sql(v)
+    if v == true or v == "true" or v == 1 or v == "1" then
+        return "TRUE"
+    end
+    if v == false or v == "false" or v == 0 or v == "0" then
+        return "FALSE"
+    end
+    return "NULL"
+end
+
+local function num_sql(v)
+    local n = tonumber(v)
+    if n == nil then
+        return "NULL"
+    end
+    return tostring(n)
+end
+
+local function ident(name)
+    return '"' .. tostring(name):gsub('"', "") .. '"'
+end
+
+function _M.new(opts)
+    opts = opts or {}
+    local self = {
+        settings = opts.settings or {},
+        pg = opts.pg,
+    }
+    setmetatable(self, { __index = _M })
+    return self
+end
+
+function _M:connect()
+    if self.pg then
+        return self.pg
+    end
+    local ok_req, pgmoon = pcall(require, "pgmoon")
+    if not ok_req or not pgmoon then
+        return nil, "pgmoon not installed"
+    end
+    local cfg = self.settings.pgsql or {}
+    local pg = pgmoon.new({
+        host     = cfg.host or cfg.pg_host or os.getenv("WSLPROXY_PG_HOST") or "127.0.0.1",
+        port     = tonumber(cfg.port or cfg.pg_port or os.getenv("WSLPROXY_PG_PORT")) or 5432,
+        database = cfg.database or cfg.pg_database or os.getenv("WSLPROXY_PG_DB") or "wslproxy",
+        user     = cfg.user or cfg.pg_user or os.getenv("WSLPROXY_PG_USER") or "wslproxy",
+        password = cfg.password or cfg.pg_password or os.getenv("WSLPROXY_PG_PASSWORD") or "",
+        ssl      = cfg.ssl == true,
+    })
+    local ok, err = pg:connect()
+    if not ok then
+        return nil, err or "pgsql connect failed"
+    end
+    self.pg = pg
+    return pg
+end
+
+function _M:query(sql)
+    local pg, err = self:connect()
+    if not pg then
+        return nil, err
+    end
+    local res, qerr = pg:query(sql)
+    if not res then
+        return nil, qerr
+    end
+    return res
+end
+
+local function typed_columns(resource, env, id, rec)
+    rec = rec or {}
+    local now = os.date("!%Y-%m-%dT%H:%M:%SZ")
+    if resource == "servers" then
+        return {
+            id = id,
+            env_profile = env,
+            server_name = rec.server_name or rec.id,
+            proxy_server_name = rec.proxy_server_name,
+            profile_id = rec.profile_id or env,
+            ssl_enabled = rec.ssl_enabled,
+            ssl_force_https = rec.ssl_force_https,
+            cache_enabled = rec.cache_enabled,
+            varnish_enabled = rec.varnish_enabled,
+            waf_enabled = rec.waf_enabled,
+            waf_policy_id = rec.waf_policy_id,
+            rate_limit_enabled = rec.rate_limit_enabled,
+            config_status = rec.config_status,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "rules" then
+        local match = rec.match or {}
+        local rules = match.rules or {}
+        local response = match.response or {}
+        return {
+            id = id,
+            env_profile = env,
+            name = rec.name,
+            priority = rec.priority or 0,
+            profile_id = rec.profile_id or env,
+            path = rules.path,
+            path_key = rules.path_key,
+            status_code = response.code,
+            redirect_uri = response.redirect_uri,
+            schema_version = rec._schema_version or 2,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "secrets" then
+        return {
+            id = id,
+            env_profile = env,
+            name = rec.name,
+            kind = rec.kind or rec.type,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "upstreams" then
+        return {
+            id = id,
+            env_profile = env,
+            name = rec.name,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "waf_policies" then
+        return {
+            id = id,
+            env_profile = env,
+            name = rec.name,
+            mode = rec.mode,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "waf_rules" then
+        return {
+            id = id,
+            env_profile = env,
+            name = rec.name,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "waf_events" then
+        return {
+            id = id,
+            env_profile = env,
+            created_at = rec.created_at or now,
+        }
+    elseif resource == "instances" then
+        return {
+            id = id,
+            env_profile = env,
+            name = rec.name,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "users" then
+        return {
+            id = id,
+            username = rec.username or rec.name,
+            email = rec.email,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "pops" then
+        return {
+            id = id,
+            name = rec.name,
+            status = rec.status,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "bookmarks" then
+        return {
+            id = id,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "profiles" then
+        return {
+            id = id,
+            name = rec.name or id,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    elseif resource == "company_logo" then
+        return {
+            id = id,
+            created_at = rec.created_at or now,
+            updated_at = rec.updated_at or now,
+        }
+    end
+    return { id = id, env_profile = env }
+end
+
+local function col_sql(resource, cols)
+    local order
+    if resource == "servers" then
+        order = {
+            "id", "env_profile", "server_name", "proxy_server_name", "profile_id",
+            "ssl_enabled", "ssl_force_https", "cache_enabled", "varnish_enabled",
+            "waf_enabled", "waf_policy_id", "rate_limit_enabled", "config_status",
+            "created_at", "updated_at", "raw_json",
+        }
+    elseif resource == "rules" then
+        order = {
+            "id", "env_profile", "name", "priority", "profile_id",
+            "path", "path_key", "status_code", "redirect_uri", "schema_version",
+            "created_at", "updated_at", "raw_json",
+        }
+    elseif resource == "secrets" then
+        order = { "id", "env_profile", "name", "kind", "created_at", "updated_at", "raw_json" }
+    elseif resource == "upstreams" then
+        order = { "id", "env_profile", "name", "created_at", "updated_at", "raw_json" }
+    elseif resource == "waf_policies" then
+        order = { "id", "env_profile", "name", "mode", "created_at", "updated_at", "raw_json" }
+    elseif resource == "waf_rules" then
+        order = { "id", "env_profile", "name", "created_at", "updated_at", "raw_json" }
+    elseif resource == "waf_events" then
+        order = { "id", "env_profile", "created_at", "raw_json" }
+    elseif resource == "instances" then
+        order = { "id", "env_profile", "name", "created_at", "updated_at", "raw_json" }
+    elseif resource == "users" then
+        order = { "id", "username", "email", "created_at", "updated_at", "raw_json" }
+    elseif resource == "pops" then
+        order = { "id", "name", "status", "created_at", "updated_at", "raw_json" }
+    elseif resource == "bookmarks" then
+        order = { "id", "created_at", "updated_at", "raw_json" }
+    elseif resource == "profiles" then
+        order = { "id", "name", "created_at", "updated_at", "raw_json" }
+    elseif resource == "company_logo" then
+        order = { "id", "created_at", "updated_at", "raw_json" }
+    else
+        order = { "id", "raw_json" }
+    end
+
+    local bools = {
+        ssl_enabled = true, ssl_force_https = true, cache_enabled = true,
+        varnish_enabled = true, waf_enabled = true, rate_limit_enabled = true,
+        config_status = true,
+    }
+    local nums = { priority = true, schema_version = true, status_code = true }
+
+    local names, values, updates = {}, {}, {}
+    for _, col in ipairs(order) do
+        names[#names + 1] = ident(col)
+        local v
+        if col == "raw_json" then
+            v = "NULL" -- filled by caller
+        elseif bools[col] then
+            v = bool_sql(cols[col])
+        elseif nums[col] then
+            v = num_sql(cols[col])
+        else
+            v = esc(cols[col])
+        end
+        values[#values + 1] = v
+        if col ~= "id" and col ~= "env_profile" then
+            updates[#updates + 1] = ident(col) .. " = EXCLUDED." .. ident(col)
+        end
+    end
+    return names, values, updates, order
+end
+
+local function conflict_target(resource)
+    if SCOPED[resource] then
+        return "(id, env_profile)"
+    end
+    return "(id)"
+end
+
+local function where_pk(resource, env, id)
+    if SCOPED[resource] then
+        return "id = " .. esc(id) .. " AND env_profile = " .. esc(env)
+    end
+    return "id = " .. esc(id)
+end
+
+local function row_to_record(row)
+    if not row then
+        return nil
+    end
+    local raw = row.raw_json
+    if type(raw) == "table" then
+        return raw
+    end
+    if type(raw) == "string" and raw ~= "" then
+        local ok, decoded = pcall(cjson.decode, raw)
+        if ok and type(decoded) == "table" then
+            return decoded
+        end
+    end
+    -- typed-column fallback (should be rare)
+    local rec = {}
+    for k, v in pairs(row) do
+        if k ~= "raw_json" then
+            rec[k] = v
+        end
+    end
+    return rec
+end
+
+function _M:get(resource, env, id)
+    local table_name = TABLE_MAP[resource]
+    if not table_name then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    local sql = "SELECT * FROM " .. ident(table_name) .. " WHERE " .. where_pk(resource, env, id) .. " LIMIT 1"
+    local res, err = self:query(sql)
+    if not res then
+        return nil, err
+    end
+    if type(res) ~= "table" or #res == 0 then
+        return nil
+    end
+    return row_to_record(res[1])
+end
+
+function _M:list(resource, env, filter, sort, pagination)
+    local table_name = TABLE_MAP[resource]
+    if not table_name then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    local sql
+    if SCOPED[resource] then
+        sql = "SELECT * FROM " .. ident(table_name) .. " WHERE env_profile = " .. esc(env)
+    else
+        sql = "SELECT * FROM " .. ident(table_name)
+    end
+    -- Indexed equality filters when the column exists on the typed table.
+    filter = filter or {}
+    local extra = {}
+    if resource == "servers" then
+        if filter.server_name then extra[#extra + 1] = "server_name = " .. esc(filter.server_name) end
+        if filter.waf_policy_id then extra[#extra + 1] = "waf_policy_id = " .. esc(filter.waf_policy_id) end
+        if filter.ssl_enabled ~= nil and filter.ssl_enabled ~= "" then
+            extra[#extra + 1] = "ssl_enabled = " .. bool_sql(filter.ssl_enabled)
+        end
+    elseif resource == "rules" then
+        if filter.name then extra[#extra + 1] = "name = " .. esc(filter.name) end
+        if filter.path_key then extra[#extra + 1] = "path_key = " .. esc(filter.path_key) end
+        if filter.priority then extra[#extra + 1] = "priority = " .. num_sql(filter.priority) end
+    end
+    if #extra > 0 then
+        if SCOPED[resource] then
+            sql = sql .. " AND " .. table.concat(extra, " AND ")
+        else
+            sql = sql .. " WHERE " .. table.concat(extra, " AND ")
+        end
+    end
+    local res, err = self:query(sql)
+    if not res then
+        return nil, err
+    end
+    local records = {}
+    if type(res) == "table" then
+        for _, row in ipairs(res) do
+            local rec = row_to_record(row)
+            if rec then
+                records[#records + 1] = rec
+            end
+        end
+    end
+    local page, total = Query.paginate(records, filter, sort, pagination)
+    return { records = page, total = total }
+end
+
+local function upsert_children(self, resource, env, id, rec)
+    if resource == "servers" then
+        self:query("DELETE FROM server_listens WHERE server_id = " .. esc(id) .. " AND env_profile = " .. esc(env))
+        self:query("DELETE FROM server_rules WHERE server_id = " .. esc(id) .. " AND env_profile = " .. esc(env))
+        local listens = rec.listens or {}
+        for i, listen in ipairs(listens) do
+            local val = type(listen) == "table" and (listen.listen or listen.value) or listen
+            self:query(
+                "INSERT INTO server_listens (server_id, env_profile, listen, position) VALUES ("
+                .. esc(id) .. ", " .. esc(env) .. ", " .. esc(val) .. ", " .. tostring(i) .. ")"
+            )
+        end
+        local rules = rec.rules
+        if type(rules) == "string" and rules ~= "" then
+            rules = { rules }
+        end
+        if type(rules) == "table" then
+            for i, rid in ipairs(rules) do
+                if type(rid) == "string" then
+                    self:query(
+                        "INSERT INTO server_rules (server_id, env_profile, rule_id, position) VALUES ("
+                        .. esc(id) .. ", " .. esc(env) .. ", " .. esc(rid) .. ", " .. tostring(i) .. ")"
+                    )
+                end
+            end
+        end
+        local cases = rec.match_cases or {}
+        for i, mc in ipairs(cases) do
+            local rid = type(mc) == "table" and (mc.statement or mc.rule_id) or mc
+            if rid and tostring(rid) ~= "" then
+                    self:query(
+                        "INSERT INTO server_rules (server_id, env_profile, rule_id, position) VALUES ("
+                        .. esc(id) .. ", " .. esc(env) .. ", " .. esc(rid) .. ", " .. tostring(i + 1000) .. ")"
+                    )
+            end
+        end
+    elseif resource == "rules" then
+        self:query("DELETE FROM rule_backends WHERE rule_id = " .. esc(id) .. " AND env_profile = " .. esc(env))
+        local backends = (((rec.match or {}).response or {}).backends) or rec.backends or {}
+        for i, b in ipairs(backends) do
+            if type(b) == "table" then
+                self:query(
+                    "INSERT INTO rule_backends (rule_id, env_profile, address, weight, label, position) VALUES ("
+                    .. esc(id) .. ", " .. esc(env) .. ", " .. esc(b.address) .. ", "
+                    .. num_sql(b.weight or 1) .. ", " .. esc(b.label) .. ", " .. tostring(i) .. ")"
+                )
+            end
+        end
+    end
+end
+
+function _M:create(resource, env, id, record)
+    return self:update(resource, env, id, record)
+end
+
+function _M:update(resource, env, id, record)
+    local table_name = TABLE_MAP[resource]
+    if not table_name then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    if type(record) ~= "table" then
+        return nil, "record must be a table"
+    end
+    record.id = record.id or id
+    local cols = typed_columns(resource, env, id, record)
+    local names, values, updates, order = col_sql(resource, cols)
+    for i, col in ipairs(order) do
+        if col == "raw_json" then
+            values[i] = json_esc(record) .. "::jsonb"
+        end
+    end
+    local sql = "INSERT INTO " .. ident(table_name) .. " (" .. table.concat(names, ", ") .. ") VALUES ("
+        .. table.concat(values, ", ") .. ") ON CONFLICT " .. conflict_target(resource)
+        .. " DO UPDATE SET " .. table.concat(updates, ", ")
+    local _, err = self:query(sql)
+    if err then
+        return nil, err
+    end
+    local ok_ch, ch_err = pcall(upsert_children, self, resource, env, id, record)
+    if not ok_ch and ngx and ngx.log then
+        ngx.log(ngx.WARN, "pgsql child upsert failed: ", tostring(ch_err))
+    end
+    -- Keep config_store in sync so leftover pgsql_storage hash callers still work.
+    local bucket = Driver.redis_hash(resource, env)
+    if bucket then
+        self:query(
+            "INSERT INTO config_store (bucket, key, value, updated_at) VALUES ("
+            .. esc(bucket) .. ", " .. esc(id) .. ", " .. json_esc(record) .. "::jsonb, NOW()) "
+            .. "ON CONFLICT (bucket, key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()"
+        )
+    end
+    return record
+end
+
+function _M:delete(resource, env, id)
+    local table_name = TABLE_MAP[resource]
+    if not table_name then
+        return nil, "unknown resource: " .. tostring(resource)
+    end
+    if resource == "servers" then
+        self:query("DELETE FROM server_listens WHERE server_id = " .. esc(id) .. " AND env_profile = " .. esc(env))
+        self:query("DELETE FROM server_rules WHERE server_id = " .. esc(id) .. " AND env_profile = " .. esc(env))
+    elseif resource == "rules" then
+        self:query("DELETE FROM rule_backends WHERE rule_id = " .. esc(id) .. " AND env_profile = " .. esc(env))
+    end
+    local _, err = self:query("DELETE FROM " .. ident(table_name) .. " WHERE " .. where_pk(resource, env, id))
+    if err then
+        return nil, err
+    end
+    local bucket = Driver.redis_hash(resource, env)
+    if bucket then
+        self:query("DELETE FROM config_store WHERE bucket = " .. esc(bucket) .. " AND key = " .. esc(id))
+    end
+    return true
+end
+
+function _M:exists(resource, env, id)
+    local table_name = TABLE_MAP[resource]
+    if not table_name then
+        return false, "unknown resource: " .. tostring(resource)
+    end
+    local res, err = self:query(
+        "SELECT 1 FROM " .. ident(table_name) .. " WHERE " .. where_pk(resource, env, id) .. " LIMIT 1"
+    )
+    if err then
+        return false, err
+    end
+    return type(res) == "table" and #res > 0
+end
+
+function _M:health()
+    local t0 = os.clock()
+    local res, err = self:query("SELECT 1 AS ok")
+    local ms = (os.clock() - t0) * 1000
+    if not res then
+        return { ok = false, latency_ms = ms, detail = tostring(err) }
+    end
+    return { ok = true, latency_ms = ms, detail = "pgsql" }
+end
+
+return _M

--- a/api/storage/query.lua
+++ b/api/storage/query.lua
@@ -1,0 +1,87 @@
+-- Shared list filter → sort → paginate used by every storage driver.
+-- Extracted from api.lua listPaginationLocal so disk/redis/pgsql lists
+-- return identical shapes for the same query params.
+
+local cjson = Cjson or require("cjson")
+
+local _M = {}
+
+local function to_number_or_nil(v)
+    if v == nil then
+        return nil
+    end
+    return tonumber(v)
+end
+
+-- Returns (page, total) where page is the slice for pagination.page/perPage.
+function _M.paginate(records, filter, sort, pagination)
+    filter = filter or {}
+    sort = sort or {}
+    pagination = pagination or {}
+
+    local filtered = {}
+    for _, rec in ipairs(records or {}) do
+        local ok = true
+        for k, v in pairs(filter) do
+            if k ~= "q" and rec[k] ~= nil and tostring(rec[k]) ~= tostring(v) then
+                ok = false
+                break
+            end
+        end
+        if ok and filter.q and filter.q ~= "" then
+            local q = string.lower(tostring(filter.q))
+            local blob
+            local enc_ok, encoded = pcall(cjson.encode, rec)
+            if enc_ok then
+                blob = string.lower(encoded)
+            else
+                blob = ""
+            end
+            if not string.find(blob, q, 1, true) then
+                ok = false
+            end
+        end
+        if ok then
+            filtered[#filtered + 1] = rec
+        end
+    end
+
+    local field = sort.field or "id"
+    local order = string.upper(tostring(sort.order or "ASC"))
+    table.sort(filtered, function(a, b)
+        local av, bv = a[field], b[field]
+        if av == nil then av = "" end
+        if bv == nil then bv = "" end
+        if type(av) == "number" and type(bv) == "number" then
+            if order == "DESC" then
+                return av > bv
+            end
+            return av < bv
+        end
+        av, bv = tostring(av), tostring(bv)
+        if order == "DESC" then
+            return av > bv
+        end
+        return av < bv
+    end)
+
+    local total = #filtered
+    local page_size = to_number_or_nil(pagination.perPage)
+    local page_number = to_number_or_nil(pagination.page)
+    if not page_size or not page_number then
+        return filtered, total
+    end
+    if page_size < 1 then page_size = 10 end
+    if page_number < 1 then page_number = 1 end
+    local start_index = (page_number - 1) * page_size + 1
+    local end_index = math.min(start_index + page_size - 1, total)
+    local page = {}
+    if start_index <= total then
+        for i = start_index, end_index do
+            page[#page + 1] = filtered[i]
+        end
+    end
+    return page, total
+end
+
+return _M

--- a/api/storage/redis_driver.lua
+++ b/api/storage/redis_driver.lua
@@ -1,0 +1,183 @@
+-- Redis hash driver. Keys match the historical api.lua layout:
+--   servers_{env}, request_rules_{env}, secrets_{env}, ...
+--   users (no env suffix)
+
+local cjson = Cjson or require("cjson")
+local Driver = require("storage.driver")
+local Query = require("storage.query")
+
+local _M = {}
+
+local NGX_NULL = (ngx and ngx.null) or {}
+
+local function is_null(v)
+    if v == nil or v == NGX_NULL then
+        return true
+    end
+    if ngx and v == ngx.null then
+        return true
+    end
+    return false
+end
+
+local function decode_record(raw)
+    if is_null(raw) or raw == "" then
+        return nil
+    end
+    if type(raw) == "table" then
+        return raw
+    end
+    local ok, decoded = pcall(cjson.decode, raw)
+    if ok and type(decoded) == "table" then
+        return decoded
+    end
+    return nil, "invalid json"
+end
+
+function _M.new(opts)
+    opts = opts or {}
+    local self = {
+        settings = opts.settings,
+        red = opts.red,
+    }
+    setmetatable(self, { __index = _M })
+    return self
+end
+
+function _M:connect()
+    if self.red then
+        return self.red
+    end
+    local ok_req, redis = pcall(require, "resty.redis")
+    if not ok_req or not redis then
+        return nil, "resty.redis not available"
+    end
+    local red = redis:new()
+    red:set_timeout(1000)
+    local settings = self.settings or {}
+    local env = settings.env_vars or {}
+    local host = env.REDIS_HOST or os.getenv("REDIS_HOST") or "127.0.0.1"
+    local port = tonumber(env.REDIS_PORT or os.getenv("REDIS_PORT")) or 6379
+    local ok, err = red:connect(host, port)
+    if not ok then
+        return nil, err or "redis connect failed"
+    end
+    self.red = red
+    return red
+end
+
+function _M:get(resource, env, id)
+    local red, err = self:connect()
+    if not red then
+        return nil, err
+    end
+    local hash, herr = Driver.redis_hash(resource, env)
+    if not hash then
+        return nil, herr
+    end
+    local raw, gerr = red:hget(hash, tostring(id))
+    if gerr then
+        return nil, gerr
+    end
+    return decode_record(raw)
+end
+
+function _M:list(resource, env, filter, sort, pagination)
+    local red, err = self:connect()
+    if not red then
+        return nil, err
+    end
+    local hash, herr = Driver.redis_hash(resource, env)
+    if not hash then
+        return nil, herr
+    end
+    local all, lerr = red:hgetall(hash)
+    if lerr then
+        return nil, lerr
+    end
+    local records = {}
+    if type(all) == "table" then
+        -- redis hgetall returns {k1, v1, k2, v2, ...}
+        for i = 1, #all, 2 do
+            local rec = decode_record(all[i + 1])
+            if rec then
+                rec.id = rec.id or all[i]
+                records[#records + 1] = rec
+            end
+        end
+    end
+    local page, total = Query.paginate(records, filter, sort, pagination)
+    return { records = page, total = total }
+end
+
+function _M:create(resource, env, id, record)
+    return self:update(resource, env, id, record)
+end
+
+function _M:update(resource, env, id, record)
+    local red, err = self:connect()
+    if not red then
+        return nil, err
+    end
+    local hash, herr = Driver.redis_hash(resource, env)
+    if not hash then
+        return nil, herr
+    end
+    if type(record) ~= "table" then
+        return nil, "record must be a table"
+    end
+    record.id = record.id or id
+    local ok, werr = red:hset(hash, tostring(id), cjson.encode(record))
+    if not ok then
+        return nil, werr or "redis hset failed"
+    end
+    return record
+end
+
+function _M:delete(resource, env, id)
+    local red, err = self:connect()
+    if not red then
+        return nil, err
+    end
+    local hash, herr = Driver.redis_hash(resource, env)
+    if not hash then
+        return nil, herr
+    end
+    local ok, derr = red:hdel(hash, tostring(id))
+    if not ok then
+        return nil, derr or "redis hdel failed"
+    end
+    return true
+end
+
+function _M:exists(resource, env, id)
+    local red, err = self:connect()
+    if not red then
+        return false, err
+    end
+    local hash, herr = Driver.redis_hash(resource, env)
+    if not hash then
+        return false, herr
+    end
+    local n, eerr = red:hexists(hash, tostring(id))
+    if eerr then
+        return false, eerr
+    end
+    return n == 1 or n == true
+end
+
+function _M:health()
+    local t0 = os.clock()
+    local red, err = self:connect()
+    if not red then
+        return { ok = false, latency_ms = 0, detail = tostring(err) }
+    end
+    local pong, perr = red:ping()
+    local ms = (os.clock() - t0) * 1000
+    if not pong then
+        return { ok = false, latency_ms = ms, detail = tostring(perr or "ping failed") }
+    end
+    return { ok = true, latency_ms = ms, detail = "redis" }
+end
+
+return _M

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -177,6 +177,7 @@ services:
       - postgres-data-local:/var/lib/postgresql/data
       # Schema is applied automatically on first start
       - ./infra/db/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql
+      - ./infra/pgsql/migrations/0001_baseline.sql:/docker-entrypoint-initdb.d/02-typed.sql
 
     networks:
       wslproxy-local-network:

--- a/infra/pgsql/migrations/0001_baseline.sql
+++ b/infra/pgsql/migrations/0001_baseline.sql
@@ -1,0 +1,190 @@
+-- Additive typed schema for WSLProxy PostgreSQL storage.
+-- Safe to re-run (IF NOT EXISTS). Does NOT drop config_store.
+-- Disk JSON remains the request-path source of truth; these tables
+-- are the pgsql-mode index + raw_json document store.
+
+CREATE TABLE IF NOT EXISTS config_store (
+    bucket      TEXT NOT NULL,
+    key         TEXT NOT NULL,
+    value       JSONB NOT NULL DEFAULT '{}'::jsonb,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (bucket, key)
+);
+
+CREATE TABLE IF NOT EXISTS servers (
+    id                  TEXT NOT NULL,
+    env_profile         TEXT NOT NULL,
+    server_name         TEXT,
+    proxy_server_name   TEXT,
+    profile_id          TEXT,
+    ssl_enabled         BOOLEAN,
+    ssl_force_https     BOOLEAN,
+    cache_enabled       BOOLEAN,
+    varnish_enabled     BOOLEAN,
+    waf_enabled         BOOLEAN,
+    waf_policy_id       TEXT,
+    rate_limit_enabled  BOOLEAN,
+    config_status       BOOLEAN,
+    created_at          TIMESTAMPTZ,
+    updated_at          TIMESTAMPTZ,
+    raw_json            JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (id, env_profile)
+);
+CREATE INDEX IF NOT EXISTS idx_servers_server_name ON servers (server_name);
+CREATE INDEX IF NOT EXISTS idx_servers_waf_policy ON servers (waf_policy_id);
+CREATE INDEX IF NOT EXISTS idx_servers_ssl ON servers (ssl_enabled);
+
+CREATE TABLE IF NOT EXISTS server_listens (
+    server_id    TEXT NOT NULL,
+    env_profile  TEXT NOT NULL,
+    listen       TEXT,
+    position     INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_server_listens_pk ON server_listens (server_id, env_profile);
+
+CREATE TABLE IF NOT EXISTS server_rules (
+    server_id    TEXT NOT NULL,
+    env_profile  TEXT NOT NULL,
+    rule_id      TEXT NOT NULL,
+    position     INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_server_rules_pk ON server_rules (server_id, env_profile);
+
+CREATE TABLE IF NOT EXISTS rules (
+    id              TEXT NOT NULL,
+    env_profile     TEXT NOT NULL,
+    name            TEXT,
+    priority        INTEGER DEFAULT 0,
+    profile_id      TEXT,
+    path            TEXT,
+    path_key        TEXT,
+    status_code     INTEGER,
+    redirect_uri    TEXT,
+    schema_version  INTEGER DEFAULT 2,
+    created_at      TIMESTAMPTZ,
+    updated_at      TIMESTAMPTZ,
+    raw_json        JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (id, env_profile)
+);
+CREATE INDEX IF NOT EXISTS idx_rules_name ON rules (name);
+CREATE INDEX IF NOT EXISTS idx_rules_path_key ON rules (path_key);
+CREATE INDEX IF NOT EXISTS idx_rules_priority ON rules (priority);
+
+CREATE TABLE IF NOT EXISTS rule_backends (
+    rule_id      TEXT NOT NULL,
+    env_profile  TEXT NOT NULL,
+    address      TEXT,
+    weight       INTEGER DEFAULT 1,
+    label        TEXT,
+    position     INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_rule_backends_pk ON rule_backends (rule_id, env_profile);
+
+CREATE TABLE IF NOT EXISTS secrets (
+    id           TEXT NOT NULL,
+    env_profile  TEXT NOT NULL,
+    name         TEXT,
+    kind         TEXT,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (id, env_profile)
+);
+
+CREATE TABLE IF NOT EXISTS instances (
+    id           TEXT NOT NULL,
+    env_profile  TEXT NOT NULL,
+    name         TEXT,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (id, env_profile)
+);
+
+CREATE TABLE IF NOT EXISTS upstreams (
+    id           TEXT NOT NULL,
+    env_profile  TEXT NOT NULL,
+    name         TEXT,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (id, env_profile)
+);
+
+CREATE TABLE IF NOT EXISTS waf_rules (
+    id           TEXT NOT NULL,
+    env_profile  TEXT NOT NULL,
+    name         TEXT,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (id, env_profile)
+);
+
+CREATE TABLE IF NOT EXISTS waf_policies (
+    id           TEXT NOT NULL,
+    env_profile  TEXT NOT NULL,
+    name         TEXT,
+    mode         TEXT,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (id, env_profile)
+);
+
+CREATE TABLE IF NOT EXISTS waf_events (
+    id           TEXT NOT NULL,
+    env_profile  TEXT NOT NULL,
+    created_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (id, env_profile)
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    id           TEXT PRIMARY KEY,
+    username     TEXT,
+    email        TEXT,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS pops (
+    id           TEXT PRIMARY KEY,
+    name         TEXT,
+    status       TEXT,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS bookmarks (
+    id           TEXT PRIMARY KEY,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS profiles (
+    id           TEXT PRIMARY KEY,
+    name         TEXT,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS company_logo (
+    id           TEXT PRIMARY KEY,
+    created_at   TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ,
+    raw_json     JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version      TEXT PRIMARY KEY,
+    applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO schema_migrations (version)
+VALUES ('0001_baseline')
+ON CONFLICT (version) DO NOTHING;

--- a/scripts/pg-import-from-disk.sh
+++ b/scripts/pg-import-from-disk.sh
@@ -10,7 +10,11 @@ PGHOST="${PGHOST:-${WSLPROXY_PG_HOST:-127.0.0.1}}"
 PGPORT="${PGPORT:-${WSLPROXY_PG_PORT:-5436}}"
 PGUSER="${PGUSER:-${WSLPROXY_PG_USER:-wslproxy}}"
 PGDATABASE="${PGDATABASE:-${WSLPROXY_PG_DB:-wslproxy}}"
-export PGPASSWORD="${PGPASSWORD:-${WSLPROXY_PG_PASSWORD:-wslproxy_local_dev}}"
+export PGPASSWORD="${PGPASSWORD:-${WSLPROXY_PG_PASSWORD:-}}"
+if [[ -z "$PGPASSWORD" ]]; then
+  echo "pg-import: set PGPASSWORD or WSLPROXY_PG_PASSWORD" >&2
+  exit 1
+fi
 
 psql=(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1)
 

--- a/scripts/pg-import-from-disk.sh
+++ b/scripts/pg-import-from-disk.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# One-shot import of on-disk JSON into PostgreSQL typed tables.
+# Does not change storage_type. Safe to re-run (upserts).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DATA_DIR="${DATA_DIR:-$ROOT/data}"
+
+PGHOST="${PGHOST:-${WSLPROXY_PG_HOST:-127.0.0.1}}"
+PGPORT="${PGPORT:-${WSLPROXY_PG_PORT:-5436}}"
+PGUSER="${PGUSER:-${WSLPROXY_PG_USER:-wslproxy}}"
+PGDATABASE="${PGDATABASE:-${WSLPROXY_PG_DB:-wslproxy}}"
+export PGPASSWORD="${PGPASSWORD:-${WSLPROXY_PG_PASSWORD:-wslproxy_local_dev}}"
+
+psql=(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1)
+
+echo "pg-import: data=$DATA_DIR → $PGUSER@$PGHOST:$PGPORT/$PGDATABASE"
+
+python3 - "$DATA_DIR" <<'PY' | "${psql[@]}"
+import json, os, sys, glob
+
+data_dir = sys.argv[1]
+
+def esc(s):
+    if s is None:
+        return "NULL"
+    return "'" + str(s).replace("'", "''") + "'"
+
+def json_esc(obj):
+    return esc(json.dumps(obj, separators=(",", ":"))) + "::jsonb"
+
+def bool_sql(v):
+    if v is True:
+        return "TRUE"
+    if v is False:
+        return "FALSE"
+    return "NULL"
+
+def load_json(path):
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+scoped = {
+    "servers": "servers",
+    "rules": "rules",
+    "secrets": "secrets",
+    "instances": "instances",
+    "upstreams": "upstreams",
+    "waf_rules": "waf_rules",
+    "waf_policies": "waf_policies",
+    "waf_events": "waf_events",
+}
+
+print("BEGIN;")
+for folder, table in scoped.items():
+    for env_path in glob.glob(os.path.join(data_dir, folder, "*")):
+        if not os.path.isdir(env_path) or os.path.basename(env_path) == "conf":
+            continue
+        env = os.path.basename(env_path)
+        for path in glob.glob(os.path.join(env_path, "*.json")):
+            rec = load_json(path)
+            rid = rec.get("id") or os.path.splitext(os.path.basename(path))[0]
+            rec["id"] = rid
+            print(
+                f"INSERT INTO {table} (id, env_profile, raw_json) VALUES "
+                f"({esc(rid)}, {esc(env)}, {json_esc(rec)}) "
+                f"ON CONFLICT (id, env_profile) DO UPDATE SET raw_json = EXCLUDED.raw_json;"
+            )
+            if table == "servers":
+                print(f"UPDATE servers SET server_name = {esc(rec.get('server_name'))}, "
+                      f"proxy_server_name = {esc(rec.get('proxy_server_name'))}, "
+                      f"profile_id = {esc(rec.get('profile_id') or env)}, "
+                      f"ssl_enabled = {bool_sql(rec.get('ssl_enabled'))}, "
+                      f"waf_enabled = {bool_sql(rec.get('waf_enabled'))}, "
+                      f"waf_policy_id = {esc(rec.get('waf_policy_id'))}, "
+                      f"config_status = {bool_sql(rec.get('config_status'))} "
+                      f"WHERE id = {esc(rid)} AND env_profile = {esc(env)};")
+            if table == "rules":
+                match = rec.get("match") or {}
+                rules = match.get("rules") or {}
+                response = match.get("response") or {}
+                print(f"UPDATE rules SET name = {esc(rec.get('name'))}, "
+                      f"priority = {int(rec.get('priority') or 0)}, "
+                      f"path = {esc(rules.get('path'))}, "
+                      f"path_key = {esc(rules.get('path_key'))}, "
+                      f"status_code = {esc(response.get('code')) if response.get('code') is None else int(response.get('code'))}, "
+                      f"schema_version = {int(rec.get('_schema_version') or 2)} "
+                      f"WHERE id = {esc(rid)} AND env_profile = {esc(env)};")
+
+users_path = os.path.join(data_dir, "users.json")
+if os.path.isfile(users_path):
+    users = load_json(users_path)
+    if isinstance(users, dict):
+        users = list(users.values()) if users and not isinstance(next(iter(users.values()), None), dict) else [
+            dict(v, id=v.get("id", k)) for k, v in users.items() if isinstance(v, dict)
+        ]
+    for rec in users or []:
+        if not isinstance(rec, dict):
+            continue
+        rid = rec.get("id")
+        if not rid:
+            continue
+        print(
+            f"INSERT INTO users (id, username, email, raw_json) VALUES "
+            f"({esc(rid)}, {esc(rec.get('username') or rec.get('name'))}, {esc(rec.get('email'))}, {json_esc(rec)}) "
+            f"ON CONFLICT (id) DO UPDATE SET raw_json = EXCLUDED.raw_json;"
+        )
+
+pops_dir = os.path.join(data_dir, "pops")
+if os.path.isdir(pops_dir):
+    for path in glob.glob(os.path.join(pops_dir, "*.json")):
+        rec = load_json(path)
+        rid = rec.get("id") or os.path.splitext(os.path.basename(path))[0]
+        rec["id"] = rid
+        print(
+            f"INSERT INTO pops (id, name, status, raw_json) VALUES "
+            f"({esc(rid)}, {esc(rec.get('name'))}, {esc(rec.get('status'))}, {json_esc(rec)}) "
+            f"ON CONFLICT (id) DO UPDATE SET raw_json = EXCLUDED.raw_json;"
+        )
+
+print("COMMIT;")
+PY
+
+echo "pg-import: done"

--- a/scripts/pg-migrate.sh
+++ b/scripts/pg-migrate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Apply additive PostgreSQL migrations. Never DROPs. Idempotent.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MIGRATIONS_DIR="${MIGRATIONS_DIR:-$ROOT/infra/pgsql/migrations}"
+
+PGHOST="${PGHOST:-${WSLPROXY_PG_HOST:-127.0.0.1}}"
+PGPORT="${PGPORT:-${WSLPROXY_PG_PORT:-5436}}"
+PGUSER="${PGUSER:-${WSLPROXY_PG_USER:-wslproxy}}"
+PGDATABASE="${PGDATABASE:-${WSLPROXY_PG_DB:-wslproxy}}"
+export PGPASSWORD="${PGPASSWORD:-${WSLPROXY_PG_PASSWORD:-wslproxy_local_dev}}"
+
+echo "pg-migrate: host=$PGHOST port=$PGPORT db=$PGDATABASE user=$PGUSER"
+echo "pg-migrate: dir=$MIGRATIONS_DIR"
+
+psql=(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1)
+
+"${psql[@]}" -c "CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW());"
+
+shopt -s nullglob
+for sql in "$MIGRATIONS_DIR"/*.sql; do
+  version="$(basename "$sql" .sql)"
+  applied="$("${psql[@]}" -tAc "SELECT 1 FROM schema_migrations WHERE version = '$version'")"
+  if [[ "$applied" == "1" ]]; then
+    echo "skip $version (already applied)"
+    continue
+  fi
+  echo "apply $version"
+  "${psql[@]}" -f "$sql"
+done
+
+echo "pg-migrate: done"

--- a/scripts/pg-migrate.sh
+++ b/scripts/pg-migrate.sh
@@ -9,7 +9,11 @@ PGHOST="${PGHOST:-${WSLPROXY_PG_HOST:-127.0.0.1}}"
 PGPORT="${PGPORT:-${WSLPROXY_PG_PORT:-5436}}"
 PGUSER="${PGUSER:-${WSLPROXY_PG_USER:-wslproxy}}"
 PGDATABASE="${PGDATABASE:-${WSLPROXY_PG_DB:-wslproxy}}"
-export PGPASSWORD="${PGPASSWORD:-${WSLPROXY_PG_PASSWORD:-wslproxy_local_dev}}"
+export PGPASSWORD="${PGPASSWORD:-${WSLPROXY_PG_PASSWORD:-}}"
+if [[ -z "$PGPASSWORD" ]]; then
+  echo "pg-migrate: set PGPASSWORD or WSLPROXY_PG_PASSWORD" >&2
+  exit 1
+fi
 
 echo "pg-migrate: host=$PGHOST port=$PGPORT db=$PGDATABASE user=$PGUSER"
 echo "pg-migrate: dir=$MIGRATIONS_DIR"

--- a/test/storage/test_disk_driver.lua
+++ b/test/storage/test_disk_driver.lua
@@ -1,0 +1,243 @@
+-- Plain Lua contract tests for disk driver + query + dual_writer.
+-- Run: lua test/storage/test_disk_driver.lua
+-- (luajit also works; does not require OpenResty)
+
+package.path = "api/?.lua;api/?/init.lua;" .. package.path
+
+local failures = 0
+local function assert_eq(a, b, msg)
+    if a ~= b then
+        failures = failures + 1
+        io.stderr:write("FAIL: " .. (msg or "") .. " expected " .. tostring(b) .. " got " .. tostring(a) .. "\n")
+    end
+end
+
+local function assert_true(v, msg)
+    if not v then
+        failures = failures + 1
+        io.stderr:write("FAIL: " .. (msg or "expected truthy") .. "\n")
+    end
+end
+
+-- Stubs used by storage modules when ngx is absent.
+_G.ngx = {
+    ERR = 4, WARN = 5, INFO = 7, EMERG = 1, null = {},
+    log = function() end,
+    HTTP_BAD_REQUEST = 400,
+}
+_G.Cjson = (function()
+    local ok, c = pcall(require, "cjson")
+    if ok then return c end
+    ok, c = pcall(require, "dkjson")
+    if ok then return { encode = c.encode, decode = c.decode } end
+    -- Minimal JSON for contract tests (no cjson in host luajit).
+    local function encode(v)
+        local t = type(v)
+        if t == "nil" then return "null" end
+        if t == "boolean" then return v and "true" or "false" end
+        if t == "number" then return tostring(v) end
+        if t == "string" then return '"' .. v:gsub("\\", "\\\\"):gsub('"', '\\"') .. '"' end
+        if t == "table" then
+            local is_arr, n = true, 0
+            for k, _ in pairs(v) do
+                n = n + 1
+                if type(k) ~= "number" then is_arr = false end
+            end
+            local parts = {}
+            if is_arr and n > 0 then
+                for i = 1, n do parts[i] = encode(v[i]) end
+                return "[" .. table.concat(parts, ",") .. "]"
+            end
+            for k, val in pairs(v) do
+                parts[#parts + 1] = encode(tostring(k)) .. ":" .. encode(val)
+            end
+            return "{" .. table.concat(parts, ",") .. "}"
+        end
+        return "null"
+    end
+    local function decode(s)
+        local pos = 1
+        local function peek() return s:sub(pos, pos) end
+        local function skip()
+            while s:sub(pos, pos):match("%s") do pos = pos + 1 end
+        end
+        local parse
+        local function parse_string()
+            pos = pos + 1
+            local out = {}
+            while pos <= #s do
+                local ch = s:sub(pos, pos)
+                if ch == '"' then pos = pos + 1; break end
+                if ch == "\\" then
+                    pos = pos + 1
+                    out[#out + 1] = s:sub(pos, pos)
+                else
+                    out[#out + 1] = ch
+                end
+                pos = pos + 1
+            end
+            return table.concat(out)
+        end
+        parse = function()
+            skip()
+            local ch = peek()
+            if ch == '"' then return parse_string() end
+            if ch == "{" then
+                pos = pos + 1
+                local obj = {}
+                skip()
+                if peek() == "}" then pos = pos + 1; return obj end
+                while true do
+                    skip()
+                    local key = parse_string()
+                    skip()
+                    assert(peek() == ":", "expected :")
+                    pos = pos + 1
+                    obj[key] = parse()
+                    skip()
+                    if peek() == "}" then pos = pos + 1; break end
+                    assert(peek() == ",", "expected ,")
+                    pos = pos + 1
+                end
+                return obj
+            end
+            if ch == "[" then
+                pos = pos + 1
+                local arr = {}
+                skip()
+                if peek() == "]" then pos = pos + 1; return arr end
+                while true do
+                    arr[#arr + 1] = parse()
+                    skip()
+                    if peek() == "]" then pos = pos + 1; break end
+                    assert(peek() == ",", "expected ,")
+                    pos = pos + 1
+                end
+                return arr
+            end
+            if s:sub(pos, pos + 3) == "true" then pos = pos + 4; return true end
+            if s:sub(pos, pos + 4) == "false" then pos = pos + 5; return false end
+            if s:sub(pos, pos + 3) == "null" then pos = pos + 4; return nil end
+            local num = s:match("^%-?%d+%.?%d*", pos)
+            pos = pos + #num
+            return tonumber(num)
+        end
+        return parse()
+    end
+    return { encode = encode, decode = decode }
+end)()
+
+-- Minimal helpers stub with real file IO.
+package.loaded.helpers = {
+    getDataFromFile = function(path)
+        local f = io.open(path, "rb")
+        if not f then return nil end
+        local s = f:read("*a")
+        f:close()
+        return s
+    end,
+    setDataToFile = function(path, value, dir)
+        os.execute('mkdir -p "' .. dir .. '"')
+        local f, err = io.open(path, "w")
+        assert(f, err)
+        if type(value) == "table" then
+            f:write(_G.Cjson.encode(value))
+        else
+            f:write(tostring(value))
+        end
+        f:close()
+        return true
+    end,
+}
+
+local tmp = os.tmpname()
+os.remove(tmp)
+os.execute('mkdir -p "' .. tmp .. '/data/servers/prod"')
+os.execute('mkdir -p "' .. tmp .. '/data"')
+
+-- settings.json for health()
+do
+    local f = io.open(tmp .. "/data/settings.json", "w")
+    f:write('{"storage_type":"disk"}')
+    f:close()
+end
+
+local Query = require("storage.query")
+local page, total = Query.paginate({
+    { id = "b", name = "bravo" },
+    { id = "a", name = "alpha" },
+    { id = "c", name = "charlie" },
+}, { q = "alp" }, { field = "name", order = "ASC" }, { page = 1, perPage = 10 })
+assert_eq(total, 1, "q filter total")
+assert_eq(page[1].id, "a", "q filter hit")
+
+local Disk = require("storage.disk_driver")
+local disk = Disk.new({ config_path = tmp .. "/" })
+
+local rec = { id = "host:example.test", server_name = "example.test", ssl_enabled = true }
+local saved = disk:create("servers", "prod", rec.id, rec)
+assert_eq(saved.server_name, "example.test", "create returns record")
+
+local got = disk:get("servers", "prod", rec.id)
+assert_eq(got.server_name, "example.test", "get roundtrip")
+assert_eq(got.ssl_enabled, true, "bool preserved")
+
+local listed = disk:list("servers", "prod", {}, { field = "id", order = "ASC" }, nil)
+assert_eq(listed.total, 1, "list total")
+assert_eq(listed.records[1].id, rec.id, "list record")
+
+assert_true(disk:exists("servers", "prod", rec.id), "exists")
+assert_true(disk:delete("servers", "prod", rec.id), "delete")
+assert_true(not disk:get("servers", "prod", rec.id), "deleted")
+
+local h = disk:health()
+assert_true(h.ok, "disk health")
+
+-- Dual writer: primary succeeds, disk fails → primary rolled back.
+local FakePrimary = {}
+function FakePrimary.new()
+    return setmetatable({ store = {} }, { __index = FakePrimary })
+end
+function FakePrimary:get(resource, env, id)
+    return self.store[resource .. "/" .. tostring(env) .. "/" .. id]
+end
+function FakePrimary:create(resource, env, id, record)
+    self.store[resource .. "/" .. tostring(env) .. "/" .. id] = record
+    return record
+end
+function FakePrimary:update(resource, env, id, record)
+    return self:create(resource, env, id, record)
+end
+function FakePrimary:delete(resource, env, id)
+    self.store[resource .. "/" .. tostring(env) .. "/" .. id] = nil
+    return true
+end
+function FakePrimary:health()
+    return { ok = true, latency_ms = 0, detail = "fake" }
+end
+
+local FailDisk = {
+    get = function() return nil end,
+    create = function() return nil, "disk full" end,
+    update = function() return nil, "disk full" end,
+    delete = function() return nil, "disk full" end,
+    exists = function() return false end,
+    health = function() return { ok = false, latency_ms = 0, detail = "fail" } end,
+    list = function() return nil, "disk full" end,
+}
+
+local Dual = require("storage.dual_writer")
+local primary = FakePrimary.new()
+local dual = Dual.new({ primary = primary, disk = FailDisk })
+local ok, err = dual:create("servers", "prod", "host:x", { id = "host:x" })
+assert_true(not ok, "dual create fails when disk fails")
+assert_true(err == "disk full", "disk error surfaced")
+assert_true(primary:get("servers", "prod", "host:x") == nil, "primary rolled back")
+
+os.execute('rm -rf "' .. tmp .. '"')
+
+if failures > 0 then
+    io.stderr:write(failures .. " failure(s)\n")
+    os.exit(1)
+end
+print("ok")

--- a/test/storage/test_pgsql_driver.lua
+++ b/test/storage/test_pgsql_driver.lua
@@ -28,6 +28,11 @@ if not ok_pg then
     os.exit(0)
 end
 
+if not (os.getenv("WSLPROXY_PG_PASSWORD") or os.getenv("PGPASSWORD")) then
+    print("skip: set WSLPROXY_PG_PASSWORD or PGPASSWORD")
+    os.exit(0)
+end
+
 local Pgsql = require("storage.pgsql_driver")
 local drv = Pgsql.new({
     settings = {
@@ -36,7 +41,7 @@ local drv = Pgsql.new({
             port = tonumber(os.getenv("WSLPROXY_PG_PORT") or "5436"),
             database = os.getenv("WSLPROXY_PG_DB") or "wslproxy",
             user = os.getenv("WSLPROXY_PG_USER") or "wslproxy",
-            password = os.getenv("WSLPROXY_PG_PASSWORD") or "wslproxy_local_dev",
+            password = os.getenv("WSLPROXY_PG_PASSWORD") or os.getenv("PGPASSWORD"),
         }
     }
 })

--- a/test/storage/test_pgsql_driver.lua
+++ b/test/storage/test_pgsql_driver.lua
@@ -1,0 +1,71 @@
+-- Optional pgsql driver smoke test. Skips when pgmoon/Postgres are absent.
+-- Run: lua test/storage/test_pgsql_driver.lua
+
+package.path = "api/?.lua;api/?/init.lua;" .. package.path
+
+_G.ngx = {
+    ERR = 4, WARN = 5, INFO = 7, EMERG = 1, null = {},
+    log = function() end,
+}
+_G.Cjson = (function()
+    local ok, c = pcall(require, "cjson")
+    if ok then return c end
+    ok, c = pcall(require, "dkjson")
+    if ok then return { encode = c.encode, decode = c.decode } end
+    print("skip: no cjson")
+    os.exit(0)
+end)()
+
+package.loaded.helpers = package.loaded.helpers or {
+    getDataFromFile = function() return nil end,
+    setDataToFile = function() return true end,
+    settings = function() return {} end,
+}
+
+local ok_pg, _ = pcall(require, "pgmoon")
+if not ok_pg then
+    print("skip: pgmoon not installed")
+    os.exit(0)
+end
+
+local Pgsql = require("storage.pgsql_driver")
+local drv = Pgsql.new({
+    settings = {
+        pgsql = {
+            host = os.getenv("WSLPROXY_PG_HOST") or "127.0.0.1",
+            port = tonumber(os.getenv("WSLPROXY_PG_PORT") or "5436"),
+            database = os.getenv("WSLPROXY_PG_DB") or "wslproxy",
+            user = os.getenv("WSLPROXY_PG_USER") or "wslproxy",
+            password = os.getenv("WSLPROXY_PG_PASSWORD") or "wslproxy_local_dev",
+        }
+    }
+})
+
+local pg, err = drv:connect()
+if not pg then
+    print("skip: postgres unavailable: " .. tostring(err))
+    os.exit(0)
+end
+
+local rec = {
+    id = "host:pg-storage-test.example",
+    server_name = "pg-storage-test.example",
+    ssl_enabled = true,
+    extra_nested = { keep = "me" },
+}
+local saved, werr = drv:update("servers", "prod", rec.id, rec)
+if not saved then
+    io.stderr:write("FAIL write: " .. tostring(werr) .. "\n")
+    os.exit(1)
+end
+local got, gerr = drv:get("servers", "prod", rec.id)
+if not got then
+    io.stderr:write("FAIL get: " .. tostring(gerr) .. "\n")
+    os.exit(1)
+end
+if got.extra_nested == nil or got.extra_nested.keep ~= "me" then
+    io.stderr:write("FAIL raw_json roundtrip lost nested field\n")
+    os.exit(1)
+end
+drv:delete("servers", "prod", rec.id)
+print("ok")


### PR DESCRIPTION
## Summary
- Introduce `api/storage/` drivers (disk, redis, pgsql) and a dual-writer so redis/pgsql modes still emit on-disk JSON — request-path Lua is unchanged and still reads files.
- Add a real PostgreSQL schema (`infra/pgsql/migrations/0001_baseline.sql`) with typed columns plus `raw_json` for lossless round-trip; `scripts/pg-migrate.sh` / `scripts/pg-import-from-disk.sh` are opt-in (no boot-time migrate).
- Route admin CRUD in `api/api.lua` through `api/repo/` instead of `red:h*` / `getDataFromFile` pairs. Frontends and disk/redis behaviour are unchanged.

## Test plan
- [x] `luac -p` on `api/api.lua`, storage, repo, init, ready
- [x] `luajit test/storage/test_disk_driver.lua` (CRUD, q-filter, dual-writer rollback)
- [ ] `storage_type=disk`: list/get/save a server + rule in the admin UI; confirm `data/servers|rules/<env>/*.json` still written
- [ ] `storage_type=redis`: same CRUD; confirm redis hash `servers_{env}` / `request_rules_{env}` **and** disk JSON
- [ ] `storage_type=pgsql`: `scripts/pg-migrate.sh` then CRUD; confirm typed row + `raw_json` + disk JSON; `/ready` reports storage health
- [ ] Confirm `gateway_ack` / `rule_loader` still serve from disk JSON (no request-path change)


Made with [Cursor](https://cursor.com)